### PR TITLE
Remove chart card styling

### DIFF
--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -2,7 +2,7 @@
 
 import React from "react"
 import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid } from "recharts"
-import { Card, CardContent } from "@/components/ui/card"
+
 import { LLMData } from "@/lib/data-loader"
 import { PROVIDER_COLORS } from "@/lib/provider-colors"
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "./ui/chart"
@@ -24,63 +24,58 @@ export default function CostScoreChart({ llmData }: Props) {
   if (!llmData.length) return null
 
   return (
-    <Card className="border-0">
-      <CardContent>
-        <ChartContainer
-          config={{
-            normalizedCost: { label: "Cost" },
-            averageScore: { label: "Score" },
+    <ChartContainer
+      config={{
+        normalizedCost: { label: "Cost" },
+        averageScore: { label: "Score" },
+      }}
+    >
+      <ScatterChart
+        width={600}
+        height={300}
+        margin={{ top: 20, right: 20, bottom: 20, left: 0 }}
+      >
+        <CartesianGrid />
+        <XAxis
+          dataKey="normalizedCost"
+          type="number"
+          name="Cost"
+          scale="log"
+          domain={["dataMin", "dataMax"]}
+          tickFormatter={(v) => v && v.toFixed(2)}
+        />
+        <YAxis
+          dataKey="averageScore"
+          type="number"
+          domain={[0, 100]}
+          name="Score"
+        />
+        <ChartTooltip
+          labelFormatter={(_, payload) =>
+            (payload?.[0]?.payload as LLMData).model
+          }
+          itemSorter={(a, b) => {
+            const order: Record<string, number> = { Score: 0, Cost: 1 }
+            return (
+              (order[a.name as string] ?? 0) - (order[b.name as string] ?? 0)
+            )
           }}
-        >
-          <ScatterChart
-            width={600}
-            height={300}
-            margin={{ top: 20, right: 20, bottom: 20, left: 0 }}
-          >
-            <CartesianGrid />
-            <XAxis
-              dataKey="normalizedCost"
-              type="number"
-              name="Cost"
-              scale="log"
-              domain={["dataMin", "dataMax"]}
-              tickFormatter={(v) => v && v.toFixed(2)}
-            />
-            <YAxis
-              dataKey="averageScore"
-              type="number"
-              domain={[0, 100]}
-              name="Score"
-            />
-            <ChartTooltip
-              labelFormatter={(_, payload) =>
-                (payload?.[0]?.payload as LLMData).model
-              }
-              itemSorter={(a, b) => {
-                const order: Record<string, number> = { Score: 0, Cost: 1 }
-                return (
-                  (order[a.name as string] ?? 0) -
-                  (order[b.name as string] ?? 0)
-                )
-              }}
-              formatter={(value: number | string, name: string) => (
-                <span>
-                  {name}: {typeof value === "number" ? value.toFixed(2) : value}
-                </span>
-              )}
-              content={<ChartTooltipContent />}
-            />
-            {Object.entries(groups).map(([provider, data]) => (
-              <Scatter
-                key={provider}
-                data={data}
-                name={provider}
-                fill={PROVIDER_COLORS[provider]}
-              />
-            ))}
-          </ScatterChart>
-        </ChartContainer>
-      </CardContent>
-    </Card>
+          formatter={(value: number | string, name: string) => (
+            <span>
+              {name}: {typeof value === "number" ? value.toFixed(2) : value}
+            </span>
+          )}
+          content={<ChartTooltipContent />}
+        />
+        {Object.entries(groups).map(([provider, data]) => (
+          <Scatter
+            key={provider}
+            data={data}
+            name={provider}
+            fill={PROVIDER_COLORS[provider]}
+          />
+        ))}
+      </ScatterChart>
+    </ChartContainer>
   )
 }


### PR DESCRIPTION
## Summary
- display the main cost/score scatter chart without a Card wrapper

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- `pnpm prettier`


------
https://chatgpt.com/codex/tasks/task_e_6866fa75b79c83208b964453f1407d2d