### PR TITLE
Add navigation pill links across pages

### DIFF
--- a/app/benchmarks/page.tsx
+++ b/app/benchmarks/page.tsx
@@ -1,5 +1,5 @@
 import { loadBenchmarks } from "@/lib/benchmark-loader"
-import Link from "next/link"
+import NavigationPills from "@/components/navigation-pills"
 
 export const metadata = {
   title: "Benchmarks",
@@ -14,6 +14,7 @@ export default async function BenchmarksPage() {
       <p className="text-center text-muted-foreground">
         Models are evaluated on the following benchmarks.
       </p>
+      <NavigationPills />
       <ul className="space-y-4">
         {benchmarks.map((b) => (
           <li key={b.slug} className="border rounded-lg p-4">
@@ -24,14 +25,6 @@ export default async function BenchmarksPage() {
           </li>
         ))}
       </ul>
-      <div className="text-center space-x-4">
-        <Link href="/" className="underline">
-          Back to leaderboard
-        </Link>
-        <Link href="/methodology" className="underline">
-          Methodology
-        </Link>
-      </div>
     </main>
   )
 }

--- a/app/methodology/page.tsx
+++ b/app/methodology/page.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link"
+import NavigationPills from "@/components/navigation-pills"
 
 export const metadata = {
   title: "Methodology",
@@ -12,6 +12,7 @@ export default function MethodologyPage() {
       <p className="text-center text-muted-foreground">
         Explanation of how average scores are computed.
       </p>
+      <NavigationPills />
       <div className="space-y-4">
         <p>
           Models are evaluated using a collection of public benchmarks. Raw
@@ -26,11 +27,6 @@ export default function MethodologyPage() {
           This approach ensures that benchmarks with different scales contribute
           equally to the final average.
         </p>
-      </div>
-      <div className="text-center">
-        <Link href="/" className="underline">
-          Back to leaderboard
-        </Link>
       </div>
     </main>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,17 @@
 import LeaderboardTable from "@/components/leaderboard-table"
-import Link from "next/link"
+import NavigationPills from "@/components/navigation-pills"
 
 export default function Home() {
   return (
-    <main className="container mx-auto px-4 py-8 max-w-7xl">
-      <div className="mb-4 text-right space-x-4">
-        <Link href="/benchmarks" className="underline">
-          Benchmarks
-        </Link>
-        <Link href="/methodology" className="underline">
-          Methodology
-        </Link>
+    <main className="container mx-auto px-4 py-8 max-w-7xl space-y-6">
+      <div className="text-center space-y-2">
+        <h1 className="text-4xl font-bold">LLM Benchmark Leaderboard</h1>
+        <p className="text-muted-foreground text-lg">
+          Sortable and filterable comparison of LLM performance across key
+          benchmarks
+        </p>
       </div>
+      <NavigationPills />
       <LeaderboardTable />
     </main>
   )

--- a/components/leaderboard-table.tsx
+++ b/components/leaderboard-table.tsx
@@ -12,20 +12,10 @@ export default async function LeaderboardTable() {
   const tableData: TableRow[] = transformToTableData(data)
 
   return (
-    <div className="space-y-6">
-      <div className="text-center space-y-2">
-        <h1 className="text-4xl font-bold">LLM Benchmark Leaderboard</h1>
-        <p className="text-muted-foreground text-lg">
-          Sortable and filterable comparison of LLM performance across key
-          benchmarks
-        </p>
-      </div>
-
-      <Card>
-        <CardContent>
-          <DataTable columns={columns} data={tableData} />
-        </CardContent>
-      </Card>
-    </div>
+    <Card>
+      <CardContent>
+        <DataTable columns={columns} data={tableData} />
+      </CardContent>
+    </Card>
   )
 }

--- a/components/navigation-pills.tsx
+++ b/components/navigation-pills.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { cn } from "@/lib/utils"
+
+const links = [
+  { href: "/", label: "Leaderboard" },
+  { href: "/benchmarks", label: "Benchmarks" },
+  { href: "/methodology", label: "Methodology" },
+]
+
+export default function NavigationPills() {
+  const pathname = usePathname()
+
+  return (
+    <nav className="flex justify-center gap-2">
+      {links.map((link) => (
+        <Link
+          key={link.href}
+          href={link.href}
+          className={cn(
+            "px-4 py-1 rounded-full border text-sm",
+            pathname === link.href
+              ? "bg-primary text-primary-foreground"
+              : "hover:bg-accent hover:text-accent-foreground",
+          )}
+        >
+          {link.label}
+        </Link>
+      ))}
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary
- create `NavigationPills` component
- place navigation pills beneath each page heading
- move leaderboard heading to page component
- remove header from `LeaderboardTable` component

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm prettier`

------
https://chatgpt.com/codex/tasks/task_e_686176869b8c832093d4248abec7a70a