### PR TITLE
Add benchmarks page

### DIFF
--- a/app/benchmarks/page.tsx
+++ b/app/benchmarks/page.tsx
@@ -1,0 +1,34 @@
+import { loadBenchmarks } from "@/lib/benchmark-loader"
+import Link from "next/link"
+
+export const metadata = {
+  title: "Benchmarks",
+  description: "List of benchmarks used for model evaluation",
+}
+
+export default async function BenchmarksPage() {
+  const benchmarks = await loadBenchmarks()
+  return (
+    <main className="container mx-auto px-4 py-8 max-w-3xl space-y-6">
+      <h1 className="text-4xl font-bold text-center">Benchmarks</h1>
+      <p className="text-center text-muted-foreground">
+        Models are evaluated on the following benchmarks.
+      </p>
+      <ul className="space-y-4">
+        {benchmarks.map((b) => (
+          <li key={b.slug} className="border rounded-lg p-4">
+            <h2 className="font-semibold text-lg">{b.benchmark}</h2>
+            {b.description && (
+              <p className="text-muted-foreground text-sm">{b.description}</p>
+            )}
+          </li>
+        ))}
+      </ul>
+      <div className="text-center">
+        <Link href="/" className="underline">
+          Back to leaderboard
+        </Link>
+      </div>
+    </main>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,14 @@
 import LeaderboardTable from "@/components/leaderboard-table"
+import Link from "next/link"
 
 export default function Home() {
   return (
     <main className="container mx-auto px-4 py-8 max-w-7xl">
+      <div className="mb-4 text-right">
+        <Link href="/benchmarks" className="underline">
+          Benchmarks
+        </Link>
+      </div>
       <LeaderboardTable />
     </main>
   )

--- a/lib/benchmark-loader.ts
+++ b/lib/benchmark-loader.ts
@@ -1,0 +1,38 @@
+import { parse } from "yaml"
+import fs from "fs/promises"
+import path from "path"
+
+export interface BenchmarkInfo {
+  slug: string
+  benchmark: string
+  description: string
+}
+
+export async function loadBenchmarks(): Promise<BenchmarkInfo[]> {
+  const benchmarkDir = path.join(process.cwd(), "public", "data", "benchmarks")
+  const slugs = (await fs.readdir(benchmarkDir))
+    .filter((f) => f.endsWith(".yaml"))
+    .map((f) => f.replace(/\.yaml$/, ""))
+
+  const benchmarks: BenchmarkInfo[] = []
+  for (const slug of slugs) {
+    try {
+      const text = await fs.readFile(
+        path.join(benchmarkDir, `${slug}.yaml`),
+        "utf8",
+      )
+      const data = parse(text) as { benchmark: string; description: string }
+      if (!data.benchmark) {
+        throw new Error(`Invalid benchmark structure for ${slug}`)
+      }
+      benchmarks.push({
+        slug,
+        benchmark: data.benchmark,
+        description: data.description,
+      })
+    } catch (error) {
+      console.error(`Failed to load benchmark info for ${slug}:`, error)
+    }
+  }
+  return benchmarks.sort((a, b) => a.benchmark.localeCompare(b.benchmark))
+}


### PR DESCRIPTION
## Summary
- load benchmark metadata from YAML files
- add a Benchmarks page listing them
- link to the Benchmarks page from the leaderboard

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68616d0a65808320a98751c42638c8f9