### PR TITLE
Adjust scraping scripts to keep raw model names

### DIFF
--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -82,8 +82,8 @@ export async function loadLLMData(): Promise<LLMData[]> {
         throw new Error(`Invalid benchmark structure for ${slug}`)
       }
       for (const [rawName, score] of Object.entries(data.results)) {
-        const slug = aliasMap[rawName] || rawName
-        const llm = llmMap[slug]
+        const mappedSlug = aliasMap[rawName] || rawName
+        const llm = llmMap[mappedSlug]
         if (llm) {
           llm.benchmarks[data.benchmark] = {
             score: Number(score),

--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -35,6 +35,7 @@ export async function loadLLMData(): Promise<LLMData[]> {
   ]
 
   const llmMap: Record<string, LLMData> = {}
+  const aliasMap: Record<string, string> = {}
 
   for (const slug of modelSlugs) {
     try {
@@ -43,7 +44,11 @@ export async function loadLLMData(): Promise<LLMData[]> {
         throw new Error(`Failed to fetch ${slug}.yaml: ${response.status}`)
       }
       const text = await response.text()
-      const data = parse(text) as { model: string; provider: string }
+      const data = parse(text) as {
+        model: string
+        provider: string
+        aliases?: string[]
+      }
       if (!data.model || !data.provider) {
         throw new Error(`Invalid data structure for ${slug}`)
       }
@@ -51,6 +56,10 @@ export async function loadLLMData(): Promise<LLMData[]> {
         model: data.model,
         provider: data.provider,
         benchmarks: {},
+      }
+      aliasMap[data.model] = slug
+      for (const alias of data.aliases || []) {
+        aliasMap[alias] = slug
       }
     } catch (error) {
       console.error(`Failed to load model data for ${slug}:`, error)
@@ -72,8 +81,9 @@ export async function loadLLMData(): Promise<LLMData[]> {
       if (!data.benchmark || !data.results) {
         throw new Error(`Invalid benchmark structure for ${slug}`)
       }
-      for (const [modelSlug, score] of Object.entries(data.results)) {
-        const llm = llmMap[modelSlug]
+      for (const [rawName, score] of Object.entries(data.results)) {
+        const slug = aliasMap[rawName] || rawName
+        const llm = llmMap[slug]
         if (llm) {
           llm.benchmarks[data.benchmark] = {
             score: Number(score),

--- a/public/data/benchmarks/livebench.yaml
+++ b/public/data/benchmarks/livebench.yaml
@@ -7,7 +7,7 @@ results:
   claude-3-7-sonnet-20250219-base: 58.48
   claude-3-7-sonnet-20250219-thinking-64k: 67.43
   claude-4-opus-20250514-base: 65.93
-  claude-3: 72.93
+  claude-4-opus-20250514-thinking-32k: 72.93
   claude-4-sonnet-20250514-base: 63.37
   claude-4-sonnet-20250514-thinking-64k: 72.08
   command-r-08-2024: 27.15
@@ -20,12 +20,12 @@ results:
   gemini-2.0-flash-lite-001: 46.78
   gemini-2.5-flash-preview-04-17: 62.8
   gemini-2.5-flash-preview-05-20: 64.32
-  gemini-pro: 71.99
+  gemini-2.5-pro-preview-05-06: 71.99
   gemma-3-27b-it: 42
   gpt-4.1-2025-04-14: 55.9
   gpt-4.1-mini-2025-04-14: 51.57
   gpt-4.1-nano-2025-04-14: 40.4
-  gpt-4: 58.65
+  gpt-4.5-preview-2025-02-27: 58.65
   gpt-4o-2024-11-20: 47.43
   grok-3-beta: 56.05
   grok-3-mini-beta-high: 62.36

--- a/public/data/benchmarks/simplebench.yaml
+++ b/public/data/benchmarks/simplebench.yaml
@@ -1,41 +1,41 @@
 benchmark: SimpleBench
 description: Score (AVG@5) on SimpleBench
 results:
-  human-baseline: 83.7
-  gemini-pro: 62.4
-  claude-3: 58.8
-  o3-high: 53.1
-  gemini-2-5-pro-03-25: 51.6
-  claude-3-7-sonnet-thinking: 46.4
-  claude-4-sonnet-thinking: 45.5
-  claude-3-7-sonnet: 44.9
+  Human Baseline*: 83.7
+  Gemini 2.5 Pro (06-05): 62.4
+  Claude 4 Opus (thinking): 58.8
+  o3 (high): 53.1
+  Gemini 2.5 Pro (03-25): 51.6
+  Claude 3.7 Sonnet (thinking): 46.4
+  Claude 4 Sonnet (thinking): 45.5
+  Claude 3.7 Sonnet: 44.9
   o1-preview: 41.7
-  claude-3-5-sonnet-10-22: 41.4
-  deepseek-r1-05-28: 40.8
-  o1-2024-12-17-high: 40.1
-  o4-mini-high: 38.7
-  o1-2024-12-17-med: 36.7
-  grok-3: 36.1
-  gpt-4: 34.5
-  gemini-exp-1206: 31.1
-  qwen3-235b-a22b: 31
-  deepseek-r1: 30.9
-  gemini-2-0-flash-thinking: 30.7
-  llama-4-maverick: 27.7
-  claude-3-5-sonnet-06-20: 27.5
-  deepseek-v3-03-24: 27.2
-  gemini-1-5-pro-002: 27.1
-  gpt-4-1: 27
-  gpt-4-turbo: 25.1
-  claude-3-opus: 23.5
-  llama-3-1-405b-instruct: 23
-  o3-mini-high: 22.8
-  grok-2: 22.7
-  mistral-large-v2: 22.5
-  llama-3-3-70b-instruct: 19.9
-  deepseek-v3: 18.9
-  gemini-2-0-flash-exp: 18.9
+  Claude 3.5 Sonnet 10-22: 41.4
+  DeepSeek R1 05/28: 40.8
+  o1-2024-12-17 (high): 40.1
+  o4-mini (high): 38.7
+  o1-2024-12-17 (med): 36.7
+  Grok 3: 36.1
+  GPT-4.5: 34.5
+  Gemini-exp-1206: 31.1
+  Qwen3 235B-A22B: 31
+  DeepSeek R1: 30.9
+  Gemini 2.0 Flash Thinking: 30.7
+  Llama 4 Maverick: 27.7
+  Claude 3.5 Sonnet 06-20: 27.5
+  DeepSeek V3 03-24: 27.2
+  Gemini 1.5 Pro 002: 27.1
+  GPT-4.1: 27
+  GPT-4 Turbo: 25.1
+  Claude 3 Opus: 23.5
+  Llama 3.1 405b instruct: 23
+  o3-mini (high): 22.8
+  Grok 2: 22.7
+  Mistral Large v2: 22.5
+  Llama 3.3 70b instruct: 19.9
+  DeepSeek V3: 18.9
+  Gemini 2.0 Flash Exp: 18.9
   o1-mini: 18.1
-  gpt-4o-08-06: 17.8
-  command-r: 17.4
-  gpt-4o-mini: 10.7
+  GPT-4o 08-06: 17.8
+  Command R+: 17.4
+  GPT-4o mini: 10.7

--- a/scripts/scrape_livebench.ts
+++ b/scripts/scrape_livebench.ts
@@ -70,26 +70,9 @@ async function main(): Promise<void> {
     rawResults[row.model] = Math.round(avg * 100) / 100
   }
 
-  const modelsDir = path.join(__dirname, "..", "public", "data", "models")
-  const files = await fs.readdir(modelsDir)
-  const aliasMap: Record<string, string[]> = {}
-  for (const file of files) {
-    const slug = path.basename(file, ".yaml")
-    const content = await fs.readFile(path.join(modelsDir, file), "utf8")
-    const data = YAML.parse(content) as {
-      model: string
-      aliases?: string[]
-    }
-    aliasMap[slug] = [data.model, ...(data.aliases || [])]
-  }
-
   const results: Record<string, number> = {}
   for (const [name, score] of Object.entries(rawResults)) {
-    const slugEntry = Object.entries(aliasMap).find(([, names]) =>
-      names.includes(name),
-    )
-    const slug = slugEntry ? slugEntry[0] : name
-    results[slug] = score
+    results[name] = score
   }
   const yamlObj = {
     benchmark: "LiveBench",

--- a/scripts/scrape_simplebench.ts
+++ b/scripts/scrape_simplebench.ts
@@ -22,34 +22,10 @@ async function main(): Promise<void> {
   const data = context.data
   if (!data) throw new Error("Failed to parse leaderboard data")
 
-  const modelsDir = path.join(__dirname, "..", "public", "data", "models")
-  const files = await fs.readdir(modelsDir)
-  const aliasMap: Record<string, string[]> = {}
-  for (const file of files) {
-    const slug = path.basename(file, ".yaml")
-    const content = await fs.readFile(path.join(modelsDir, file), "utf8")
-    const parsed = YAML.parse(content) as {
-      model: string
-      aliases?: string[]
-    }
-    aliasMap[slug] = [parsed.model, ...(parsed.aliases || [])]
-  }
-
-  function slugify(str: string): string {
-    return str
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-|-$/g, "")
-  }
-
   const results: Record<string, number> = {}
   for (const entry of data) {
     const score = parseFloat(entry.score.replace(/%/, ""))
-    const slugEntry = Object.entries(aliasMap).find(([, names]) =>
-      names.includes(entry.model),
-    )
-    const slug = slugEntry ? slugEntry[0] : slugify(entry.model)
-    results[slug] = score
+    results[entry.model] = score
   }
   const yamlObj = {
     benchmark: "SimpleBench",


### PR DESCRIPTION
## Summary
- remove slug mapping logic from scraping scripts so they store results keyed by the raw model name from the benchmark
- update data loader to map benchmark names to known models when data is loaded

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_686151ea47a48320b69ed78dafd08757