### PR TITLE
Add unit tests for utility and data loader functions

### DIFF
--- a/lib/__tests__/data-loader.test.ts
+++ b/lib/__tests__/data-loader.test.ts
@@ -47,3 +47,9 @@ test("loadLLMData merges aliases and sorts results", async () => {
   const alias = llmData.find((d) => d.slug === "grok-3-preview-02-24")
   expect(alias).toBeUndefined()
 })
+
+test("loadLLMData marks deprecated models", async () => {
+  const llmData = await loadLLMData()
+  const deprecated = llmData.find((d) => d.slug === "deepseek-r1")
+  expect(deprecated?.deprecated).toBe(true)
+})

--- a/lib/__tests__/load-llm-details.test.ts
+++ b/lib/__tests__/load-llm-details.test.ts
@@ -1,0 +1,13 @@
+import { loadLLMDetails } from "../data-loader"
+import { expect, test } from "vitest"
+
+test("loadLLMDetails returns a specific model", async () => {
+  const model = await loadLLMDetails("grok-3")
+  expect(model).not.toBeNull()
+  expect(model?.model).toBe("Grok 3")
+})
+
+test("loadLLMDetails returns null for unknown slugs", async () => {
+  const model = await loadLLMDetails("does-not-exist")
+  expect(model).toBeNull()
+})

--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -1,0 +1,11 @@
+import { cn } from "../utils"
+import { expect, test } from "vitest"
+
+test("cn merges class names following tailwind rules", () => {
+  expect(cn("p-2", "p-4")).toBe("p-4")
+  expect(cn("text-left", "text-right", "text-center")).toBe("text-center")
+})
+
+test("cn filters out falsy values", () => {
+  expect(cn("foo", null, undefined, false && "bar")).toBe("foo")
+})


### PR DESCRIPTION
## Summary
- cover cn utility function with tests
- add tests for loadLLMDetails helper
- ensure deprecated models are flagged in loadLLMData

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68672025353483208c18c2c2a5738d30