### PR TITLE
Add scraping automation workflow

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -1,0 +1,54 @@
+name: Scrape and PR
+
+on:
+  schedule:
+    - cron: "0 0 * * 3,6"
+  workflow_dispatch:
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+      - name: Run scraping scripts
+        run: |
+          pnpm scrape:livebench
+          pnpm scrape:simplebench
+          pnpm scrape:lmarena-text
+          pnpm scrape:arc-agi-1
+          pnpm scrape:arc-agi-2
+          pnpm scrape:aider-polyglot
+          pnpm scrape:hle
+          pnpm scrape:gpqa-diamond
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: update benchmark data"
+          title: "Update benchmark data"
+          body: Automated scraping update
+          branch: scrape-data-${{ github.run_id }}
+          delete-branch: true
+          labels: scrape-action
+      - name: Close previous PRs
+        if: steps.cpr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          current=${{ steps.cpr.outputs.pull-request-number }}
+          for pr in $(gh pr list --label scrape-action --state open --json number --jq '.[].number'); do
+            if [ "$pr" != "$current" ]; then
+              gh pr close "$pr" --delete-branch
+            fi
+          done


### PR DESCRIPTION
## Summary
- schedule scraper workflow on Wednesdays and Saturdays
- run all scraping scripts
- auto-open a PR with scraped data
- close any previous PRs from this workflow

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm prettier`


------
https://chatgpt.com/codex/tasks/task_e_68672287804c83208c174fdb5e208e88