### PR TITLE
Remove per-benchmark columns from table

### DIFF
--- a/components/columns.tsx
+++ b/components/columns.tsx
@@ -85,36 +85,6 @@ export const columns: ColumnDef<TableRow>[] = [
     ),
   },
   {
-    accessorKey: "livebench",
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          LiveBench
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      )
-    },
-    cell: ({ row }) => <ScoreCell score={row.getValue("livebench")} />,
-  },
-  {
-    accessorKey: "simplebench",
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          SimpleBench
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      )
-    },
-    cell: ({ row }) => <ScoreCell score={row.getValue("simplebench")} />,
-  },
-  {
     accessorKey: "averageScore",
     header: ({ column }) => {
       return (

--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -16,8 +16,6 @@ export interface TableRow {
   id: string
   model: string
   provider: string
-  livebench: number
-  simplebench: number
   averageScore: number
 }
 
@@ -103,8 +101,6 @@ export function transformToTableData(llmData: LLMData[]): TableRow[] {
     id: llm.model.toLowerCase().replace(/\s+/g, "-"),
     model: llm.model,
     provider: llm.provider,
-    livebench: llm.benchmarks.LiveBench?.score || 0,
-    simplebench: llm.benchmarks.SimpleBench?.score || 0,
     averageScore: llm.averageScore || 0,
   }))
 }


### PR DESCRIPTION
## Summary
- remove `livebench` and `simplebench` scores from leaderboard table
- show only average score

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6861587130c08320a5d6895f5a181fc8