### PR TITLE
Add methodology page

### DIFF
--- a/app/benchmarks/page.tsx
+++ b/app/benchmarks/page.tsx
@@ -24,9 +24,12 @@ export default async function BenchmarksPage() {
           </li>
         ))}
       </ul>
-      <div className="text-center">
+      <div className="text-center space-x-4">
         <Link href="/" className="underline">
           Back to leaderboard
+        </Link>
+        <Link href="/methodology" className="underline">
+          Methodology
         </Link>
       </div>
     </main>

--- a/app/methodology/page.tsx
+++ b/app/methodology/page.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link"
+
+export const metadata = {
+  title: "Methodology",
+  description: "How leaderboard scores are calculated",
+}
+
+export default function MethodologyPage() {
+  return (
+    <main className="container mx-auto px-4 py-8 max-w-3xl space-y-6">
+      <h1 className="text-4xl font-bold text-center">Methodology</h1>
+      <p className="text-center text-muted-foreground">
+        Explanation of how average scores are computed.
+      </p>
+      <div className="space-y-4">
+        <p>
+          Models are evaluated using a collection of public benchmarks. Raw
+          scores are scraped from official leaderboards and documentation.
+        </p>
+        <p>
+          For each benchmark we determine the minimum and maximum score across
+          all models. Individual scores are normalised using min–max
+          normalisation and then averaged to produce the leaderboard ranking.
+        </p>
+        <p>
+          This approach ensures that benchmarks with different scales contribute
+          equally to the final average.
+        </p>
+      </div>
+      <div className="text-center">
+        <Link href="/" className="underline">
+          Back to leaderboard
+        </Link>
+      </div>
+    </main>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,9 +4,12 @@ import Link from "next/link"
 export default function Home() {
   return (
     <main className="container mx-auto px-4 py-8 max-w-7xl">
-      <div className="mb-4 text-right">
+      <div className="mb-4 text-right space-x-4">
         <Link href="/benchmarks" className="underline">
           Benchmarks
+        </Link>
+        <Link href="/methodology" className="underline">
+          Methodology
         </Link>
       </div>
       <LeaderboardTable />


### PR DESCRIPTION
## Summary
- add a new `/methodology` page explaining how scores are calculated
- link to the new page from the homepage and benchmarks page

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6861740be7b88320954512aaf24291ea