### PR TITLE
Change google color to green

### DIFF
--- a/lib/provider-colors.ts
+++ b/lib/provider-colors.ts
@@ -2,7 +2,7 @@
 export const PROVIDER_COLORS: Record<string, string> = {
   OpenAI: "#555555", // dark gray
   Anthropic: "#FF7F40", // burnt orange
-  Google: "#4285F4", // google blue
+  Google: "#34A853", // google green
   DeepSeek: "#2F88FF", // deepseek blue
   xAI: "#000000", // black
 }


### PR DESCRIPTION
## Summary
- change Google provider color to green

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686708e65ba08320ab26bdb4a7d4a774