### PR TITLE
Add leaderboard snapshot test

### DIFF
--- a/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
+++ b/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
@@ -1,0 +1,60 @@
+- id: o3-high
+  slug: o3-high
+  model: o3 (high)
+  provider: OpenAI
+  averageScore: 90.25715218004336
+  costPerTask: 1.6509151031300497
+- id: o3-pro-high
+  slug: o3-pro-high
+  model: o3-pro (high)
+  provider: OpenAI
+  averageScore: 88.5781114461564
+  costPerTask: 13.65773764644508
+- id: gemini-2.5-pro-06-05
+  slug: gemini-2.5-pro-06-05
+  model: Gemini 2.5 Pro (06-05)
+  provider: Google
+  averageScore: 87.94348787853372
+  costPerTask: 2.1481629585300466
+- id: gemini-2.5-pro-preview-03-25
+  slug: gemini-2.5-pro-preview-03-25
+  model: Gemini 2.5 Pro Preview 03-25
+  provider: Google
+  averageScore: 86.66071007114198
+  costPerTask: 2.1813103098019297
+- id: gemini-2.5-pro-preview-05-06
+  slug: gemini-2.5-pro-preview-05-06
+  model: Gemini 2.5 Pro Preview 05-06
+  provider: Google
+  averageScore: 85.88433558541382
+  costPerTask: 2.69394164328446
+- id: claude-opus-4-thinking
+  slug: claude-opus-4-thinking
+  model: Claude 4 Opus (Thinking)
+  provider: Anthropic
+  averageScore: 85.02791709390367
+  costPerTask: 4.234455108098599
+- id: o3-medium
+  slug: o3-medium
+  model: o3 (medium)
+  provider: OpenAI
+  averageScore: 84.15218316718436
+  costPerTask: 0.9803189570449125
+- id: o4-mini-high
+  slug: o4-mini-high
+  model: o4-mini (high)
+  provider: OpenAI
+  averageScore: 78.81477839478185
+  costPerTask: 1.3433438612330855
+- id: claude-opus-4-nothinking
+  slug: claude-opus-4-nothinking
+  model: Claude 4 Opus (No Thinking)
+  provider: Anthropic
+  averageScore: 77.8107740119079
+  costPerTask: 3.664103796251802
+- id: claude-sonnet-4-thinking
+  slug: claude-sonnet-4-thinking
+  model: Claude 4 Sonnet (Thinking)
+  provider: Anthropic
+  averageScore: 70.99953265370974
+  costPerTask: 1.310627914284649

--- a/lib/__tests__/default-leaderboard.snapshot.test.ts
+++ b/lib/__tests__/default-leaderboard.snapshot.test.ts
@@ -1,0 +1,20 @@
+import { loadLLMData } from "../data-loader"
+import { transformToTableData } from "../table-utils"
+import { stringify } from "yaml"
+import { expect, test } from "vitest"
+import path from "path"
+
+// Snapshot of the data that appears in the top 10 rows of the default leaderboard
+// This ensures data loading remains stable independent of the UI
+
+test("default leaderboard top 10 data", async () => {
+  const llmData = await loadLLMData()
+  const tableRows = transformToTableData(llmData).slice(0, 10)
+  const yamlData = stringify(tableRows)
+  const snapshotFile = path.join(
+    __dirname,
+    "__snapshots__",
+    "default-leaderboard-top10.yaml",
+  )
+  await expect(yamlData).toMatchFileSnapshot(snapshotFile)
+})


### PR DESCRIPTION
## Summary
- snapshot the top 10 leaderboard data
- store snapshot as YAML for diffability

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6867e71abd908320a9cf2dfd25ff4039