### PR TITLE
Add cost vs score scatter plot

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import LeaderboardTable from "@/components/leaderboard-table"
+import CostScoreChart from "@/components/cost-score-chart"
 import NavigationPills from "@/components/navigation-pills"
 import Image from "next/image"
 
@@ -22,6 +23,7 @@ export default function Home() {
         </p>
       </div>
       <NavigationPills />
+      <CostScoreChart />
       <LeaderboardTable />
     </main>
   )

--- a/components/cost-score-chart-client.tsx
+++ b/components/cost-score-chart-client.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import {
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  type TooltipProps,
+} from "recharts"
+import { Card, CardContent } from "@/components/ui/card"
+
+interface Datum {
+  model: string
+  cost: number
+  score: number
+}
+
+type Props = {
+  data: Datum[]
+}
+
+function CustomTooltip({ active, payload }: TooltipProps<number, string>) {
+  if (active && payload && payload.length) {
+    const p = payload[0].payload as Datum
+    return (
+      <div className="rounded border bg-background p-2 text-xs shadow">
+        {p.model}
+      </div>
+    )
+  }
+  return null
+}
+
+export default function CostScoreChartClient({ data }: Props) {
+  if (!data.length) return null
+  return (
+    <Card className="border-0">
+      <CardContent>
+        <div className="w-full overflow-x-auto">
+          <ScatterChart
+            width={600}
+            height={300}
+            margin={{ top: 20, right: 20, bottom: 20, left: 0 }}
+          >
+            <CartesianGrid />
+            <XAxis
+              dataKey="cost"
+              type="number"
+              name="Cost"
+              scale="log"
+              domain={["dataMin", "dataMax"]}
+              tickFormatter={(v) => v.toFixed(2)}
+            />
+            <YAxis
+              dataKey="score"
+              type="number"
+              domain={[0, 100]}
+              name="Score"
+            />
+            <Tooltip content={<CustomTooltip />} />
+            <Scatter data={data} fill="hsl(240,100%,60%)" />
+          </ScatterChart>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -1,0 +1,15 @@
+import CostScoreChartClient from "./cost-score-chart-client"
+import { loadLLMData } from "@/lib/data-loader"
+
+export default async function CostScoreChart() {
+  const llmData = await loadLLMData()
+  const chartData = llmData
+    .filter((m) => m.normalizedCost !== undefined && m.normalizedCost !== null)
+    .map((m) => ({
+      model: m.model,
+      cost: m.normalizedCost as number,
+      score: m.averageScore ?? 0,
+    }))
+
+  return <CostScoreChartClient data={chartData} />
+}


### PR DESCRIPTION
## Summary
- show a scatter chart on the main page
- chart uses normalized cost per task vs average normalized score
- hover tooltip displays the model name

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68618c0b83b4832082d5b0d9ac2375c0