### PR TITLE
Improve chart tooltip

### DIFF
--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -11,7 +11,7 @@ import {
 } from "recharts"
 import { Card, CardContent } from "@/components/ui/card"
 import { LLMData } from "@/lib/data-loader"
-import { ChartConfig, ChartContainer } from "./ui/chart"
+import { ChartContainer } from "./ui/chart"
 
 type Props = {
   llmData: LLMData[]
@@ -21,8 +21,14 @@ function CustomTooltip({ active, payload }: TooltipProps<number, string>) {
   if (active && payload && payload.length) {
     const p = payload[0].payload as LLMData
     return (
-      <div className="rounded border bg-background p-2 text-xs shadow">
-        {p.model}
+      <div className="rounded border bg-background p-2 text-xs shadow space-y-1">
+        <div>{p.model}</div>
+        {p.normalizedCost !== undefined && (
+          <div>Cost: {p.normalizedCost.toFixed(2)}</div>
+        )}
+        {p.averageScore !== undefined && (
+          <div>Score: {p.averageScore.toFixed(2)}</div>
+        )}
       </div>
     )
   }

--- a/components/leaderboard-table.tsx
+++ b/components/leaderboard-table.tsx
@@ -1,10 +1,5 @@
 import { Card, CardContent } from "@/components/ui/card"
-import {
-  loadLLMData,
-  transformToTableData,
-  type TableRow,
-  LLMData,
-} from "@/lib/data-loader"
+import { transformToTableData, type TableRow, LLMData } from "@/lib/data-loader"
 import { DataTable } from "./data-table"
 import { columns } from "./columns"
 


### PR DESCRIPTION
## Summary
- show model, cost, and score in the scatter chart tooltip
- remove unused imports

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6866192d6b48832080f9dbf45040806d