### PR TITLE
Remove border around main chart

### DIFF
--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid } from "recharts"
-import { Card, CardContent } from "@/components/ui/card"
 import { LLMData } from "@/lib/data-loader"
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "./ui/chart"
 
@@ -13,56 +12,51 @@ export default function CostScoreChart({ llmData }: Props) {
   if (!llmData.length) return null
 
   return (
-    <Card className="border-0">
-      <CardContent>
-        <ChartContainer
-          config={{
-            normalizedCost: { label: "Cost" },
-            averageScore: { label: "Score" },
+    <ChartContainer
+      config={{
+        normalizedCost: { label: "Cost" },
+        averageScore: { label: "Score" },
+      }}
+    >
+      <ScatterChart
+        width={600}
+        height={300}
+        margin={{ top: 20, right: 20, bottom: 20, left: 0 }}
+      >
+        <CartesianGrid />
+        <XAxis
+          dataKey="normalizedCost"
+          type="number"
+          name="Cost"
+          scale="log"
+          domain={["dataMin", "dataMax"]}
+          tickFormatter={(v) => v && v.toFixed(2)}
+        />
+        <YAxis
+          dataKey="averageScore"
+          type="number"
+          domain={[0, 100]}
+          name="Score"
+        />
+        <ChartTooltip
+          labelFormatter={(_, payload) =>
+            (payload?.[0]?.payload as LLMData).model
+          }
+          itemSorter={(a, b) => {
+            const order: Record<string, number> = { Score: 0, Cost: 1 }
+            return (
+              (order[a.name as string] ?? 0) - (order[b.name as string] ?? 0)
+            )
           }}
-        >
-          <ScatterChart
-            width={600}
-            height={300}
-            margin={{ top: 20, right: 20, bottom: 20, left: 0 }}
-          >
-            <CartesianGrid />
-            <XAxis
-              dataKey="normalizedCost"
-              type="number"
-              name="Cost"
-              scale="log"
-              domain={["dataMin", "dataMax"]}
-              tickFormatter={(v) => v && v.toFixed(2)}
-            />
-            <YAxis
-              dataKey="averageScore"
-              type="number"
-              domain={[0, 100]}
-              name="Score"
-            />
-            <ChartTooltip
-              labelFormatter={(_, payload) =>
-                (payload?.[0]?.payload as LLMData).model
-              }
-              itemSorter={(a, b) => {
-                const order: Record<string, number> = { Score: 0, Cost: 1 }
-                return (
-                  (order[a.name as string] ?? 0) -
-                  (order[b.name as string] ?? 0)
-                )
-              }}
-              formatter={(value: number | string, name: string) => (
-                <span>
-                  {name}: {typeof value === "number" ? value.toFixed(2) : value}
-                </span>
-              )}
-              content={<ChartTooltipContent />}
-            />
-            <Scatter data={llmData} fill="hsl(240,100%,60%)" />
-          </ScatterChart>
-        </ChartContainer>
-      </CardContent>
-    </Card>
+          formatter={(value: number | string, name: string) => (
+            <span>
+              {name}: {typeof value === "number" ? value.toFixed(2) : value}
+            </span>
+          )}
+          content={<ChartTooltipContent />}
+        />
+        <Scatter data={llmData} fill="hsl(240,100%,60%)" />
+      </ScatterChart>
+    </ChartContainer>
   )
 }


### PR DESCRIPTION
## Summary
- drop the `<Card>` wrapper from `CostScoreChart`

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6866e7612c9c8320832cf6dad0397278