### PR TITLE
Add z-score normalized cost column

### DIFF
--- a/components/columns.tsx
+++ b/components/columns.tsx
@@ -17,6 +17,11 @@ const ScoreCell = ({ score }: { score: number }) => (
   <Badge variant="secondary">{score.toFixed(1)}</Badge>
 )
 
+const CostCell = ({ cost }: { cost: number | null }) => {
+  if (cost === null || Number.isNaN(cost)) return null
+  return <Badge variant="secondary">{cost.toFixed(2)}</Badge>
+}
+
 export const columns: ColumnDef<TableRow>[] = [
   {
     accessorKey: "model",
@@ -106,6 +111,28 @@ export const columns: ColumnDef<TableRow>[] = [
       return (
         <div className="font-semibold">
           <ScoreCell score={score} />
+        </div>
+      )
+    },
+  },
+  {
+    accessorKey: "costPerTask",
+    header: ({ column }) => {
+      return (
+        <Button
+          variant="ghost"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          Cost Per Task (z-score)
+          <ArrowUpDown className="ml-2 h-4 w-4" />
+        </Button>
+      )
+    },
+    cell: ({ row }) => {
+      const cost = row.getValue("costPerTask") as number | null
+      return (
+        <div className="font-semibold">
+          <CostCell cost={cost} />
         </div>
       )
     },


### PR DESCRIPTION
## Summary
- load `cost_per_task` from benchmark YAMLs
- compute average cost per model and normalize by z-score
- show new Cost Per Task column on leaderboard table

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6861819b9454832080da8226cea4a0ff