### PR TITLE
Add domain buffer to cost chart

### DIFF
--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -33,6 +33,7 @@ export default function CostScoreChart({ llmData, showDeprecated }: Props) {
   )
 
   const costDomain = React.useMemo(() => {
+    const FACTOR = 1.2
     let min = Infinity
     let max = -Infinity
     for (const item of visible) {
@@ -42,7 +43,7 @@ export default function CostScoreChart({ llmData, showDeprecated }: Props) {
       }
     }
     if (!isFinite(min) || !isFinite(max)) return [0, 1]
-    return [min, max]
+    return [min / FACTOR, max * FACTOR]
   }, [visible])
 
   const ticks = React.useMemo(


### PR DESCRIPTION
## Summary
- expand the x-axis domain in the cost vs score chart by applying a 1.2x buffer around the data range

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm prettier`


------
https://chatgpt.com/codex/tasks/task_e_68671a641f6883209d127e13a148ffca