### PR TITLE
Add tooltip for leaderboard scores

### DIFF
--- a/components/columns.tsx
+++ b/components/columns.tsx
@@ -5,6 +5,11 @@ import { ArrowUpDown, Search } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip"
+import {
   Popover,
   PopoverTrigger,
   PopoverContent,
@@ -13,8 +18,25 @@ import { Input } from "@/components/ui/input"
 
 import type { TableRow } from "@/lib/data-loader"
 
-const ScoreCell = ({ score }: { score: number }) => (
-  <Badge variant="secondary">{score.toFixed(1)}</Badge>
+const ScoreCell = ({
+  score,
+  benchmarks,
+}: {
+  score: number
+  benchmarks: string[]
+}) => (
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <Badge variant="secondary" className="cursor-default">
+        {score.toFixed(1)}
+      </Badge>
+    </TooltipTrigger>
+    {benchmarks.length > 0 && (
+      <TooltipContent className="text-xs">
+        {benchmarks.join(", ")}
+      </TooltipContent>
+    )}
+  </Tooltip>
 )
 
 const CostCell = ({ cost }: { cost: number | null }) => {
@@ -108,9 +130,10 @@ export const columns: ColumnDef<TableRow>[] = [
     },
     cell: ({ row }) => {
       const score = row.getValue("averageScore") as number
+      const benchmarks = row.original.benchmarks
       return (
         <div className="font-semibold">
-          <ScoreCell score={score} />
+          <ScoreCell score={score} benchmarks={benchmarks} />
         </div>
       )
     },

--- a/components/leaderboard-table.tsx
+++ b/components/leaderboard-table.tsx
@@ -5,6 +5,7 @@ import { transformToTableData, type TableRow } from "@/lib/table-utils"
 import type { LLMData } from "@/lib/data-loader"
 import { DataTable } from "./data-table"
 import { columns } from "./columns"
+import { TooltipProvider } from "@/components/ui/tooltip"
 
 export default function LeaderboardTable({ llmData }: { llmData: LLMData[] }) {
   const tableData: TableRow[] = transformToTableData(llmData)
@@ -12,7 +13,9 @@ export default function LeaderboardTable({ llmData }: { llmData: LLMData[] }) {
   return (
     <Card className="border-0">
       <CardContent>
-        <DataTable columns={columns} data={tableData} />
+        <TooltipProvider>
+          <DataTable columns={columns} data={tableData} />
+        </TooltipProvider>
       </CardContent>
     </Card>
   )

--- a/lib/__tests__/data-loader.test.ts
+++ b/lib/__tests__/data-loader.test.ts
@@ -23,6 +23,7 @@ test("transformToTableData converts LLMData objects to table rows", () => {
       provider: "Bar",
       averageScore: 42,
       costPerTask: null,
+      benchmarks: [],
     },
   ])
 })

--- a/lib/table-utils.ts
+++ b/lib/table-utils.ts
@@ -4,6 +4,7 @@ export interface TableRow {
   provider: string
   averageScore: number
   costPerTask: number | null
+  benchmarks: string[]
 }
 
 export function transformToTableData(
@@ -12,6 +13,7 @@ export function transformToTableData(
     provider: string
     averageScore?: number
     normalizedCost?: number | null
+    benchmarks?: Record<string, unknown>
   }[],
 ): TableRow[] {
   return llmData.map((llm) => ({
@@ -20,5 +22,6 @@ export function transformToTableData(
     provider: llm.provider,
     averageScore: llm.averageScore || 0,
     costPerTask: llm.normalizedCost ?? null,
+    benchmarks: llm.benchmarks ? Object.keys(llm.benchmarks) : [],
   }))
 }


### PR DESCRIPTION
## Summary
- include benchmark names in `transformToTableData`
- show benchmarks in a tooltip on the leaderboard score
- wrap the table in a `TooltipProvider`
- update unit tests for new table row field

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm prettier`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6866d040f6488320a946db13b3fcafc5