### PR TITLE
Move leaderboard data fetching server-side

### DIFF
--- a/components/leaderboard-table.tsx
+++ b/components/leaderboard-table.tsx
@@ -1,6 +1,3 @@
-"use client"
-
-import { useEffect, useState } from "react"
 import {
   Card,
   CardContent,
@@ -16,25 +13,9 @@ import {
 import { DataTable } from "./data-table"
 import { columns } from "./columns"
 
-export default function LeaderboardTable() {
-  const [tableData, setTableData] = useState<TableRow[]>([])
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    loadLLMData().then((data) => {
-      const transformedData = transformToTableData(data)
-      setTableData(transformedData)
-      setLoading(false)
-    })
-  }, [])
-
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-lg">Loading benchmark data...</div>
-      </div>
-    )
-  }
+export default async function LeaderboardTable() {
+  const data = await loadLLMData()
+  const tableData: TableRow[] = transformToTableData(data)
 
   return (
     <div className="space-y-6">

--- a/components/leaderboard.tsx
+++ b/components/leaderboard.tsx
@@ -1,6 +1,3 @@
-"use client"
-
-import { useEffect, useState } from "react"
 import { Trophy, Medal, Award } from "lucide-react"
 import {
   Card,
@@ -12,16 +9,8 @@ import {
 import { Badge } from "@/components/ui/badge"
 import { loadLLMData, type LLMData } from "@/lib/data-loader"
 
-export default function Leaderboard() {
-  const [llmData, setLlmData] = useState<LLMData[]>([])
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    loadLLMData().then((data) => {
-      setLlmData(data)
-      setLoading(false)
-    })
-  }, [])
+export default async function Leaderboard() {
+  const llmData: LLMData[] = await loadLLMData()
 
   const getRankIcon = (index: number) => {
     switch (index) {
@@ -44,14 +33,6 @@ export default function Leaderboard() {
     if (score >= 90) return "text-green-600"
     if (score >= 80) return "text-yellow-600"
     return "text-red-600"
-  }
-
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-lg">Loading benchmark data...</div>
-      </div>
-    )
   }
 
   const benchmarkNames =

--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -1,4 +1,6 @@
 import { parse } from "yaml"
+import fs from "fs/promises"
+import path from "path"
 
 export interface BenchmarkResult {
   score: number
@@ -20,36 +22,23 @@ export interface TableRow {
 }
 
 export async function loadLLMData(): Promise<LLMData[]> {
-  const modelSlugs = [
-    "gpt-4",
-    "claude-3",
-    "gemini-pro",
-    "o3-high",
-    "o3-medium",
-    "gemini-2.5-pro",
-    "gemini-2.5-flash",
-    "claude-opus-4",
-    "claude-sonnet-4",
-  ]
+  const modelDir = path.join(process.cwd(), "public", "data", "models")
+  const benchmarkDir = path.join(process.cwd(), "public", "data", "benchmarks")
 
-  const benchmarkSlugs = [
-    "livebench",
-    "simplebench",
-    "lmarena-text",
-    "arc-agi-1",
-    "aider-polyglot",
-    "humanitys-last-exam",
-  ]
+  const modelSlugs = (await fs.readdir(modelDir))
+    .filter((f) => f.endsWith(".yaml"))
+    .map((f) => f.replace(/\.yaml$/, ""))
+
+  const benchmarkSlugs = (await fs.readdir(benchmarkDir))
+    .filter((f) => f.endsWith(".yaml"))
+    .map((f) => f.replace(/\.yaml$/, ""))
   const llmMap: Record<string, LLMData> = {}
   const aliasMap: Record<string, string> = {}
 
   for (const slug of modelSlugs) {
     try {
-      const response = await fetch(`/data/models/${slug}.yaml`)
-      if (!response.ok) {
-        throw new Error(`Failed to fetch ${slug}.yaml: ${response.status}`)
-      }
-      const text = await response.text()
+      const filePath = path.join(modelDir, `${slug}.yaml`)
+      const text = await fs.readFile(filePath, "utf8")
       const data = parse(text) as {
         model: string
         provider: string
@@ -74,11 +63,8 @@ export async function loadLLMData(): Promise<LLMData[]> {
 
   for (const slug of benchmarkSlugs) {
     try {
-      const response = await fetch(`/data/benchmarks/${slug}.yaml`)
-      if (!response.ok) {
-        throw new Error(`Failed to fetch ${slug}.yaml: ${response.status}`)
-      }
-      const text = await response.text()
+      const filePath = path.join(benchmarkDir, `${slug}.yaml`)
+      const text = await fs.readFile(filePath, "utf8")
       const data = parse(text) as {
         benchmark: string
         description: string


### PR DESCRIPTION
## Summary
- fetch leaderboard YAML on the server using `fs`
- make leaderboard components server components
- auto-discover model and benchmark slugs from the data folders

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686166d9533c8320821e256adbe911c3