### PR TITLE
Add shared YAML writer for scrape scripts

### DIFF
--- a/scripts/scrape_aider-polyglot.ts
+++ b/scripts/scrape_aider-polyglot.ts
@@ -1,8 +1,6 @@
-import fs from "fs/promises"
 import path from "path"
 import { fileURLToPath } from "url"
-import YAML from "yaml"
-import { curl } from "./utils"
+import { curl, saveBenchmarkResults } from "./utils"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -33,12 +31,6 @@ async function main(): Promise<void> {
       }
     }
   }
-  const yamlObj = {
-    benchmark: "Aider Polyglot",
-    description: "Pass rate (PR@2) on Aider's polyglot benchmark",
-    results,
-    cost_per_task: costPerTask,
-  }
   const outPath = path.join(
     __dirname,
     "..",
@@ -47,8 +39,7 @@ async function main(): Promise<void> {
     "benchmarks",
     "aider-polyglot.yaml",
   )
-  await fs.writeFile(outPath, YAML.stringify(yamlObj))
-  console.log(`Wrote ${outPath}`)
+  await saveBenchmarkResults(outPath, results, costPerTask)
 }
 
 main().catch((err) => {

--- a/scripts/scrape_arc_agi_1.ts
+++ b/scripts/scrape_arc_agi_1.ts
@@ -1,8 +1,6 @@
-import fs from "fs/promises"
 import path from "path"
 import { fileURLToPath } from "url"
-import YAML from "yaml"
-import { curl } from "./utils"
+import { curl, saveBenchmarkResults } from "./utils"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -47,13 +45,6 @@ async function main(): Promise<void> {
     }
   }
 
-  const yamlObj = {
-    benchmark: dataset.displayName,
-    description: "Accuracy on ARC-AGI-1",
-    results,
-    cost_per_task: costPerTask,
-  }
-
   const outPath = path.join(
     __dirname,
     "..",
@@ -62,8 +53,7 @@ async function main(): Promise<void> {
     "benchmarks",
     "arc-agi-1.yaml",
   )
-  await fs.writeFile(outPath, YAML.stringify(yamlObj))
-  console.log(`Wrote ${outPath}`)
+  await saveBenchmarkResults(outPath, results, costPerTask)
 }
 
 main().catch((err) => {

--- a/scripts/scrape_arc_agi_2.ts
+++ b/scripts/scrape_arc_agi_2.ts
@@ -1,8 +1,6 @@
-import fs from "fs/promises"
 import path from "path"
 import { fileURLToPath } from "url"
-import YAML from "yaml"
-import { curl } from "./utils"
+import { curl, saveBenchmarkResults } from "./utils"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -47,13 +45,6 @@ async function main(): Promise<void> {
     }
   }
 
-  const yamlObj = {
-    benchmark: dataset.displayName,
-    description: "Accuracy on ARC-AGI-2",
-    results,
-    cost_per_task: costPerTask,
-  }
-
   const outPath = path.join(
     __dirname,
     "..",
@@ -62,8 +53,7 @@ async function main(): Promise<void> {
     "benchmarks",
     "arc-agi-2.yaml",
   )
-  await fs.writeFile(outPath, YAML.stringify(yamlObj))
-  console.log(`Wrote ${outPath}`)
+  await saveBenchmarkResults(outPath, results, costPerTask)
 }
 
 main().catch((err) => {

--- a/scripts/scrape_artificial_analysis_index.ts
+++ b/scripts/scrape_artificial_analysis_index.ts
@@ -1,8 +1,7 @@
 import { chromium } from "playwright"
-import fs from "fs/promises"
 import path from "path"
 import { fileURLToPath } from "url"
-import YAML from "yaml"
+import { saveBenchmarkResults } from "./utils"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -94,12 +93,6 @@ async function main() {
     }
 
     // Save results to yaml
-    const yamlObj = {
-      benchmark: "Artificial Analysis Index",
-      description: "Score on Artificial Analysis Index benchmark",
-      results: resultsMap,
-      cost_per_task: costPerTaskMap,
-    }
     const outPath = path.join(
       __dirname,
       "..",
@@ -108,8 +101,7 @@ async function main() {
       "benchmarks",
       "artificial-analysis-index.yaml",
     )
-    await fs.writeFile(outPath, YAML.stringify(yamlObj))
-    console.log(`Wrote ${outPath}`)
+    await saveBenchmarkResults(outPath, resultsMap, costPerTaskMap)
   } catch (error) {
     console.error("Error during scraping:", error)
   } finally {

--- a/scripts/scrape_gpqa_diamond.ts
+++ b/scripts/scrape_gpqa_diamond.ts
@@ -1,8 +1,7 @@
 import { chromium } from "playwright"
-import fs from "fs/promises"
 import path from "path"
 import { fileURLToPath } from "url"
-import YAML from "yaml"
+import { saveBenchmarkResults } from "./utils"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -42,11 +41,6 @@ async function main() {
     }
 
     // Save results to yaml
-    const yamlObj = {
-      benchmark: "GPQA Diamond",
-      description: "Score on GPQA Diamond benchmark",
-      results,
-    }
     const outPath = path.join(
       __dirname,
       "..",
@@ -55,8 +49,7 @@ async function main() {
       "benchmarks",
       "gpqa-diamond.yaml",
     )
-    await fs.writeFile(outPath, YAML.stringify(yamlObj))
-    console.log(`Wrote ${outPath}`)
+    await saveBenchmarkResults(outPath, results)
   } catch (error) {
     console.error("Error during scraping:", error)
   } finally {

--- a/scripts/scrape_hle.ts
+++ b/scripts/scrape_hle.ts
@@ -1,8 +1,6 @@
-import fs from "fs/promises"
 import path from "path"
 import { fileURLToPath } from "url"
-import YAML from "yaml"
-import { curl } from "./utils"
+import { curl, saveBenchmarkResults } from "./utils"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -24,11 +22,6 @@ async function main(): Promise<void> {
   for (const entry of data.props.pageProps.entries) {
     results[entry.model] = entry.score
   }
-  const yamlObj = {
-    benchmark: "Humanity's Last Exam",
-    description: "Score on Scale's Humanity's Last Exam",
-    results,
-  }
   const outPath = path.join(
     __dirname,
     "..",
@@ -37,8 +30,7 @@ async function main(): Promise<void> {
     "benchmarks",
     "humanitys-last-exam.yaml",
   )
-  await fs.writeFile(outPath, YAML.stringify(yamlObj))
-  console.log(`Wrote ${outPath}`)
+  await saveBenchmarkResults(outPath, results)
 }
 
 main().catch((err) => {

--- a/scripts/scrape_livebench.ts
+++ b/scripts/scrape_livebench.ts
@@ -1,8 +1,6 @@
-import fs from "fs/promises"
 import path from "path"
 import { fileURLToPath } from "url"
-import YAML from "yaml"
-import { curl } from "./utils"
+import { curl, saveBenchmarkResults } from "./utils"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -73,11 +71,6 @@ async function main(): Promise<void> {
   for (const [name, score] of Object.entries(rawResults)) {
     results[name] = score
   }
-  const yamlObj = {
-    benchmark: "LiveBench",
-    description: "Average score across LiveBench categories",
-    results,
-  }
   const outPath = path.join(
     __dirname,
     "..",
@@ -86,8 +79,7 @@ async function main(): Promise<void> {
     "benchmarks",
     "livebench.yaml",
   )
-  await fs.writeFile(outPath, YAML.stringify(yamlObj))
-  console.log(`Wrote ${outPath}`)
+  await saveBenchmarkResults(outPath, results)
 }
 
 main().catch((err) => {

--- a/scripts/scrape_lmarena_text.ts
+++ b/scripts/scrape_lmarena_text.ts
@@ -1,8 +1,6 @@
-import fs from "fs/promises"
 import path from "path"
 import { fileURLToPath } from "url"
-import YAML from "yaml"
-import { curl } from "./utils"
+import { curl, saveBenchmarkResults } from "./utils"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -20,11 +18,6 @@ async function main(): Promise<void> {
       results[model] = score
     }
   }
-  const yamlObj = {
-    benchmark: "LMArena Text",
-    description: "Elo score on LMArena Text leaderboard",
-    results,
-  }
   const outPath = path.join(
     __dirname,
     "..",
@@ -33,8 +26,7 @@ async function main(): Promise<void> {
     "benchmarks",
     "lmarena-text.yaml",
   )
-  await fs.writeFile(outPath, YAML.stringify(yamlObj))
-  console.log(`Wrote ${outPath}`)
+  await saveBenchmarkResults(outPath, results)
 }
 
 main().catch((err) => {

--- a/scripts/scrape_simplebench.ts
+++ b/scripts/scrape_simplebench.ts
@@ -1,9 +1,7 @@
-import fs from "fs/promises"
 import path from "path"
 import { fileURLToPath } from "url"
-import YAML from "yaml"
 import vm from "vm"
-import { curl } from "./utils"
+import { curl, saveBenchmarkResults } from "./utils"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -26,11 +24,6 @@ async function main(): Promise<void> {
     const score = parseFloat(entry.score.replace(/%/, ""))
     results[entry.model] = score
   }
-  const yamlObj = {
-    benchmark: "SimpleBench",
-    description: "Score (AVG@5) on SimpleBench",
-    results,
-  }
   const outPath = path.join(
     __dirname,
     "..",
@@ -39,8 +32,7 @@ async function main(): Promise<void> {
     "benchmarks",
     "simplebench.yaml",
   )
-  await fs.writeFile(outPath, YAML.stringify(yamlObj))
-  console.log(`Wrote ${outPath}`)
+  await saveBenchmarkResults(outPath, results)
 }
 
 main().catch((err) => {

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,5 +1,37 @@
 import { execSync } from "child_process"
+import fs from "fs/promises"
+import YAML from "yaml"
 
 export function curl(url: string): string {
   return execSync(`curl -sL ${url}`, { encoding: "utf8" })
+}
+
+/**
+ * Update the benchmark YAML file with new results.
+ *
+ * Only the `results` and `cost_per_task` sections are modified. All other
+ * keys remain untouched so manual edits are preserved.
+ */
+export async function saveBenchmarkResults(
+  outPath: string,
+  results: Record<string, number>,
+  costPerTask?: Record<string, number>,
+): Promise<void> {
+  let yamlObj: Record<string, unknown> = {}
+  try {
+    const existing = await fs.readFile(outPath, "utf8")
+    yamlObj = YAML.parse(existing) as Record<string, unknown>
+  } catch (err: any) {
+    if (err.code !== "ENOENT") throw err
+  }
+
+  yamlObj.results = results
+  if (costPerTask && Object.keys(costPerTask).length > 0) {
+    yamlObj.cost_per_task = costPerTask
+  } else {
+    delete yamlObj.cost_per_task
+  }
+
+  await fs.writeFile(outPath, YAML.stringify(yamlObj))
+  console.log(`Wrote ${outPath}`)
 }


### PR DESCRIPTION
## Summary
- add `saveBenchmarkResults` helper to update benchmark YAML files
- update all scrape scripts to use the helper

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68679335714c83208983bef34126ed9e