### PR TITLE
Add model details page

### DIFF
--- a/app/models/[slug]/page.tsx
+++ b/app/models/[slug]/page.tsx
@@ -1,0 +1,58 @@
+import NavigationPills from "@/components/navigation-pills"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { loadLLMData, loadLLMDetails } from "@/lib/data-loader"
+import { notFound } from "next/navigation"
+
+export async function generateStaticParams() {
+  const data = await loadLLMData()
+  return data.map((m) => ({ slug: m.slug }))
+}
+
+export default async function ModelPage({
+  params,
+}: {
+  params: { slug: string }
+}) {
+  const model = await loadLLMDetails(params.slug)
+  if (!model) return notFound()
+  const entries = Object.entries(model.benchmarks).sort((a, b) =>
+    a[0].localeCompare(b[0]),
+  )
+
+  return (
+    <main className="container mx-auto px-4 py-8 max-w-3xl space-y-6">
+      <h1 className="text-4xl font-bold text-center">{model.model}</h1>
+      <p className="text-center text-muted-foreground">{model.provider}</p>
+      <NavigationPills />
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Benchmark</TableHead>
+            <TableHead className="text-right">Score</TableHead>
+            <TableHead className="text-right">Cost</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {entries.map(([name, res]) => (
+            <TableRow key={name}>
+              <TableCell>{name}</TableCell>
+              <TableCell className="text-right">{res.score}</TableCell>
+              <TableCell className="text-right">
+                {res.costPerTask !== undefined
+                  ? res.costPerTask.toFixed(2)
+                  : "—"}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </main>
+  )
+}

--- a/components/columns.tsx
+++ b/components/columns.tsx
@@ -2,6 +2,7 @@
 
 import type { ColumnDef } from "@tanstack/react-table"
 import { ArrowUpDown, Search } from "lucide-react"
+import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { PROVIDER_COLORS } from "@/lib/provider-colors"
@@ -173,5 +174,17 @@ export const columns: ColumnDef<TableRow>[] = [
         </div>
       )
     },
+  },
+  {
+    id: "details",
+    header: "Details",
+    cell: ({ row }) => (
+      <Link
+        href={`/models/${row.original.slug}`}
+        className="text-primary underline"
+      >
+        View
+      </Link>
+    ),
   },
 ]

--- a/lib/__tests__/data-loader.test.ts
+++ b/lib/__tests__/data-loader.test.ts
@@ -19,6 +19,7 @@ test("transformToTableData converts LLMData objects to table rows", () => {
   expect(rows).toEqual([
     {
       id: "foo",
+      slug: "foo",
       model: "Foo",
       provider: "Bar",
       averageScore: 42,

--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -172,5 +172,10 @@ export async function loadLLMData(): Promise<LLMData[]> {
   return results.sort((a, b) => (b.averageScore || 0) - (a.averageScore || 0))
 }
 
+export async function loadLLMDetails(slug: string): Promise<LLMData | null> {
+  const all = await loadLLMData()
+  return all.find((m) => m.slug === slug) ?? null
+}
+
 export { transformToTableData }
 export type { TableRow }

--- a/lib/table-utils.ts
+++ b/lib/table-utils.ts
@@ -1,5 +1,6 @@
 export interface TableRow {
   id: string
+  slug: string
   model: string
   provider: string
   averageScore: number
@@ -9,6 +10,7 @@ export interface TableRow {
 
 export function transformToTableData(
   llmData: {
+    slug: string
     model: string
     provider: string
     averageScore?: number
@@ -17,7 +19,8 @@ export function transformToTableData(
   }[],
 ): TableRow[] {
   return llmData.map((llm) => ({
-    id: llm.model.toLowerCase().replace(/\s+/g, "-"),
+    id: llm.slug,
+    slug: llm.slug,
     model: llm.model,
     provider: llm.provider,
     averageScore: llm.averageScore || 0,


### PR DESCRIPTION
## Summary
- add slug property to `TableRow`
- support retrieving single model details
- link to model detail page from leaderboard
- list benchmark scores and costs on a model page
- keep tests passing

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6866fec4b594832098ae15f4875003a2