### PR TITLE
Fix missing space in about page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -40,7 +40,7 @@ export default function AboutPage() {
           </p>
           <p>
             Some benchmarks also publish pricing information for completing a
-            single task. When available, these values are used to compute a
+            single task. When available, these values are used to compute a{" "}
             <em>Cost Per Task</em> metric shown on the leaderboard.
           </p>
           <p>


### PR DESCRIPTION
## Summary
- ensure a space before the *Cost Per Task* metric tag

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68670257776c83208e0f566e547d9bfe