### PR TITLE
Remove leaderboard table border and pagination

### DIFF
--- a/components/data-table.tsx
+++ b/components/data-table.tsx
@@ -8,12 +8,9 @@ import {
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
-  getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table"
-
-import { Button } from "@/components/ui/button"
 
 import {
   Table,
@@ -46,7 +43,6 @@ export function DataTable<TData, TValue>({
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     getCoreRowModel: getCoreRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     state: {
@@ -57,7 +53,7 @@ export function DataTable<TData, TValue>({
 
   return (
     <div className="w-full">
-      <div className="rounded-md border">
+      <div className="rounded-md">
         <Table>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
@@ -104,26 +100,7 @@ export function DataTable<TData, TValue>({
           </TableBody>
         </Table>
       </div>
-      <div className="flex items-center justify-end space-x-2 py-4">
-        <div className="space-x-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => table.previousPage()}
-            disabled={!table.getCanPreviousPage()}
-          >
-            Previous
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => table.nextPage()}
-            disabled={!table.getCanNextPage()}
-          >
-            Next
-          </Button>
-        </div>
-      </div>
+      {/* Pagination removed: show all rows without controls */}
     </div>
   )
 }

--- a/components/leaderboard-table.tsx
+++ b/components/leaderboard-table.tsx
@@ -12,7 +12,7 @@ export default async function LeaderboardTable() {
   const tableData: TableRow[] = transformToTableData(data)
 
   return (
-    <Card>
+    <Card className="border-0">
       <CardContent>
         <DataTable columns={columns} data={tableData} />
       </CardContent>


### PR DESCRIPTION
## Summary
- remove outer border from leaderboard table container and surrounding card
- display all leaderboard rows at once

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm prettier`


------
https://chatgpt.com/codex/tasks/task_e_68617c44e7a883208dbe9029e5af2e90