### PR TITLE
Add benchmark count tooltip

### DIFF
--- a/components/columns.tsx
+++ b/components/columns.tsx
@@ -9,6 +9,12 @@ import {
   PopoverTrigger,
   PopoverContent,
 } from "@/components/ui/popover"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { Input } from "@/components/ui/input"
 
 import type { TableRow } from "@/lib/data-loader"
@@ -108,10 +114,20 @@ export const columns: ColumnDef<TableRow>[] = [
     },
     cell: ({ row }) => {
       const score = row.getValue("averageScore") as number
+      const count = row.getValue("benchmarkCount") as number
       return (
-        <div className="font-semibold">
-          <ScoreCell score={score} />
-        </div>
+        <TooltipProvider delayDuration={0}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className="font-semibold">
+                <ScoreCell score={score} />
+              </div>
+            </TooltipTrigger>
+            <TooltipContent>
+              Evaluated on {count} benchmark{count === 1 ? "" : "s"}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       )
     },
   },

--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -11,7 +11,7 @@ import {
 } from "recharts"
 import { Card, CardContent } from "@/components/ui/card"
 import { LLMData } from "@/lib/data-loader"
-import { ChartConfig, ChartContainer } from "./ui/chart"
+import { ChartContainer } from "./ui/chart"
 
 type Props = {
   llmData: LLMData[]

--- a/components/leaderboard-table.tsx
+++ b/components/leaderboard-table.tsx
@@ -1,10 +1,5 @@
 import { Card, CardContent } from "@/components/ui/card"
-import {
-  loadLLMData,
-  transformToTableData,
-  type TableRow,
-  LLMData,
-} from "@/lib/data-loader"
+import { transformToTableData, type TableRow, LLMData } from "@/lib/data-loader"
 import { DataTable } from "./data-table"
 import { columns } from "./columns"
 

--- a/lib/__tests__/data-loader.test.ts
+++ b/lib/__tests__/data-loader.test.ts
@@ -22,6 +22,7 @@ test("transformToTableData converts LLMData objects to table rows", () => {
       provider: "Bar",
       averageScore: 42,
       costPerTask: null,
+      benchmarkCount: 0,
     },
   ])
 })

--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -24,6 +24,7 @@ export interface TableRow {
   provider: string
   averageScore: number
   costPerTask: number | null
+  benchmarkCount: number
 }
 
 export async function loadLLMData(): Promise<LLMData[]> {
@@ -183,5 +184,6 @@ export function transformToTableData(llmData: LLMData[]): TableRow[] {
     provider: llm.provider,
     averageScore: llm.averageScore || 0,
     costPerTask: llm.normalizedCost ?? null,
+    benchmarkCount: Object.keys(llm.benchmarks).length,
   }))
 }


### PR DESCRIPTION
## Summary
- show benchmark count as a tooltip on the score column
- drop unused imports

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686619738b6c832088c1c57aea4e575c