### PR TITLE
Add deprecated model toggle

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,7 @@
-import LeaderboardTable from "@/components/leaderboard-table"
+import LeaderboardSection from "@/components/leaderboard-section"
 import NavigationPills from "@/components/navigation-pills"
 import Image from "next/image"
 import { loadLLMData } from "@/lib/data-loader"
-import CostScoreChart from "@/components/cost-score-chart"
 
 export default async function Home() {
   const llmData = await loadLLMData()
@@ -26,8 +25,7 @@ export default async function Home() {
         </p>
       </div>
       <NavigationPills />
-      <CostScoreChart llmData={llmData} />
-      <LeaderboardTable llmData={llmData} />
+      <LeaderboardSection llmData={llmData} />
     </main>
   )
 }

--- a/components/leaderboard-section.tsx
+++ b/components/leaderboard-section.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import { useState } from "react"
+import type { LLMData } from "@/lib/data-loader"
+import CostScoreChart from "./cost-score-chart"
+import LeaderboardTable from "./leaderboard-table"
+import { Switch } from "@/components/ui/switch"
+import { Label } from "@/components/ui/label"
+
+export default function LeaderboardSection({
+  llmData,
+}: {
+  llmData: LLMData[]
+}) {
+  const [showDeprecated, setShowDeprecated] = useState(false)
+  const filtered = showDeprecated
+    ? llmData
+    : llmData.filter((m) => !m.deprecated)
+
+  return (
+    <div className="space-y-4">
+      <CostScoreChart llmData={filtered} />
+      <div className="flex items-center justify-center gap-2">
+        <Switch
+          id="deprecated-toggle"
+          checked={showDeprecated}
+          onCheckedChange={setShowDeprecated}
+        />
+        <Label htmlFor="deprecated-toggle">Show deprecated models</Label>
+      </div>
+      <LeaderboardTable llmData={filtered} />
+    </div>
+  )
+}

--- a/components/leaderboard-table.tsx
+++ b/components/leaderboard-table.tsx
@@ -1,13 +1,12 @@
+"use client"
+
 import { Card, CardContent } from "@/components/ui/card"
-import { transformToTableData, type TableRow, LLMData } from "@/lib/data-loader"
+import { transformToTableData, type TableRow } from "@/lib/table-utils"
+import type { LLMData } from "@/lib/data-loader"
 import { DataTable } from "./data-table"
 import { columns } from "./columns"
 
-export default async function LeaderboardTable({
-  llmData,
-}: {
-  llmData: LLMData[]
-}) {
+export default function LeaderboardTable({ llmData }: { llmData: LLMData[] }) {
   const tableData: TableRow[] = transformToTableData(llmData)
 
   return (

--- a/lib/__tests__/data-loader.test.ts
+++ b/lib/__tests__/data-loader.test.ts
@@ -1,4 +1,5 @@
-import { loadLLMData, transformToTableData, type LLMData } from "../data-loader"
+import { loadLLMData, type LLMData } from "../data-loader"
+import { transformToTableData } from "../table-utils"
 import { expect, test } from "vitest"
 
 // Simple unit test for transformToTableData

--- a/lib/table-utils.ts
+++ b/lib/table-utils.ts
@@ -1,0 +1,24 @@
+export interface TableRow {
+  id: string
+  model: string
+  provider: string
+  averageScore: number
+  costPerTask: number | null
+}
+
+export function transformToTableData(
+  llmData: {
+    model: string
+    provider: string
+    averageScore?: number
+    normalizedCost?: number | null
+  }[],
+): TableRow[] {
+  return llmData.map((llm) => ({
+    id: llm.model.toLowerCase().replace(/\s+/g, "-"),
+    model: llm.model,
+    provider: llm.provider,
+    averageScore: llm.averageScore || 0,
+    costPerTask: llm.normalizedCost ?? null,
+  }))
+}

--- a/public/data/models/deepseek-r1.yaml
+++ b/public/data/models/deepseek-r1.yaml
@@ -2,3 +2,4 @@ model: DeepSeek R1
 provider: DeepSeek
 aliases:
   - deepseek-r1
+deprecated: true

--- a/public/data/models/gemini-2.5-pro-preview-03-25.yaml
+++ b/public/data/models/gemini-2.5-pro-preview-03-25.yaml
@@ -3,3 +3,4 @@ provider: Google
 aliases:
   - Gemini 2.5 Pro (03-25)
   - Gemini 2.5 Pro Experimental (March 2025)
+deprecated: true

--- a/public/data/models/gemini-2.5-pro-preview-05-06.yaml
+++ b/public/data/models/gemini-2.5-pro-preview-05-06.yaml
@@ -3,3 +3,4 @@ provider: Google
 aliases:
   - gemini-2.5-pro-preview-05-06
   - Gemini 2.5 Pro Preview (May 06 2025)
+deprecated: true


### PR DESCRIPTION
## Summary
- mark preview model YAMLs as deprecated
- split table utilities from the data loader
- add a `LeaderboardSection` with toggle to hide deprecated models
- fix incorrect deprecation flag for GPT‑4.1 Nano

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6866b88f59f48320af22323b10bf5467