### PR TITLE
Update docs for auto-loaded slugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,14 +15,12 @@ Use the shadcn/ui CLI to scaffold new components. Run `pnpm dlx shadcn-ui@latest
 To add a new benchmark to the leaderboard:
 
 - Create a YAML file under `public/data/benchmarks/` containing the benchmark name, description and a `results` mapping.
-- Append the slug of this new file to the `benchmarkSlugs` array in `lib/data-loader.ts`.
 - Create a scraping script under `scripts/` that generates the benchmark YAML and
   add a corresponding npm script in `package.json`.
 
 # Model YAML files
 
 Model definitions live in `public/data/models`. Each file includes `model`, `provider`, and optional `aliases`.
-To show a new model on the leaderboard, add its slug to `modelSlugs` in `lib/data-loader.ts`.
 
 # Editing this file
 


### PR DESCRIPTION
## Summary
- remove outdated instructions about manual slug lists
- clean up Claude model section

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm prettier`

------
https://chatgpt.com/codex/tasks/task_e_68616b2d302483208808ba9946db7451