### PR TITLE
Add Grok 3 Mini high model

### DIFF
--- a/public/data/benchmarks/aider-polyglot.yaml
+++ b/public/data/benchmarks/aider-polyglot.yaml
@@ -151,7 +151,7 @@ model_name_mapping:
   Optimus Alpha: null
   gpt-4.1: gpt-4.1
   claude-3-5-sonnet-20241022: null
-  Grok 3 Mini Beta (high): null
+  Grok 3 Mini Beta (high): grok-3-mini-high
   DeepSeek Chat V3 (prev): null
   gemini-2.5-flash-preview-04-17 (default): null
   chatgpt-4o-latest (2025-03-29): gpt-4o

--- a/public/data/benchmarks/livebench.yaml
+++ b/public/data/benchmarks/livebench.yaml
@@ -69,7 +69,7 @@ model_name_mapping:
   gemini-2.5-flash-preview-05-20: gemini-2.5-flash-thinking
   qwen3-32b-thinking: null
   claude-4-sonnet-20250514-base: claude-sonnet-4-nothinking
-  grok-3-mini-beta-high: grok-3-mini
+  grok-3-mini-beta-high: grok-3-mini-high
   qwen3-30b-a3b-thinking: null
   gpt-4.5-preview-2025-02-27: gpt-4.5-preview
   claude-3-7-sonnet-20250219-base: null

--- a/public/data/models/grok-3-mini-high.yaml
+++ b/public/data/models/grok-3-mini-high.yaml
@@ -1,0 +1,2 @@
+model: Grok 3 Mini (high)
+provider: xAI


### PR DESCRIPTION
## Summary
- add Grok 3 Mini (high) definition
- map `grok-3-mini-beta-high` and `Grok 3 Mini Beta (high)` aliases

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6867e7b5c9e08320ab6d657fdae66d06