### PR TITLE
Color coded providers

### DIFF
--- a/components/columns.tsx
+++ b/components/columns.tsx
@@ -4,6 +4,7 @@ import type { ColumnDef } from "@tanstack/react-table"
 import { ArrowUpDown, Search } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
+import { PROVIDER_COLORS } from "@/lib/provider-colors"
 import {
   Popover,
   PopoverTrigger,
@@ -89,9 +90,22 @@ export const columns: ColumnDef<TableRow>[] = [
         </div>
       )
     },
-    cell: ({ row }) => (
-      <Badge variant="outline">{row.getValue("provider")}</Badge>
-    ),
+    cell: ({ row }) => {
+      const provider = row.getValue("provider") as string
+      const colorVar = PROVIDER_COLORS[provider]
+      return (
+        <Badge
+          variant="outline"
+          style={{
+            backgroundColor: colorVar ? `hsl(var(${colorVar}))` : undefined,
+            color: colorVar ? "white" : undefined,
+            borderColor: colorVar ? `hsl(var(${colorVar}))` : undefined,
+          }}
+        >
+          {provider}
+        </Badge>
+      )
+    },
   },
   {
     accessorKey: "averageScore",

--- a/components/columns.tsx
+++ b/components/columns.tsx
@@ -92,14 +92,14 @@ export const columns: ColumnDef<TableRow>[] = [
     },
     cell: ({ row }) => {
       const provider = row.getValue("provider") as string
-      const colorVar = PROVIDER_COLORS[provider]
+      const color = PROVIDER_COLORS[provider]
       return (
         <Badge
           variant="outline"
           style={{
-            backgroundColor: colorVar ? `hsl(var(${colorVar}))` : undefined,
-            color: colorVar ? "white" : undefined,
-            borderColor: colorVar ? `hsl(var(${colorVar}))` : undefined,
+            backgroundColor: color,
+            color: color ? "white" : undefined,
+            borderColor: color,
           }}
         >
           {provider}

--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -1,8 +1,10 @@
 "use client"
 
+import React from "react"
 import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid } from "recharts"
 import { Card, CardContent } from "@/components/ui/card"
 import { LLMData } from "@/lib/data-loader"
+import { PROVIDER_COLORS } from "@/lib/provider-colors"
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "./ui/chart"
 
 type Props = {
@@ -10,6 +12,15 @@ type Props = {
 }
 
 export default function CostScoreChart({ llmData }: Props) {
+  const groups = React.useMemo(() => {
+    const map: Record<string, LLMData[]> = {}
+    for (const item of llmData) {
+      if (!map[item.provider]) map[item.provider] = []
+      map[item.provider].push(item)
+    }
+    return map
+  }, [llmData])
+
   if (!llmData.length) return null
 
   return (
@@ -50,7 +61,14 @@ export default function CostScoreChart({ llmData }: Props) {
               }
               content={<ChartTooltipContent />}
             />
-            <Scatter data={llmData} fill="hsl(240,100%,60%)" />
+            {Object.entries(groups).map(([provider, data]) => (
+              <Scatter
+                key={provider}
+                data={data}
+                name={provider}
+                fill={`hsl(var(${PROVIDER_COLORS[provider]}))`}
+              />
+            ))}
           </ScatterChart>
         </ChartContainer>
       </CardContent>

--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -66,7 +66,7 @@ export default function CostScoreChart({ llmData }: Props) {
                 key={provider}
                 data={data}
                 name={provider}
-                fill={`hsl(var(${PROVIDER_COLORS[provider]}))`}
+                fill={PROVIDER_COLORS[provider]}
               />
             ))}
           </ScatterChart>

--- a/lib/provider-colors.ts
+++ b/lib/provider-colors.ts
@@ -1,7 +1,8 @@
+// Brand inspired colors for each provider
 export const PROVIDER_COLORS: Record<string, string> = {
-  OpenAI: "--chart-1",
-  Anthropic: "--chart-2",
-  Google: "--chart-3",
-  DeepSeek: "--chart-4",
-  xAI: "--chart-5",
+  OpenAI: "#000000", // black
+  Anthropic: "#FF7F40", // burnt orange
+  Google: "#4285F4", // google blue
+  DeepSeek: "#2F88FF", // deepseek blue
+  xAI: "#000000", // black
 }

--- a/lib/provider-colors.ts
+++ b/lib/provider-colors.ts
@@ -1,0 +1,7 @@
+export const PROVIDER_COLORS: Record<string, string> = {
+  OpenAI: "--chart-1",
+  Anthropic: "--chart-2",
+  Google: "--chart-3",
+  DeepSeek: "--chart-4",
+  xAI: "--chart-5",
+}


### PR DESCRIPTION
## Summary
- map each model provider to a chart color
- color provider badges in the table
- color scatter points in the chart by provider

## Testing
- `pnpm prettier --check . --write lib/provider-colors.ts components/columns.tsx components/cost-score-chart.tsx`
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6866ce4f01a48320b769e092e64c78ea