### PR TITLE
Add GitHub icon to navigation pill

### DIFF
--- a/components/navigation-pills.tsx
+++ b/components/navigation-pills.tsx
@@ -2,15 +2,24 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
+import { Github } from "lucide-react"
+import type { LucideIcon } from "lucide-react"
 import { cn } from "@/lib/utils"
 
-const links = [
+type NavLink = {
+  href: string
+  label: string
+  icon?: LucideIcon
+}
+
+const links: NavLink[] = [
   { href: "/", label: "Leaderboard" },
   { href: "/benchmarks", label: "Benchmarks" },
   { href: "/about", label: "About" },
   {
     href: "https://github.com/maxencefrenette/all-the-benchmarks",
     label: "GitHub",
+    icon: Github,
   },
 ]
 
@@ -19,17 +28,19 @@ export default function NavigationPills() {
 
   return (
     <nav className="flex justify-center gap-2">
-      {links.map((link) =>
-        link.href.startsWith("http") ? (
+      {links.map((link) => {
+        const Icon = link.icon
+        return link.href.startsWith("http") ? (
           <a
             key={link.href}
             href={link.href}
             target="_blank"
             rel="noopener noreferrer"
             className={cn(
-              "px-4 py-1 rounded-full border text-sm hover:bg-accent hover:text-accent-foreground",
+              "flex items-center gap-1 px-4 py-1 rounded-full border text-sm hover:bg-accent hover:text-accent-foreground",
             )}
           >
+            {Icon && <Icon className="h-4 w-4" />}
             {link.label}
           </a>
         ) : (
@@ -37,16 +48,17 @@ export default function NavigationPills() {
             key={link.href}
             href={link.href}
             className={cn(
-              "px-4 py-1 rounded-full border text-sm",
+              "flex items-center gap-1 px-4 py-1 rounded-full border text-sm",
               pathname === link.href
                 ? "bg-primary text-primary-foreground"
                 : "hover:bg-accent hover:text-accent-foreground",
             )}
           >
+            {Icon && <Icon className="h-4 w-4" />}
             {link.label}
           </Link>
-        ),
-      )}
+        )
+      })}
     </nav>
   )
 }


### PR DESCRIPTION
## Summary
- show GitHub logo inside GitHub link pill

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6866fb37fbf48320bfb31191b6f0a801