### PR TITLE
Remove score tooltip

### DIFF
--- a/components/columns.tsx
+++ b/components/columns.tsx
@@ -7,11 +7,6 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { PROVIDER_COLORS } from "@/lib/provider-colors"
 import {
-  Tooltip,
-  TooltipTrigger,
-  TooltipContent,
-} from "@/components/ui/tooltip"
-import {
   Popover,
   PopoverTrigger,
   PopoverContent,
@@ -19,27 +14,6 @@ import {
 import { Input } from "@/components/ui/input"
 
 import type { TableRow } from "@/lib/data-loader"
-
-const ScoreCell = ({
-  score,
-  benchmarks,
-}: {
-  score: number
-  benchmarks: string[]
-}) => (
-  <Tooltip>
-    <TooltipTrigger asChild>
-      <Badge variant="secondary" className="cursor-default">
-        {score.toFixed(1)}
-      </Badge>
-    </TooltipTrigger>
-    {benchmarks.length > 0 && (
-      <TooltipContent className="text-xs">
-        {benchmarks.join(", ")}
-      </TooltipContent>
-    )}
-  </Tooltip>
-)
 
 const CostCell = ({ cost }: { cost: number | null }) => {
   if (cost === null || Number.isNaN(cost)) return null
@@ -145,10 +119,11 @@ export const columns: ColumnDef<TableRow>[] = [
     },
     cell: ({ row }) => {
       const score = row.getValue("averageScore") as number
-      const benchmarks = row.original.benchmarks
       return (
         <div className="font-semibold">
-          <ScoreCell score={score} benchmarks={benchmarks} />
+          <Badge variant="secondary" className="cursor-default">
+            {score.toFixed(1)}
+          </Badge>
         </div>
       )
     },

--- a/components/leaderboard-table.tsx
+++ b/components/leaderboard-table.tsx
@@ -4,16 +4,13 @@ import { transformToTableData, type TableRow } from "@/lib/table-utils"
 import type { LLMData } from "@/lib/data-loader"
 import { DataTable } from "./data-table"
 import { columns } from "./columns"
-import { TooltipProvider } from "@/components/ui/tooltip"
 
 export default function LeaderboardTable({ llmData }: { llmData: LLMData[] }) {
   const tableData: TableRow[] = transformToTableData(llmData)
 
   return (
     <div className="p-6 pt-0">
-      <TooltipProvider>
-        <DataTable columns={columns} data={tableData} />
-      </TooltipProvider>
+      <DataTable columns={columns} data={tableData} />
     </div>
   )
 }

--- a/lib/__tests__/data-loader.test.ts
+++ b/lib/__tests__/data-loader.test.ts
@@ -24,7 +24,6 @@ test("transformToTableData converts LLMData objects to table rows", () => {
       provider: "Bar",
       averageScore: 42,
       costPerTask: null,
-      benchmarks: [],
     },
   ])
 })

--- a/lib/table-utils.ts
+++ b/lib/table-utils.ts
@@ -5,7 +5,6 @@ export interface TableRow {
   provider: string
   averageScore: number
   costPerTask: number | null
-  benchmarks: string[]
 }
 
 export function transformToTableData(
@@ -15,7 +14,6 @@ export function transformToTableData(
     provider: string
     averageScore?: number
     normalizedCost?: number | null
-    benchmarks?: Record<string, unknown>
   }[],
 ): TableRow[] {
   return llmData.map((llm) => ({
@@ -25,6 +23,5 @@ export function transformToTableData(
     provider: llm.provider,
     averageScore: llm.averageScore || 0,
     costPerTask: llm.normalizedCost ?? null,
-    benchmarks: llm.benchmarks ? Object.keys(llm.benchmarks) : [],
   }))
 }


### PR DESCRIPTION
## Summary
- drop tooltip from average score column
- drop now-unused benchmark list in table rows
- update tests

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm prettier`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6867937844b88320868058877ee9f7b1