### PR TITLE
Adjust OpenAI provider color

### DIFF
--- a/lib/provider-colors.ts
+++ b/lib/provider-colors.ts
@@ -1,6 +1,6 @@
 // Brand inspired colors for each provider
 export const PROVIDER_COLORS: Record<string, string> = {
-  OpenAI: "#000000", // black
+  OpenAI: "#333333", // dark gray
   Anthropic: "#FF7F40", // burnt orange
   Google: "#4285F4", // google blue
   DeepSeek: "#2F88FF", // deepseek blue

--- a/lib/provider-colors.ts
+++ b/lib/provider-colors.ts
@@ -1,6 +1,6 @@
 // Brand inspired colors for each provider
 export const PROVIDER_COLORS: Record<string, string> = {
-  OpenAI: "#333333", // dark gray
+  OpenAI: "#555555", // dark gray
   Anthropic: "#FF7F40", // burnt orange
   Google: "#4285F4", // google blue
   DeepSeek: "#2F88FF", // deepseek blue


### PR DESCRIPTION
## Summary
- tweak OpenAI brand color so it's not identical to xAI

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6867023162ec8320a61a0e07bb66b6f0