### PR TITLE
Add ARC-AGI-2 benchmark scraper

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "scrape:simplebench": "tsx scripts/scrape_simplebench.ts",
     "scrape:lmarena-text": "tsx scripts/scrape_lmarena_text.ts",
     "scrape:arc-agi-1": "tsx scripts/scrape_arc_agi_1.ts",
+    "scrape:arc-agi-2": "tsx scripts/scrape_arc_agi_2.ts",
     "scrape:aider-polyglot": "tsx scripts/scrape_aider-polyglot.ts",
     "scrape:hle": "tsx scripts/scrape_hle.ts",
     "start": "next start"

--- a/public/data/benchmarks/arc-agi-2.yaml
+++ b/public/data/benchmarks/arc-agi-2.yaml
@@ -1,0 +1,122 @@
+benchmark: ARC-AGI-2
+description: Accuracy on ARC-AGI-2
+results:
+  Human Panel: 100
+  Claude Opus 4 (Thinking 16K): 8.6
+  o3 (High): 6.5
+  o4-mini (High): 6.1
+  Claude Sonnet 4 (Thinking 16K): 5.9
+  o3-Pro (High): 4.9
+  Gemini 2.5 Pro (Thinking 32K): 4.9
+  Claude Opus 4 (Thinking 8K): 4.5
+  Gemini 2.5 Pro (Thinking 16K): 4
+  o3-preview (Low)*: 4
+  o3-mini (High): 3
+  o3 (Medium): 3
+  Gemini 2.5 Pro (Thinking 8K): 2.9
+  Gemini 2.5 Flash (Preview) (Thinking 24K): 2.5
+  ARChitects: 2.5
+  o4-mini (Medium): 2.4
+  Gemini 2.5 Flash (Preview) (Thinking 1K): 2.2
+  Gemini 2.5 Flash (Preview) (Thinking 8K): 2.1
+  Claude Sonnet 4 (Thinking 8K): 2.1
+  o3-mini (Medium): 2.1
+  o3-Pro (Low): 2.1
+  o3 (Low): 2
+  Gemini 2.5 Flash (Preview) (Thinking 16K): 2
+  o3-Pro (Medium): 1.9
+  Gemini 2.5 Flash (Preview): 1.7
+  o4-mini (Low): 1.7
+  Icecuber: 1.6
+  Gemini 2.0 Flash: 1.3
+  Deepseek R1: 1.3
+  Codex Mini (Latest): 1.3
+  Claude Sonnet 4: 1.3
+  Claude Opus 4: 1.3
+  o1 (Medium): 1.3
+  Deepseek R1 (05/28): 1.1
+  o1-pro (Low): 0.9
+  Claude 3.7 (8K): 0.9
+  Claude Sonnet 4 (Thinking 1K): 0.9
+  o1-mini: 0.8
+  o1 (Low): 0.8
+  Gemini 1.5 Pro: 0.8
+  GPT-4.5: 0.8
+  Claude 3.7 (16K): 0.7
+  GPT-4.1: 0.4
+  Grok 3 Mini (Low): 0.4
+  Claude 3.7 (1K): 0.4
+  Claude 3.7: 0
+  GPT-4o: 0
+  GPT-4o-mini: 0
+  Llama 4 Maverick: 0
+  Llama 4 Scout: 0
+  GPT-4.1-Nano: 0
+  GPT-4.1-Mini: 0
+  o3-mini (Low): 0
+  Claude Opus 4 (Thinking 1K): 0
+  Grok 3: 0
+  Magistral Small: 0
+  Magistral Medium: 0
+  Magistral Medium (Thinking): 0
+  Gemini 2.5 Pro (Thinking 1K): 0
+cost_per_task:
+  Human Panel: 17
+  Claude Opus 4 (Thinking 16K): 1.9284
+  o3 (High): 0.8339
+  o4-mini (High): 0.856
+  Claude Sonnet 4 (Thinking 16K): 0.4857
+  o3-Pro (High): 7.5516
+  Gemini 2.5 Pro (Thinking 32K): 0.757
+  Claude Opus 4 (Thinking 8K): 1.1569
+  Gemini 2.5 Pro (Thinking 16K): 0.7145
+  o3-preview (Low)*: 200
+  o3-mini (High): 0.5472
+  o3 (Medium): 0.4787
+  Gemini 2.5 Pro (Thinking 8K): 0.4439
+  Gemini 2.5 Flash (Preview) (Thinking 24K): 0.3191
+  ARChitects: 0.2
+  o4-mini (Medium): 0.2311
+  Gemini 2.5 Flash (Preview) (Thinking 1K): 0.0302
+  Gemini 2.5 Flash (Preview) (Thinking 8K): 0.1994
+  Claude Sonnet 4 (Thinking 8K): 0.2654
+  o3-mini (Medium): 0.2843
+  o3-Pro (Low): 2.2293
+  o3 (Low): 0.2343
+  Gemini 2.5 Flash (Preview) (Thinking 16K): 0.3173
+  o3-Pro (Medium): 4.7441
+  Gemini 2.5 Flash (Preview): 0.057
+  o4-mini (Low): 0.05
+  Icecuber: 0.13
+  Gemini 2.0 Flash: 0.004
+  Deepseek R1: 0.08
+  Codex Mini (Latest): 0.23
+  Claude Sonnet 4: 0.1272
+  Claude Opus 4: 0.6388
+  o1 (Medium): 2.6116
+  Deepseek R1 (05/28): 0.0527
+  o1-pro (Low): 13.9521
+  Claude 3.7 (8K): 0.36
+  Claude Sonnet 4 (Thinking 1K): 0.1425
+  o1-mini: 0.1907
+  o1 (Low): 1.4656
+  Gemini 1.5 Pro: 0.04
+  GPT-4.5: 2.1
+  Claude 3.7 (16K): 0.51
+  GPT-4.1: 0.0691
+  Grok 3 Mini (Low): 0.0131
+  Claude 3.7 (1K): 0.14
+  Claude 3.7: 0.12
+  GPT-4o: 0.08
+  GPT-4o-mini: 0.01
+  Llama 4 Maverick: 0.0121
+  Llama 4 Scout: 0.0062
+  GPT-4.1-Nano: 0.0036
+  GPT-4.1-Mini: 0.0139
+  o3-mini (Low): 0.0623
+  Claude Opus 4 (Thinking 1K): 0.7503
+  Grok 3: 0.1421
+  Magistral Small: 0.0488
+  Magistral Medium: 0.1079
+  Magistral Medium (Thinking): 0.123
+  Gemini 2.5 Pro (Thinking 1K): 0.0885

--- a/scripts/scrape_arc_agi_2.ts
+++ b/scripts/scrape_arc_agi_2.ts
@@ -1,0 +1,73 @@
+import fs from "fs/promises"
+import path from "path"
+import { execSync } from "child_process"
+import YAML from "yaml"
+
+function curl(url: string): string {
+  return execSync(`curl -sL ${url}`, { encoding: "utf8" })
+}
+
+async function main(): Promise<void> {
+  const datasets = JSON.parse(
+    curl("https://arcprize.org/media/data/leaderboard/datasets.json"),
+  ) as Array<{ id: string; displayName: string }>
+  const models = JSON.parse(
+    curl("https://arcprize.org/media/data/leaderboard/models.json"),
+  ) as Array<{ id: string; displayName: string }>
+  const evaluations = JSON.parse(
+    curl("https://arcprize.org/media/data/leaderboard/evaluations.json"),
+  ) as Array<{
+    datasetId: string
+    modelId: string
+    score: number
+    costPerTask?: number
+    display?: boolean
+  }>
+
+  const datasetId = "v2_Semi_Private"
+  const dataset = datasets.find((d) => d.id === datasetId)
+  if (!dataset) throw new Error("Dataset not found")
+
+  const modelMap: Record<string, string> = {}
+  for (const m of models) modelMap[m.id] = m.displayName
+
+  const entries = evaluations.filter(
+    (e) => e.datasetId === datasetId && (e as any).display,
+  )
+  entries.sort((a, b) => b.score - a.score)
+
+  const results: Record<string, number> = {}
+  const costPerTask: Record<string, number> = {}
+  for (const e of entries) {
+    let score = e.score
+    if (score > 0 && score <= 1) score *= 100
+    const name = modelMap[e.modelId] || e.modelId
+    results[name] = Math.round(score * 10) / 10
+    if (typeof e.costPerTask === "number") {
+      costPerTask[name] = e.costPerTask
+    }
+  }
+
+  const yamlObj = {
+    benchmark: dataset.displayName,
+    description: "Accuracy on ARC-AGI-2",
+    results,
+    cost_per_task: costPerTask,
+  }
+
+  const outPath = path.join(
+    __dirname,
+    "..",
+    "public",
+    "data",
+    "benchmarks",
+    "arc-agi-2.yaml",
+  )
+  await fs.writeFile(outPath, YAML.stringify(yamlObj))
+  console.log(`Wrote ${outPath}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- scrape the ARC-AGI-2 leaderboard data
- generate `arc-agi-2.yaml`
- expose `scrape:arc-agi-2` pnpm script

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`
- `pnpm run scrape:arc-agi-2`

------
https://chatgpt.com/codex/tasks/task_e_68617a0b5db88320a8a7d21314cd5649