### PR TITLE
Add mappings for latest top models

### DIFF
--- a/public/data/models/deepseek-r1-0528.yaml
+++ b/public/data/models/deepseek-r1-0528.yaml
@@ -1,0 +1,7 @@
+model: DeepSeek R1 (05/28)
+provider: DeepSeek
+aliases:
+  - deepseek-r1-0528
+  - "DeepSeek R1 05/28"
+  - "DeepSeek R1 (0528)"
+  - "Deepseek R1 (05/28)"

--- a/public/data/models/deepseek-r1.yaml
+++ b/public/data/models/deepseek-r1.yaml
@@ -1,0 +1,4 @@
+model: DeepSeek R1
+provider: DeepSeek
+aliases:
+  - deepseek-r1

--- a/public/data/models/gpt-4.1-mini.yaml
+++ b/public/data/models/gpt-4.1-mini.yaml
@@ -1,0 +1,5 @@
+model: GPT-4.1 Mini
+provider: OpenAI
+aliases:
+  - gpt-4.1-mini-2025-04-14
+  - gpt-4.1-mini

--- a/public/data/models/gpt-4.1-nano.yaml
+++ b/public/data/models/gpt-4.1-nano.yaml
@@ -1,0 +1,5 @@
+model: GPT-4.1 Nano
+provider: OpenAI
+aliases:
+  - gpt-4.1-nano-2025-04-14
+  - gpt-4.1-nano

--- a/public/data/models/gpt-4.1.yaml
+++ b/public/data/models/gpt-4.1.yaml
@@ -1,0 +1,5 @@
+model: GPT-4.1
+provider: OpenAI
+aliases:
+  - gpt-4.1-2025-04-14
+  - gpt-4.1

--- a/public/data/models/gpt-4.5-preview.yaml
+++ b/public/data/models/gpt-4.5-preview.yaml
@@ -1,0 +1,7 @@
+model: GPT-4.5 Preview
+provider: OpenAI
+aliases:
+  - gpt-4.5-preview-2025-02-27
+  - gpt-4.5-preview
+  - "GPT 4.5 Preview"
+  - GPT-4.5

--- a/public/data/models/gpt-4o.yaml
+++ b/public/data/models/gpt-4o.yaml
@@ -1,0 +1,11 @@
+model: GPT-4o
+provider: OpenAI
+aliases:
+  - gpt-4o-2024-05-13
+  - gpt-4o-2024-08-06
+  - gpt-4o-2024-11-20
+  - "GPT-4o 08-06"
+  - gpt-4o-latest-20250326
+  - chatgpt-4o-latest-2025-03-27
+  - "chatgpt-4o-latest (2025-02-15)"
+  - "chatgpt-4o-latest (2025-03-29)"

--- a/public/data/models/grok-3-mini.yaml
+++ b/public/data/models/grok-3-mini.yaml
@@ -1,0 +1,5 @@
+model: Grok 3 Mini
+provider: xAI
+aliases:
+  - grok-3-mini-beta
+  - grok-3-mini-beta-high

--- a/public/data/models/grok-3.yaml
+++ b/public/data/models/grok-3.yaml
@@ -1,0 +1,5 @@
+model: Grok 3
+provider: xAI
+aliases:
+  - grok-3-preview-02-24
+  - grok-3-beta

--- a/public/data/models/o4-mini-high.yaml
+++ b/public/data/models/o4-mini-high.yaml
@@ -1,0 +1,7 @@
+model: o4-mini (high)
+provider: OpenAI
+aliases:
+  - o4-mini-2025-04-16-high
+  - o4-mini (high)
+  - o4-mini (High)
+  - o4-mini (high) (April 2025)


### PR DESCRIPTION
## Summary
- map new models so benchmark results show up
- clean up GPT-4o alias list
- split GPT-4.1 mini and nano into dedicated files
- separate DeepSeek R1 (05/28) release
- split Grok 3 and Grok 3 Mini mappings
- fix o4-mini-high aliases

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68616bdebf508320909c785cb78d98f8