### PR TITLE
Embed filters in table headers

### DIFF
--- a/components/columns.tsx
+++ b/components/columns.tsx
@@ -1,9 +1,15 @@
 "use client"
 
 import type { ColumnDef } from "@tanstack/react-table"
-import { ArrowUpDown } from "lucide-react"
+import { ArrowUpDown, Search } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover"
+import { Input } from "@/components/ui/input"
 
 import type { TableRow } from "@/lib/data-loader"
 
@@ -16,13 +22,31 @@ export const columns: ColumnDef<TableRow>[] = [
     accessorKey: "model",
     header: ({ column }) => {
       return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Model
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+            className="p-0 hover:bg-transparent"
+          >
+            Model
+            <ArrowUpDown className="ml-2 h-4 w-4" />
+          </Button>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="ghost" size="icon" className="h-4 w-4">
+                <Search className="h-3.5 w-3.5" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-48 p-2">
+              <Input
+                placeholder="Filter..."
+                value={(column.getFilterValue() as string) ?? ""}
+                onChange={(event) => column.setFilterValue(event.target.value)}
+                className="h-8"
+              />
+            </PopoverContent>
+          </Popover>
+        </div>
       )
     },
     cell: ({ row }) => (
@@ -33,13 +57,31 @@ export const columns: ColumnDef<TableRow>[] = [
     accessorKey: "provider",
     header: ({ column }) => {
       return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Provider
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+            className="p-0 hover:bg-transparent"
+          >
+            Provider
+            <ArrowUpDown className="ml-2 h-4 w-4" />
+          </Button>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="ghost" size="icon" className="h-4 w-4">
+                <Search className="h-3.5 w-3.5" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-48 p-2">
+              <Input
+                placeholder="Filter..."
+                value={(column.getFilterValue() as string) ?? ""}
+                onChange={(event) => column.setFilterValue(event.target.value)}
+                className="h-8"
+              />
+            </PopoverContent>
+          </Popover>
+        </div>
       )
     },
     cell: ({ row }) => (

--- a/components/data-table.tsx
+++ b/components/data-table.tsx
@@ -15,7 +15,6 @@ import {
 
 import { Button } from "@/components/ui/button"
 
-import { Input } from "@/components/ui/input"
 import {
   Table,
   TableBody,
@@ -58,26 +57,6 @@ export function DataTable<TData, TValue>({
 
   return (
     <div className="w-full">
-      <div className="flex items-center py-4 gap-4">
-        <Input
-          placeholder="Filter models..."
-          value={(table.getColumn("model")?.getFilterValue() as string) ?? ""}
-          onChange={(event) =>
-            table.getColumn("model")?.setFilterValue(event.target.value)
-          }
-          className="max-w-sm"
-        />
-        <Input
-          placeholder="Filter providers..."
-          value={
-            (table.getColumn("provider")?.getFilterValue() as string) ?? ""
-          }
-          onChange={(event) =>
-            table.getColumn("provider")?.setFilterValue(event.target.value)
-          }
-          className="max-w-sm"
-        />
-      </div>
       <div className="rounded-md border">
         <Table>
           <TableHeader>


### PR DESCRIPTION
## Summary
- embed filter inputs inside each column header via popovers
- remove standalone filter inputs above the table

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686179cd947483208bf2c992d375c90b