### PR TITLE
Add Claude 4 no-thinking models

### DIFF
--- a/public/data/models/claude-opus-4-nothinking.yaml
+++ b/public/data/models/claude-opus-4-nothinking.yaml
@@ -1,0 +1,6 @@
+model: Claude 4 Opus (No Thinking)
+provider: Anthropic
+aliases:
+  - claude-opus-4-20250514 (no think)
+  - claude-4-opus-20250514-base
+  - Claude 4 Opus (no thinking)

--- a/public/data/models/claude-sonnet-4-nothinking.yaml
+++ b/public/data/models/claude-sonnet-4-nothinking.yaml
@@ -1,0 +1,6 @@
+model: Claude 4 Sonnet (No Thinking)
+provider: Anthropic
+aliases:
+  - claude-sonnet-4-20250514 (no thinking)
+  - claude-4-sonnet-20250514-base
+  - Claude 4 Sonnet (no thinking)


### PR DESCRIPTION
## Summary
- add new model entries for Claude 4 Opus (No Thinking) and Claude 4 Sonnet (No Thinking)

## Testing
- `pnpm prettier`
- `pnpm lint` *(fails: 'CartesianGrid' is defined but never used)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68670cdbcbc88320ad37454f2c1bd6bb