### PR TITLE
Rescale normalized scores to 0-100

### DIFF
--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -110,8 +110,9 @@ export async function loadLLMData(): Promise<LLMData[]> {
       return (result.score - min) / (max - min)
     })
     llm.averageScore =
-      normalised.reduce((sum, score) => sum + score, 0) /
-      (normalised.length || 1)
+      (normalised.reduce((sum, score) => sum + score, 0) /
+        (normalised.length || 1)) *
+      100
     return llm
   })
 


### PR DESCRIPTION
## Summary
- display average normalized scores on a 0-100 scale
- label leaderboard and column headers accordingly

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm prettier`


------
https://chatgpt.com/codex/tasks/task_e_68617d9863a48320818722f0d3336dbb