### PR TITLE
Increase data loader test coverage

### DIFF
--- a/lib/__tests__/data-loader.test.ts
+++ b/lib/__tests__/data-loader.test.ts
@@ -1,4 +1,4 @@
-import { transformToTableData, type LLMData } from "../data-loader"
+import { loadLLMData, transformToTableData, type LLMData } from "../data-loader"
 import { expect, test } from "vitest"
 
 // Simple unit test for transformToTableData
@@ -24,4 +24,23 @@ test("transformToTableData converts LLMData objects to table rows", () => {
       costPerTask: null,
     },
   ])
+})
+
+test("loadLLMData merges aliases and sorts results", async () => {
+  const llmData = await loadLLMData()
+
+  // should return some data
+  expect(llmData.length).toBeGreaterThan(0)
+
+  // results must be sorted by averageScore descending
+  const scores = llmData.map((d) => d.averageScore || 0)
+  const sorted = [...scores].sort((a, b) => b - a)
+  expect(scores).toEqual(sorted)
+
+  // aliases like `grok-3-preview-02-24` should map to `grok-3`
+  const grok = llmData.find((d) => d.slug === "grok-3")
+  expect(grok).toBeDefined()
+  expect(grok?.benchmarks["LMArena Text"]).toBeDefined()
+  const alias = llmData.find((d) => d.slug === "grok-3-preview-02-24")
+  expect(alias).toBeUndefined()
 })


### PR DESCRIPTION
## Summary
- add new tests for `loadLLMData`

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68661bb42f84832086a941f45df238d1