### PR TITLE
Rerun scraping scripts

### DIFF
--- a/public/data/benchmarks/aider-polyglot.yaml
+++ b/public/data/benchmarks/aider-polyglot.yaml
@@ -60,6 +60,7 @@ results:
   o3 (high): 81.3
   o3: 76.9
   o3 (high) + gpt-4.1: 78.2
+  o3-pro (high): 84.9
 cost_per_task:
   Gemini 2.0 Pro exp-02-05: 0
   gpt-4o-mini-2024-07-18: 0.0014
@@ -119,3 +120,4 @@ cost_per_task:
   o3 (high): 0.0943
   o3: 0.0611
   o3 (high) + gpt-4.1: 0.0784
+  o3-pro (high): 0.6503

--- a/public/data/benchmarks/gpqa-diamond.yaml
+++ b/public/data/benchmarks/gpqa-diamond.yaml
@@ -31,7 +31,7 @@ results:
   Gemini 2.5 Flash-Lite (Reasoning): 63
   Magistral Small: 64
   o1-mini: 60
-  Gemini 2.5 Flash: 59
+  Gemini 2.5 Flash: 68
   DeepSeek V3 0324 (Mar '25): 66
   Claude 4 Sonnet: 68
   GPT-4.5 (Preview): 71
@@ -42,6 +42,7 @@ results:
   DeepSeek R1 Distill Qwen 32B: 62
   Qwen3 8B (Reasoning): 59
   Llama 3.3 Nemotron Super 49B Reasoning: 64
+  Solar Pro 2 (Reasoning): 58
   Grok 3: 69
   Llama 4 Maverick: 67
   GPT-4o (March 2025): 66
@@ -49,6 +50,7 @@ results:
   DeepSeek R1 Distill Qwen 14B: 48
   Mistral Medium 3: 58
   Sonar Reasoning: 62
+  Gemini 2.5 Flash (April '25): 59
   DeepSeek R1 Distill Llama 70B: 40
   Claude 3.7 Sonnet: 66
   Gemini 2.0 Flash: 62
@@ -60,6 +62,7 @@ results:
   DeepSeek V3 (Dec '24): 56
   Qwen2.5 Max: 59
   Llama 3.1 Nemotron Nano 4B v1.1 (Reasoning): 41
+  Solar Pro 2: 54
   Gemini 1.5 Pro (Sep): 59
   Claude 3.5 Sonnet (Oct): 60
   Qwen3 32B: 54

--- a/public/data/benchmarks/livebench.yaml
+++ b/public/data/benchmarks/livebench.yaml
@@ -13,18 +13,18 @@ results:
   command-r-08-2024: 27.15
   command-r-plus-08-2024: 30.14
   deepseek-r1: 65.15
-  deepseek-r1-0528: 69.39
+  deepseek-r1-0528: 70.1
   deepseek-r1-distill-llama-70b: 48.53
   deepseek-r1-distill-qwen-32b: 41.44
   deepseek-v3-0324: 55.99
   gemini-2.0-flash-lite-001: 46.78
-  gemini-2.5-flash-preview-04-17: 62.8
-  gemini-2.5-flash-preview-05-20: 64.32
-  gemini-2.5-pro-preview-05-06: 71.99
+  gemini-2.5-flash-preview-05-20: 64.42
+  gemini-2.5-pro-preview-06-05-default: 69.39
+  gemini-2.5-pro-preview-06-05-highthinking: 70.95
   gemma-3-27b-it: 42
   gpt-4.1-2025-04-14: 55.9
   gpt-4.1-mini-2025-04-14: 51.57
-  gpt-4.1-nano-2025-04-14: 40.4
+  gpt-4.1-nano-2025-04-14: 40.51
   gpt-4.5-preview-2025-02-27: 58.65
   gpt-4o-2024-11-20: 47.43
   grok-3-beta: 56.05
@@ -34,8 +34,9 @@ results:
   mistral-large-2411: 43.31
   mistral-medium-2505: 50.65
   mistral-small-2503: 40.55
-  o3-2025-04-16-high: 74.42
+  o3-2025-04-16-high: 74.61
   o3-2025-04-16-medium: 71.98
+  o3-pro-2025-06-10-high: 74.72
   o4-mini-2025-04-16-high: 71.52
   o4-mini-2025-04-16-medium: 66.87
   phi-4-reasoning-plus: 49.27
@@ -44,3 +45,9 @@ results:
   qwen3-235b-a22b-thinking: 64.93
   qwen3-30b-a3b-thinking: 59.02
   qwen3-32b-thinking: 63.71
+  command-a-03-2025: 44.17
+  gemma-3-12b-it: 37.08
+  gemma-3-4b-it: 23.33
+  gemma-3n-e2b-it: 21.74
+  gemma-3n-e4b-it: 27.85
+  gemini-2.5-flash-lite-preview-06-17-highthinking: 57.53

--- a/public/data/benchmarks/lmarena-text.yaml
+++ b/public/data/benchmarks/lmarena-text.yaml
@@ -1,214 +1,214 @@
 benchmark: LMArena Text
 description: Elo score on LMArena Text leaderboard
 results:
-  gemini-2.5-pro: 1467
-  o3-2025-04-16: 1451
-  chatgpt-4o-latest-20250326: 1442
-  gpt-4.5-preview-2025-02-27: 1437
-  claude-opus-4-20250514: 1418
-  gemini-2.5-flash: 1418
+  gemini-2.5-pro: 1463
+  o3-2025-04-16: 1449
+  chatgpt-4o-latest-20250326: 1441
+  gpt-4.5-preview-2025-02-27: 1436
+  claude-opus-4-20250514: 1417
+  gemini-2.5-flash: 1415
   deepseek-r1-0528: 1413
   gpt-4.1-2025-04-14: 1411
-  grok-3-preview-02-24: 1409
+  grok-3-preview-02-24: 1408
   o1-2024-12-17: 1399
   o4-mini-2025-04-16: 1398
-  deepseek-v3-0324: 1397
+  deepseek-v3-0324: 1396
   qwen3-235b-a22b-no-thinking: 1396
   deepseek-r1: 1395
   claude-sonnet-4-20250514: 1393
   minimax-m1: 1391
   gemini-2.5-flash-lite-preview-06-17-thinking: 1387
-  claude-3-7-sonnet-20250219-thinking-32k: 1387
+  claude-3-7-sonnet-20250219-thinking-32k: 1385
+  hunyuan-turbos-20250416: 1382
   o1-preview: 1383
   mistral-medium-2505: 1381
-  hunyuan-turbos-20250416: 1379
-  claude-3-7-sonnet-20250219: 1376
-  gpt-4.1-mini-2025-04-14: 1374
-  qwen3-235b-a22b: 1369
+  claude-3-7-sonnet-20250219: 1375
+  gpt-4.1-mini-2025-04-14: 1373
+  qwen3-235b-a22b: 1371
   qwen2.5-max: 1368
-  claude-3-5-sonnet-20241022: 1367
+  claude-3-5-sonnet-20241022: 1366
   o3-mini-high: 1366
   gemini-2.0-flash-001: 1364
-  gemma-3-27b-it: 1362
-  grok-3-mini-beta: 1357
+  gemma-3-27b-it: 1363
+  grok-3-mini-beta: 1356
   deepseek-v3: 1357
   gemini-2.0-flash-lite-preview-02-05: 1350
-  hunyuan-turbos-20250226: 1345
+  hunyuan-turbos-20250226: 1344
   gemini-1.5-pro-002: 1348
-  o3-mini: 1348
+  o3-mini: 1347
   qwen-plus-0125: 1343
+  gemma-3-12b-it: 1342
   hunyuan-turbo-0110: 1339
   command-a-03-2025: 1345
-  gemma-3-12b-it: 1341
-  gpt-4o-2024-05-13: 1344
-  claude-3-5-sonnet-20240620: 1341
+  gpt-4o-2024-05-13: 1343
+  glm-4-plus-0111: 1337
+  claude-3-5-sonnet-20240620: 1340
   qwq-32b: 1337
-  glm-4-plus-0111: 1336
   o1-mini: 1335
   step-2-16k-exp-202412: 1331
-  llama-3.3-nemotron-49b-super-v1: 1327
+  llama-3.3-nemotron-49b-super-v1: 1326
   llama-3.1-nemotron-ultra-253b-v1: 1326
   gemini-advanced-0514: 1334
   llama-3.1-405b-instruct-bf16: 1334
   llama-3.1-405b-instruct-fp8: 1333
   qwen3-32b: 1328
-  gpt-4o-2024-08-06: 1331
-  llama-4-maverick-17b-128e-instruct: 1329
+  llama-4-maverick-17b-128e-instruct: 1330
+  gpt-4o-2024-08-06: 1330
   grok-2-2024-08-13: 1329
   yi-lightning: 1327
   hunyuan-large-2025-02-10: 1322
   gpt-4.1-nano-2025-04-14: 1320
-  deepseek-v2.5-1210: 1320
   amazon-nova-experimental-chat-05-14: 1319
-  gpt-4-turbo-2024-04-09: 1323
+  deepseek-v2.5-1210: 1320
+  gpt-4-turbo-2024-04-09: 1322
   gemini-1.5-pro-001: 1321
   claude-3-opus-20240229: 1319
+  gemma-3n-e4b-it: 1316
   llama-4-scout-17b-16e-instruct: 1315
-  gemma-3n-e4b-it: 1311
   hunyuan-standard-2025-02-10: 1310
-  magistral-medium-2506: 1308
+  llama-3.3-70b-instruct: 1315
   claude-3-5-haiku-20241022: 1315
   glm-4-plus: 1315
-  llama-3.3-70b-instruct: 1315
   gpt-4-1106-preview: 1315
   gpt-4o-mini-2024-07-18: 1314
-  qwen-max-0919: 1312
   qwen2.5-plus-1127: 1311
   mistral-large-2407: 1312
+  qwen-max-0919: 1311
   athene-v2-chat: 1311
+  magistral-medium-2506: 1307
   gpt-4-0125-preview: 1311
   gemini-1.5-flash-002: 1309
   deepseek-v2.5: 1306
   gemma-3-4b-it: 1301
-  grok-2-mini-2024-08-13: 1305
   athene-70b-0725: 1303
+  grok-2-mini-2024-08-13: 1304
   qwen2.5-72b-instruct: 1302
   mistral-large-2411: 1301
-  mistral-small-3.1-24b-instruct-2503: 1296
+  mistral-small-3.1-24b-instruct-2503: 1298
   llama-3.1-nemotron-70b-instruct: 1296
   qwen3-30b-a3b: 1295
   llama-3.1-tulu-3-70b: 1289
   llama-3.1-70b-instruct: 1294
-  reka-core-20240904: 1288
-  llama-3.1-nemotron-51b-instruct: 1285
-  jamba-1.5-large: 1286
+  reka-core-20240904: 1287
+  llama-3.1-nemotron-51b-instruct: 1284
   amazon-nova-pro-v1.0: 1288
-  gemma-2-27b-it: 1288
-  gemini-1.5-flash-001: 1285
+  gemma-2-27b-it: 1287
+  jamba-1.5-large: 1285
+  gemini-1.5-flash-001: 1284
   gemma-2-9b-it-simpo: 1280
-  command-r-plus-08-2024: 1278
+  hunyuan-large-vision: 1273
   gpt-4-0314: 1280
+  command-r-plus-08-2024: 1277
   claude-3-sonnet-20240229: 1278
-  nemotron-4-340b-instruct: 1277
-  llama-3-70b-instruct: 1276
+  nemotron-4-340b-instruct: 1276
+  llama-3-70b-instruct: 1275
   reka-flash-20240904: 1273
   qwen2.5-coder-32b-instruct: 1270
   mistral-small-24b-instruct-2501: 1271
-  glm-4-0520: 1269
-  gpt-4-0613: 1266
+  glm-4-0520: 1268
+  gpt-4-0613: 1265
   c4ai-aya-expanse-32b: 1265
-  deepseek-coder-v2: 1263
-  hunyuan-large-vision: 1259
+  deepseek-coder-v2: 1262
   command-r-plus: 1263
-  amazon-nova-lite-v1.0: 1262
   qwen2-72b-instruct: 1261
-  gemma-2-9b-it: 1261
+  amazon-nova-lite-v1.0: 1261
   olmo-2-0325-32b-instruct: 1255
-  gemini-1.5-flash-8b-001: 1260
+  gemma-2-9b-it: 1260
+  gemini-1.5-flash-8b-001: 1259
   claude-3-haiku-20240307: 1258
   phi-4: 1257
   command-r-08-2024: 1256
-  amazon-nova-micro-v1.0: 1244
+  amazon-nova-micro-v1.0: 1243
   ministral-8b-2410: 1240
   jamba-1.5-mini: 1240
   mistral-large-2402: 1238
-  qwen1.5-110b-chat: 1236
   hunyuan-standard-256k: 1233
-  reka-flash-21b-20240226-online: 1232
+  qwen1.5-110b-chat: 1235
+  reka-flash-21b-20240226-online: 1231
   c4ai-aya-expanse-8b: 1231
   llama-3.1-tulu-3-8b: 1227
-  mixtral-8x22b-instruct-v0.1: 1230
-  qwen1.5-72b-chat: 1229
+  gemini-pro-dev-api: 1227
+  mixtral-8x22b-instruct-v0.1: 1229
   command-r: 1228
-  gemini-pro-dev-api: 1228
+  qwen1.5-72b-chat: 1228
   llama-3-8b-instruct: 1223
-  mistral-medium: 1222
   reka-flash-21b-20240226: 1222
   granite-3.1-8b-instruct: 1215
-  gpt-3.5-turbo-0125: 1218
-  gemini-pro: 1213
-  yi-1.5-34b-chat: 1214
+  mistral-medium: 1221
+  gemini-pro: 1212
+  gpt-3.5-turbo-0125: 1217
   zephyr-orpo-141b-A35b-v0.1: 1211
   llama-3.1-8b-instruct: 1213
+  yi-1.5-34b-chat: 1213
   qwen1.5-32b-chat: 1207
-  gemma-2-2b-it: 1198
   phi-3-medium-4k-instruct: 1198
+  gemma-2-2b-it: 1198
   internlm2_5-20b-chat: 1196
-  mixtral-8x7b-instruct-v0.1: 1195
-  dbrx-instruct-preview: 1194
-  granite-3.0-8b-instruct: 1190
-  gpt-3.5-turbo-1106: 1191
-  granite-3.1-2b-instruct: 1184
-  qwen1.5-14b-chat: 1188
-  wizardlm-70b: 1186
-  snowflake-arctic-instruct: 1183
-  yi-34b-chat: 1182
-  openchat-3.5-0106: 1181
-  gemma-1.1-7b-it: 1180
+  mixtral-8x7b-instruct-v0.1: 1194
+  dbrx-instruct-preview: 1193
+  granite-3.0-8b-instruct: 1189
+  gpt-3.5-turbo-1106: 1189
+  qwen1.5-14b-chat: 1187
+  wizardlm-70b: 1185
+  granite-3.1-2b-instruct: 1183
+  yi-34b-chat: 1181
+  snowflake-arctic-instruct: 1182
+  openchat-3.5-0106: 1180
+  gemma-1.1-7b-it: 1179
   phi-3-small-8k-instruct: 1179
   openchat-3.5: 1175
-  llama-3.2-3b-instruct: 1174
-  tulu-2-dpo-70b: 1173
-  deepseek-llm-67b-chat: 1172
-  openhermes-2.5-mistral-7b: 1171
+  llama-3.2-3b-instruct: 1173
+  tulu-2-dpo-70b: 1172
+  deepseek-llm-67b-chat: 1171
+  openhermes-2.5-mistral-7b: 1170
   starling-lm-7b-beta: 1172
   vicuna-33b: 1172
   qwq-32b-preview: 1167
-  starling-lm-7b-alpha: 1164
-  granite-3.0-2b-instruct: 1162
+  starling-lm-7b-alpha: 1163
+  granite-3.0-2b-instruct: 1161
   llama-2-70b-chat: 1162
   llama2-70b-steerlm-chat: 1154
   nous-hermes-2-mixtral-8x7b-dpo: 1152
   dolphin-2.2.1-mistral-7b: 1150
   qwen1.5-7b-chat: 1145
-  phi-3-mini-4k-instruct-june-2024: 1149
-  mistral-7b-instruct-v0.2: 1148
+  phi-3-mini-4k-instruct-june-2024: 1148
   solar-10.7b-instruct-v1.0: 1146
+  falcon-180b-chat: 1139
+  mistral-7b-instruct-v0.2: 1147
   wizardlm-13b: 1144
   mpt-30b-chat: 1141
-  falcon-180b-chat: 1140
-  qwen-14b-chat: 1137
+  qwen-14b-chat: 1136
   smollm2-1.7b-instruct: 1132
-  vicuna-13b: 1139
-  phi-3-mini-4k-instruct: 1137
-  llama-2-13b-chat: 1135
-  zephyr-7b-alpha: 1127
-  codellama-34b-instruct: 1128
-  zephyr-7b-beta: 1130
-  codellama-70b-instruct: 1119
-  gemma-7b-it: 1129
+  vicuna-13b: 1138
+  phi-3-mini-4k-instruct: 1136
+  llama-2-13b-chat: 1134
+  zephyr-7b-alpha: 1126
   phi-3-mini-128k-instruct: 1129
+  zephyr-7b-beta: 1129
+  codellama-34b-instruct: 1127
+  codellama-70b-instruct: 1118
+  gemma-7b-it: 1128
   llama-3.2-1b-instruct: 1125
-  guanaco-33b: 1121
-  palm-2: 1123
-  gemma-1.1-2b-it: 1121
-  stripedhyena-nous-7b: 1115
-  mistral-7b-instruct: 1107
-  llama-2-7b-chat: 1106
-  vicuna-7b: 1102
-  qwen1.5-4b-chat: 1095
-  gemma-2b-it: 1089
-  olmo-7b-instruct: 1074
-  koala-13b: 1061
-  gpt4all-13b-snoozy: 1053
-  chatglm3-6b: 1055
-  alpaca-13b: 1048
-  mpt-7b-chat: 1048
-  RWKV-4-Raven-14B: 1030
-  chatglm2-6b: 1024
-  oasst-pythia-12b: 1012
-  fastchat-t5-3b: 977
-  chatglm-6b: 969
-  dolly-v2-12b: 963
-  llama-13b: 949
-  stablelm-tuned-alpha-7b: 940
+  guanaco-33b: 1120
+  palm-2: 1122
+  gemma-1.1-2b-it: 1120
+  stripedhyena-nous-7b: 1114
+  mistral-7b-instruct: 1106
+  llama-2-7b-chat: 1105
+  vicuna-7b: 1101
+  qwen1.5-4b-chat: 1094
+  gemma-2b-it: 1088
+  olmo-7b-instruct: 1073
+  koala-13b: 1060
+  gpt4all-13b-snoozy: 1052
+  chatglm3-6b: 1054
+  mpt-7b-chat: 1047
+  alpaca-13b: 1047
+  RWKV-4-Raven-14B: 1029
+  chatglm2-6b: 1023
+  oasst-pythia-12b: 1011
+  fastchat-t5-3b: 976
+  chatglm-6b: 968
+  dolly-v2-12b: 962
+  llama-13b: 948
+  stablelm-tuned-alpha-7b: 939

--- a/scripts/scrape_aider-polyglot.ts
+++ b/scripts/scrape_aider-polyglot.ts
@@ -1,7 +1,10 @@
 import fs from "fs/promises"
 import path from "path"
+import { fileURLToPath } from "url"
 import { execSync } from "child_process"
 import YAML from "yaml"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 function curl(url: string): string {
   return execSync(`curl -sL ${url}`, { encoding: "utf8" })

--- a/scripts/scrape_arc_agi_1.ts
+++ b/scripts/scrape_arc_agi_1.ts
@@ -1,7 +1,10 @@
 import fs from "fs/promises"
 import path from "path"
+import { fileURLToPath } from "url"
 import { execSync } from "child_process"
 import YAML from "yaml"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 function curl(url: string): string {
   return execSync(`curl -sL ${url}`, { encoding: "utf8" })

--- a/scripts/scrape_arc_agi_2.ts
+++ b/scripts/scrape_arc_agi_2.ts
@@ -1,7 +1,10 @@
 import fs from "fs/promises"
 import path from "path"
+import { fileURLToPath } from "url"
 import { execSync } from "child_process"
 import YAML from "yaml"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 function curl(url: string): string {
   return execSync(`curl -sL ${url}`, { encoding: "utf8" })

--- a/scripts/scrape_gpqa_diamond.ts
+++ b/scripts/scrape_gpqa_diamond.ts
@@ -1,15 +1,20 @@
 import { chromium } from "playwright"
 import fs from "fs/promises"
 import path from "path"
+import { fileURLToPath } from "url"
 import YAML from "yaml"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 async function main() {
   const browser = await chromium.launch({
     headless: true,
   })
 
+  const context = await browser.newContext({ ignoreHTTPSErrors: true })
+  const page = await context.newPage()
+
   try {
-    const page = await browser.newPage()
     await page.goto("https://artificialanalysis.ai/leaderboards/models")
     await page.waitForLoadState("networkidle")
 

--- a/scripts/scrape_hle.ts
+++ b/scripts/scrape_hle.ts
@@ -1,7 +1,10 @@
 import fs from "fs/promises"
 import path from "path"
+import { fileURLToPath } from "url"
 import { execSync } from "child_process"
 import YAML from "yaml"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 function curl(url: string): string {
   return execSync(`curl -sL ${url}`, { encoding: "utf8" })

--- a/scripts/scrape_livebench.ts
+++ b/scripts/scrape_livebench.ts
@@ -1,7 +1,10 @@
 import fs from "fs/promises"
 import path from "path"
+import { fileURLToPath } from "url"
 import { execSync } from "child_process"
 import YAML from "yaml"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 interface Categories {
   [category: string]: string[]

--- a/scripts/scrape_lmarena_text.ts
+++ b/scripts/scrape_lmarena_text.ts
@@ -1,7 +1,10 @@
 import fs from "fs/promises"
 import path from "path"
+import { fileURLToPath } from "url"
 import { execSync } from "child_process"
 import YAML from "yaml"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 function curl(url: string): string {
   return execSync(`curl -sL ${url}`, { encoding: "utf8" })

--- a/scripts/scrape_simplebench.ts
+++ b/scripts/scrape_simplebench.ts
@@ -1,8 +1,11 @@
 import fs from "fs/promises"
 import path from "path"
+import { fileURLToPath } from "url"
 import { execSync } from "child_process"
 import YAML from "yaml"
 import vm from "vm"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 function curl(url: string): string {
   return execSync(`curl -sL ${url}`, { encoding: "utf8" })


### PR DESCRIPTION
## Summary
- fix scraping scripts to run as ES modules
- rerun all scraping scripts to update benchmark data

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm prettier`
- `pnpm exec playwright install chromium`
- `pnpm run scrape:livebench`
- `pnpm run scrape:simplebench`
- `pnpm run scrape:lmarena-text`
- `pnpm run scrape:arc-agi-1`
- `pnpm run scrape:arc-agi-2`
- `pnpm run scrape:aider-polyglot`
- `pnpm run scrape:hle`
- `pnpm run scrape:gpqa-diamond`


------
https://chatgpt.com/codex/tasks/task_e_686719ea5a68832094240cc679016aa4