### PR TITLE
Display normalized scores on model pages

### DIFF
--- a/app/models/[slug]/page.tsx
+++ b/app/models/[slug]/page.tsx
@@ -43,6 +43,7 @@ export default async function ModelPage({
           <TableRow>
             <TableHead>Benchmark</TableHead>
             <TableHead className="text-right">Score</TableHead>
+            <TableHead className="text-right">Normalized</TableHead>
             <TableHead className="text-right">Cost</TableHead>
           </TableRow>
         </TableHeader>
@@ -52,6 +53,11 @@ export default async function ModelPage({
               <TableCell>{name}</TableCell>
               <TableCell className="text-right">
                 {res?.score !== undefined ? res.score : "—"}
+              </TableCell>
+              <TableCell className="text-right">
+                {res?.normalizedScore !== undefined
+                  ? res.normalizedScore.toFixed(1)
+                  : "—"}
               </TableCell>
               <TableCell className="text-right">
                 {res?.costPerTask !== undefined

--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -5,6 +5,7 @@ import { type TableRow, transformToTableData } from "./table-utils"
 
 export interface BenchmarkResult {
   score: number
+  normalizedScore?: number
   description: string
   costPerTask?: number
   normalizedCost?: number
@@ -125,8 +126,12 @@ export async function loadLLMData(): Promise<LLMData[]> {
   const results = Object.values(llmMap).map((llm) => {
     const normalised = Object.entries(llm.benchmarks).map(([name, result]) => {
       const { min, max } = benchmarkStats[name]
-      if (max === min) return 1
-      return (result.score - min) / (max - min)
+      let value = 1
+      if (max !== min) {
+        value = (result.score - min) / (max - min)
+      }
+      result.normalizedScore = value * 100
+      return value
     })
     llm.averageScore =
       (normalised.reduce((sum, score) => sum + score, 0) /


### PR DESCRIPTION
## Summary
- track normalized score in `loadLLMData`
- show each benchmark's normalized score on model details page

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6867a1efaca883208dc294cd83c6b9ad