### PR TITLE
Customize scatter chart tooltip

### DIFF
--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -45,9 +45,18 @@ export default function CostScoreChart({ llmData }: Props) {
               labelFormatter={(_, payload) =>
                 (payload?.[0]?.payload as LLMData).model
               }
-              formatter={(value: number) =>
-                typeof value === "number" ? value.toFixed(2) : value
-              }
+              itemSorter={(a, b) => {
+                const order: Record<string, number> = { Score: 0, Cost: 1 }
+                return (
+                  (order[a.name as string] ?? 0) -
+                  (order[b.name as string] ?? 0)
+                )
+              }}
+              formatter={(value: number | string, name: string) => (
+                <span>
+                  {name}: {typeof value === "number" ? value.toFixed(2) : value}
+                </span>
+              )}
               content={<ChartTooltipContent />}
             />
             <Scatter data={llmData} fill="hsl(240,100%,60%)" />


### PR DESCRIPTION
## Summary
- tweak cost-score chart tooltip to show model name, score and cost

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm prettier`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6866ce0d666c8320825813a313fabb51