### PR TITLE
Remove old benchmarks

### DIFF
--- a/components/columns.tsx
+++ b/components/columns.tsx
@@ -85,51 +85,6 @@ export const columns: ColumnDef<TableRow>[] = [
     ),
   },
   {
-    accessorKey: "mmlu",
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          MMLU
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      )
-    },
-    cell: ({ row }) => <ScoreCell score={row.getValue("mmlu")} />,
-  },
-  {
-    accessorKey: "hellaswag",
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          HellaSwag
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      )
-    },
-    cell: ({ row }) => <ScoreCell score={row.getValue("hellaswag")} />,
-  },
-  {
-    accessorKey: "arc",
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          ARC
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      )
-    },
-    cell: ({ row }) => <ScoreCell score={row.getValue("arc")} />,
-  },
-  {
     accessorKey: "livebench",
     header: ({ column }) => {
       return (

--- a/components/leaderboard-table.tsx
+++ b/components/leaderboard-table.tsx
@@ -50,8 +50,8 @@ export default function LeaderboardTable() {
         <CardHeader>
           <CardTitle>Benchmark Results</CardTitle>
           <CardDescription>
-            Compare LLM performance across MMLU, HellaSwag, and ARC benchmarks.
-            Click column headers to sort, use filters to narrow results.
+            Compare LLM performance across available benchmarks. Click column
+            headers to sort, use filters to narrow results.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -16,9 +16,6 @@ export interface TableRow {
   id: string
   model: string
   provider: string
-  mmlu: number
-  hellaswag: number
-  arc: number
   livebench: number
   simplebench: number
   averageScore: number
@@ -26,13 +23,7 @@ export interface TableRow {
 
 export async function loadLLMData(): Promise<LLMData[]> {
   const modelSlugs = ["gpt-4", "claude-3", "gemini-pro"]
-  const benchmarkSlugs = [
-    "mmlu",
-    "hellaswag",
-    "arc",
-    "livebench",
-    "simplebench",
-  ]
+  const benchmarkSlugs = ["livebench", "simplebench"]
 
   const llmMap: Record<string, LLMData> = {}
   const aliasMap: Record<string, string> = {}
@@ -112,9 +103,6 @@ export function transformToTableData(llmData: LLMData[]): TableRow[] {
     id: llm.model.toLowerCase().replace(/\s+/g, "-"),
     model: llm.model,
     provider: llm.provider,
-    mmlu: llm.benchmarks.MMLU?.score || 0,
-    hellaswag: llm.benchmarks.HellaSwag?.score || 0,
-    arc: llm.benchmarks.ARC?.score || 0,
     livebench: llm.benchmarks.LiveBench?.score || 0,
     simplebench: llm.benchmarks.SimpleBench?.score || 0,
     averageScore: llm.averageScore || 0,

--- a/public/data/benchmarks/arc.yaml
+++ b/public/data/benchmarks/arc.yaml
@@ -1,6 +1,0 @@
-benchmark: ARC
-description: AI2 Reasoning Challenge
-results:
-  gpt-4: 96.3
-  claude-3: 96.4
-  gemini-pro: 87.0

--- a/public/data/benchmarks/hellaswag.yaml
+++ b/public/data/benchmarks/hellaswag.yaml
@@ -1,6 +1,0 @@
-benchmark: HellaSwag
-description: Commonsense Natural Language Inference
-results:
-  gpt-4: 95.3
-  claude-3: 95.4
-  gemini-pro: 87.8

--- a/public/data/benchmarks/mmlu.yaml
+++ b/public/data/benchmarks/mmlu.yaml
@@ -1,6 +1,0 @@
-benchmark: MMLU
-description: Massive Multitask Language Understanding
-results:
-  gpt-4: 86.4
-  claude-3: 86.8
-  gemini-pro: 83.7


### PR DESCRIPTION
## Summary
- delete ARC, HellaSwag and MMLU benchmark data
- drop their columns from the table
- strip removed benchmarks from data loader
- update leaderboard description

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm prettier`


------
https://chatgpt.com/codex/tasks/task_e_6861559e6edc8320910d01e4fb216869