### PR TITLE
Update leaderboard heading

### DIFF
--- a/components/leaderboard-table.tsx
+++ b/components/leaderboard-table.tsx
@@ -16,7 +16,7 @@ export default async function LeaderboardTable() {
     <div className="space-y-6">
       <div className="text-center space-y-2">
         <h1 className="text-4xl font-bold flex items-center justify-center gap-2">
-          <Image src="/favicon.png" alt="icon" width={24} height={24} />
+          <Image src="/favicon.png" alt="icon" width={32} height={32} />
           <span>All the benchmarks!</span>
         </h1>
         <p className="text-muted-foreground text-lg">

--- a/components/leaderboard-table.tsx
+++ b/components/leaderboard-table.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/lib/data-loader"
 import { DataTable } from "./data-table"
 import { columns } from "./columns"
+import Image from "next/image"
 
 export default async function LeaderboardTable() {
   const data = await loadLLMData()
@@ -14,7 +15,10 @@ export default async function LeaderboardTable() {
   return (
     <div className="space-y-6">
       <div className="text-center space-y-2">
-        <h1 className="text-4xl font-bold">LLM Benchmark Leaderboard</h1>
+        <h1 className="text-4xl font-bold flex items-center justify-center gap-2">
+          <Image src="/favicon.png" alt="icon" width={24} height={24} />
+          <span>All the benchmarks!</span>
+        </h1>
         <p className="text-muted-foreground text-lg">
           Sortable and filterable comparison of LLM performance across key
           benchmarks


### PR DESCRIPTION
## Summary
- add favicon icon to the leaderboard heading and update text

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm prettier`


------
https://chatgpt.com/codex/tasks/task_e_6861763120e483208fe436f49e5e0b81