### PR TITLE
Remove leaderboard card header text

### DIFF
--- a/components/leaderboard-table.tsx
+++ b/components/leaderboard-table.tsx
@@ -1,10 +1,4 @@
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
+import { Card, CardContent } from "@/components/ui/card"
 import {
   loadLLMData,
   transformToTableData,
@@ -28,13 +22,6 @@ export default async function LeaderboardTable() {
       </div>
 
       <Card>
-        <CardHeader>
-          <CardTitle>Benchmark Results</CardTitle>
-          <CardDescription>
-            Compare LLM performance across available benchmarks. Click column
-            headers to sort, use filters to narrow results.
-          </CardDescription>
-        </CardHeader>
         <CardContent>
           <DataTable columns={columns} data={tableData} />
         </CardContent>


### PR DESCRIPTION
## Summary
- remove the Benchmark Results header and description from the leaderboard table

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm prettier`


------
https://chatgpt.com/codex/tasks/task_e_68616cc259a88320a89e9c92bdeec10b