### PR TITLE
Fix chart width to match table

### DIFF
--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -53,11 +53,7 @@ export default function CostScoreChart({ llmData, showDeprecated }: Props) {
           averageScore: { label: "Score" },
         }}
       >
-        <ScatterChart
-          width={600}
-          height={300}
-          margin={{ top: 20, right: 20, bottom: 20, left: 0 }}
-        >
+        <ScatterChart margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <CartesianGrid />
           <XAxis
             dataKey="normalizedCost"

--- a/components/leaderboard-table.tsx
+++ b/components/leaderboard-table.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { Card, CardContent } from "@/components/ui/card"
 import { transformToTableData, type TableRow } from "@/lib/table-utils"
 import type { LLMData } from "@/lib/data-loader"
 import { DataTable } from "./data-table"
@@ -11,12 +10,10 @@ export default function LeaderboardTable({ llmData }: { llmData: LLMData[] }) {
   const tableData: TableRow[] = transformToTableData(llmData)
 
   return (
-    <Card className="border-0">
-      <CardContent>
-        <TooltipProvider>
-          <DataTable columns={columns} data={tableData} />
-        </TooltipProvider>
-      </CardContent>
-    </Card>
+    <div className="p-6 pt-0">
+      <TooltipProvider>
+        <DataTable columns={columns} data={tableData} />
+      </TooltipProvider>
+    </div>
   )
 }

--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -52,7 +52,7 @@ const ChartContainer = React.forwardRef<
         data-chart={chartId}
         ref={ref}
         className={cn(
-          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          "flex w-full aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
           className,
         )}
         {...props}


### PR DESCRIPTION
## Summary
- make `ChartContainer` span full width
- remove fixed chart size so it can expand
- simplify `LeaderboardTable` container

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_686701d9f1648320b5b24ba61bef56ff