### PR TITLE
Remove deprecated model files

### DIFF
--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -21,9 +21,6 @@ export interface TableRow {
 
 export async function loadLLMData(): Promise<LLMData[]> {
   const modelSlugs = [
-    "gpt-4",
-    "claude-3",
-    "gemini-pro",
     "o3-high",
     "o3-medium",
     "gemini-2.5-pro",

--- a/public/data/models/claude-3.yaml
+++ b/public/data/models/claude-3.yaml
@@ -1,5 +1,0 @@
-model: Claude-3 Opus
-provider: Anthropic
-aliases:
-  - claude-4-opus-20250514-thinking-32k
-  - Claude 4 Opus (thinking)

--- a/public/data/models/gemini-pro.yaml
+++ b/public/data/models/gemini-pro.yaml
@@ -1,5 +1,0 @@
-model: Gemini Pro
-provider: Google
-aliases:
-  - gemini-2.5-pro-preview-05-06
-  - Gemini 2.5 Pro (06-05)

--- a/public/data/models/gpt-4.yaml
+++ b/public/data/models/gpt-4.yaml
@@ -1,5 +1,0 @@
-model: GPT-4
-provider: OpenAI
-aliases:
-  - gpt-4.5-preview-2025-02-27
-  - GPT-4.5


### PR DESCRIPTION
## Summary
- remove `gpt-4.yaml`, `claude-3.yaml` and `gemini-pro.yaml`
- drop the slugs for those models from `data-loader.ts`

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686166538410832084b0b376f4e3f298