### PR TITLE
Remove Benchmark Details section

### DIFF
--- a/components/leaderboard-table.tsx
+++ b/components/leaderboard-table.tsx
@@ -58,40 +58,6 @@ export default function LeaderboardTable() {
           <DataTable columns={columns} data={tableData} />
         </CardContent>
       </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Benchmark Details</CardTitle>
-          <CardDescription>
-            Understanding the evaluation metrics
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="grid gap-4 md:grid-cols-3">
-            <div>
-              <h4 className="font-semibold">MMLU</h4>
-              <p className="text-sm text-muted-foreground">
-                Measures knowledge across 57 academic subjects including
-                mathematics, history, computer science, and more.
-              </p>
-            </div>
-            <div>
-              <h4 className="font-semibold">HellaSwag</h4>
-              <p className="text-sm text-muted-foreground">
-                Tests commonsense reasoning by asking models to complete
-                scenarios with the most logical ending.
-              </p>
-            </div>
-            <div>
-              <h4 className="font-semibold">ARC</h4>
-              <p className="text-sm text-muted-foreground">
-                AI2 Reasoning Challenge focusing on grade-school level science
-                questions requiring reasoning.
-              </p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
     </div>
   )
 }

--- a/components/leaderboard.tsx
+++ b/components/leaderboard.tsx
@@ -116,40 +116,6 @@ export default function Leaderboard() {
           </Card>
         ))}
       </div>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Benchmark Details</CardTitle>
-          <CardDescription>
-            Understanding the evaluation metrics
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="grid gap-4 md:grid-cols-3">
-            <div>
-              <h4 className="font-semibold">MMLU</h4>
-              <p className="text-sm text-muted-foreground">
-                Measures knowledge across 57 academic subjects including
-                mathematics, history, computer science, and more.
-              </p>
-            </div>
-            <div>
-              <h4 className="font-semibold">HellaSwag</h4>
-              <p className="text-sm text-muted-foreground">
-                Tests commonsense reasoning by asking models to complete
-                scenarios with the most logical ending.
-              </p>
-            </div>
-            <div>
-              <h4 className="font-semibold">ARC</h4>
-              <p className="text-sm text-muted-foreground">
-                AI2 Reasoning Challenge focusing on grade-school level science
-                questions requiring reasoning.
-              </p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- remove unused "Benchmark Details" cards from Leaderboard components

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm prettier`

------
https://chatgpt.com/codex/tasks/task_e_68609da969a48320b969a4cc4d9aa42f