### PR TITLE
Update benchmark instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,15 @@ This repository uses pnpm as package manager.
 
 Use the shadcn/ui CLI to scaffold new components. Run `pnpm dlx shadcn-ui@latest add <component>`.
 
+# Adding benchmarks
+
+To add a new benchmark to the leaderboard:
+
+- Create a YAML file under `public/data/benchmarks/` containing the benchmark name, description and a `results` mapping.
+- Append the slug of this new file to the `benchmarkSlugs` array in `lib/data-loader.ts`.
+- Create a scraping script under `scripts/` that generates the benchmark YAML and
+  add a corresponding npm script in `package.json`.
+
 # Editing this file
 
 Whenever you learn something new, add it to this file.


### PR DESCRIPTION
## Summary
- remove step about modifying `TableRow` interface
- keep instructions for creating a scraping script

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686157e5f254832091296a7f4be35416