### PR TITLE
Add axis labels to cost score chart

### DIFF
--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -62,12 +62,22 @@ export default function CostScoreChart({ llmData, showDeprecated }: Props) {
             scale="log"
             domain={costDomain as [number, number]}
             tickFormatter={(v) => v && v.toFixed(2)}
+            label={{
+              value: "Normalized Cost per Task",
+              position: "insideBottom",
+              offset: -10,
+            }}
           />
           <YAxis
             dataKey="averageScore"
             type="number"
             domain={[0, 100]}
             name="Score"
+            label={{
+              value: "Average Normalized Score",
+              angle: -90,
+              position: "insideLeft",
+            }}
           />
           <ChartTooltip
             labelFormatter={(_, payload) =>


### PR DESCRIPTION
## Summary
- add axis label configuration to ScatterChart axes so the y axis shows *Average Normalized Score* and the x axis shows *Normalized Cost per Task*

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686704ef221c83209d619e02a247a9ab