### PR TITLE
Fix tests

### DIFF
--- a/lib/__tests__/data-loader.test.ts
+++ b/lib/__tests__/data-loader.test.ts
@@ -10,6 +10,12 @@ test("transformToTableData converts LLMData objects to table rows", () => {
 
   const rows = transformToTableData(llms)
   expect(rows).toEqual([
-    { id: "foo", model: "Foo", provider: "Bar", averageScore: 42 },
+    {
+      id: "foo",
+      model: "Foo",
+      provider: "Bar",
+      averageScore: 42,
+      costPerTask: null,
+    },
   ])
 })


### PR DESCRIPTION
## Summary
- update `data-loader` test to check for a `null` `costPerTask`

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm prettier`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68618d3cc42083208539514e22bcd009