### PR TITLE
Refactor curl into shared utility

### DIFF
--- a/scripts/scrape_aider-polyglot.ts
+++ b/scripts/scrape_aider-polyglot.ts
@@ -1,14 +1,10 @@
 import fs from "fs/promises"
 import path from "path"
 import { fileURLToPath } from "url"
-import { execSync } from "child_process"
 import YAML from "yaml"
+import { curl } from "./utils"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-
-function curl(url: string): string {
-  return execSync(`curl -sL ${url}`, { encoding: "utf8" })
-}
 
 interface Entry {
   model: string

--- a/scripts/scrape_arc_agi_1.ts
+++ b/scripts/scrape_arc_agi_1.ts
@@ -1,14 +1,10 @@
 import fs from "fs/promises"
 import path from "path"
 import { fileURLToPath } from "url"
-import { execSync } from "child_process"
 import YAML from "yaml"
+import { curl } from "./utils"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-
-function curl(url: string): string {
-  return execSync(`curl -sL ${url}`, { encoding: "utf8" })
-}
 
 async function main(): Promise<void> {
   const datasets = JSON.parse(

--- a/scripts/scrape_arc_agi_2.ts
+++ b/scripts/scrape_arc_agi_2.ts
@@ -1,14 +1,10 @@
 import fs from "fs/promises"
 import path from "path"
 import { fileURLToPath } from "url"
-import { execSync } from "child_process"
 import YAML from "yaml"
+import { curl } from "./utils"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-
-function curl(url: string): string {
-  return execSync(`curl -sL ${url}`, { encoding: "utf8" })
-}
 
 async function main(): Promise<void> {
   const datasets = JSON.parse(

--- a/scripts/scrape_hle.ts
+++ b/scripts/scrape_hle.ts
@@ -1,14 +1,10 @@
 import fs from "fs/promises"
 import path from "path"
 import { fileURLToPath } from "url"
-import { execSync } from "child_process"
 import YAML from "yaml"
+import { curl } from "./utils"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-
-function curl(url: string): string {
-  return execSync(`curl -sL ${url}`, { encoding: "utf8" })
-}
 
 interface Entry {
   model: string

--- a/scripts/scrape_livebench.ts
+++ b/scripts/scrape_livebench.ts
@@ -1,8 +1,8 @@
 import fs from "fs/promises"
 import path from "path"
 import { fileURLToPath } from "url"
-import { execSync } from "child_process"
 import YAML from "yaml"
+import { curl } from "./utils"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -12,10 +12,6 @@ interface Categories {
 
 interface Row {
   [column: string]: string
-}
-
-function curl(url: string): string {
-  return execSync(`curl -sL ${url}`, { encoding: "utf8" })
 }
 
 function getLatestDate(): string {

--- a/scripts/scrape_lmarena_text.ts
+++ b/scripts/scrape_lmarena_text.ts
@@ -1,14 +1,10 @@
 import fs from "fs/promises"
 import path from "path"
 import { fileURLToPath } from "url"
-import { execSync } from "child_process"
 import YAML from "yaml"
+import { curl } from "./utils"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-
-function curl(url: string): string {
-  return execSync(`curl -sL ${url}`, { encoding: "utf8" })
-}
 
 async function main(): Promise<void> {
   const md = curl("https://r.jina.ai/https://lmarena.ai/leaderboard/text")

--- a/scripts/scrape_simplebench.ts
+++ b/scripts/scrape_simplebench.ts
@@ -1,15 +1,11 @@
 import fs from "fs/promises"
 import path from "path"
 import { fileURLToPath } from "url"
-import { execSync } from "child_process"
 import YAML from "yaml"
 import vm from "vm"
+import { curl } from "./utils"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-
-function curl(url: string): string {
-  return execSync(`curl -sL ${url}`, { encoding: "utf8" })
-}
 
 interface Entry {
   rank: string

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,0 +1,5 @@
+import { execSync } from "child_process"
+
+export function curl(url: string): string {
+  return execSync(`curl -sL ${url}`, { encoding: "utf8" })
+}


### PR DESCRIPTION
## Summary
- centralize repeated `curl` helper into `scripts/utils.ts`
- use this helper in scraping scripts

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6867202443f8832095f90591a6981a69