### PR TITLE
Add benchmark details page

### DIFF
--- a/app/benchmarks/[slug]/page.tsx
+++ b/app/benchmarks/[slug]/page.tsx
@@ -1,0 +1,85 @@
+import NavigationPills from "@/components/navigation-pills"
+import PageHeader from "@/components/page-header"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { loadBenchmarks, loadBenchmarkDetails } from "@/lib/benchmark-loader"
+import { loadLLMData } from "@/lib/data-loader"
+import { notFound } from "next/navigation"
+
+export async function generateStaticParams() {
+  const benches = await loadBenchmarks()
+  return benches.map((b) => ({ slug: b.slug }))
+}
+
+export default async function BenchmarkPage({
+  params,
+}: {
+  params: { slug: string }
+}) {
+  const [info, llms] = await Promise.all([
+    loadBenchmarkDetails(params.slug),
+    loadLLMData(),
+  ])
+  if (!info) return notFound()
+  const entries = llms
+    .map((m) => {
+      const res = m.benchmarks[info.benchmark]
+      return res ? { slug: m.slug, model: m.model, ...res } : null
+    })
+    .filter(Boolean) as {
+    slug: string
+    model: string
+    score: number
+    normalizedScore?: number
+    normalizedCost?: number
+    costPerTask?: number
+  }[]
+  entries.sort((a, b) => b.score - a.score)
+
+  return (
+    <main className="container mx-auto px-4 py-8 max-w-3xl space-y-6">
+      <PageHeader title={info.benchmark} subtitle={info.description} />
+      <NavigationPills />
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Model</TableHead>
+            <TableHead className="text-right">Score</TableHead>
+            <TableHead className="text-right">Normalized</TableHead>
+            <TableHead className="text-right">Cost</TableHead>
+            <TableHead className="text-right">Raw Cost</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {entries.map((entry) => (
+            <TableRow key={entry.slug}>
+              <TableCell>{entry.model}</TableCell>
+              <TableCell className="text-right">{entry.score}</TableCell>
+              <TableCell className="text-right">
+                {entry.normalizedScore !== undefined
+                  ? entry.normalizedScore.toFixed(1)
+                  : "—"}
+              </TableCell>
+              <TableCell className="text-right">
+                {entry.normalizedCost !== undefined
+                  ? entry.normalizedCost.toFixed(2)
+                  : "—"}
+              </TableCell>
+              <TableCell className="text-right">
+                {entry.costPerTask !== undefined
+                  ? entry.costPerTask.toFixed(2)
+                  : "—"}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </main>
+  )
+}

--- a/app/benchmarks/page.tsx
+++ b/app/benchmarks/page.tsx
@@ -1,4 +1,5 @@
 import { loadBenchmarks } from "@/lib/benchmark-loader"
+import Link from "next/link"
 import NavigationPills from "@/components/navigation-pills"
 import PageHeader from "@/components/page-header"
 
@@ -19,10 +20,12 @@ export default async function BenchmarksPage() {
       <ul className="space-y-4">
         {benchmarks.map((b) => (
           <li key={b.slug} className="border rounded-lg p-4">
-            <h2 className="font-semibold text-lg">{b.benchmark}</h2>
-            {b.description && (
-              <p className="text-muted-foreground text-sm">{b.description}</p>
-            )}
+            <Link href={`/benchmarks/${b.slug}`} className="space-y-1 block">
+              <h2 className="font-semibold text-lg">{b.benchmark}</h2>
+              {b.description && (
+                <p className="text-muted-foreground text-sm">{b.description}</p>
+              )}
+            </Link>
           </li>
         ))}
       </ul>

--- a/lib/__tests__/benchmark-details.test.ts
+++ b/lib/__tests__/benchmark-details.test.ts
@@ -1,0 +1,9 @@
+import { loadBenchmarkDetails } from "../benchmark-loader"
+import { expect, test } from "vitest"
+
+test("loadBenchmarkDetails returns data for a benchmark", async () => {
+  const details = await loadBenchmarkDetails("arc-agi-1")
+  expect(details).not.toBeNull()
+  expect(details?.benchmark).toBe("ARC-AGI-1")
+  expect(Object.keys(details?.results ?? {}).length).toBeGreaterThan(0)
+})

--- a/lib/benchmark-loader.ts
+++ b/lib/benchmark-loader.ts
@@ -36,3 +36,42 @@ export async function loadBenchmarks(): Promise<BenchmarkInfo[]> {
   }
   return benchmarks.sort((a, b) => a.benchmark.localeCompare(b.benchmark))
 }
+
+export interface BenchmarkDetails extends BenchmarkInfo {
+  results: Record<string, number>
+  cost_per_task?: Record<string, number>
+  model_name_mapping?: Record<string, string | null>
+}
+
+export async function loadBenchmarkDetails(
+  slug: string,
+): Promise<BenchmarkDetails | null> {
+  const benchmarkDir = path.join(process.cwd(), "public", "data", "benchmarks")
+  try {
+    const text = await fs.readFile(
+      path.join(benchmarkDir, `${slug}.yaml`),
+      "utf8",
+    )
+    const data = parse(text) as {
+      benchmark: string
+      description: string
+      results: Record<string, number>
+      cost_per_task?: Record<string, number>
+      model_name_mapping?: Record<string, string | null>
+    }
+    if (!data.benchmark || !data.results) {
+      throw new Error(`Invalid benchmark structure for ${slug}`)
+    }
+    return {
+      slug,
+      benchmark: data.benchmark,
+      description: data.description,
+      results: data.results,
+      cost_per_task: data.cost_per_task,
+      model_name_mapping: data.model_name_mapping,
+    }
+  } catch (error) {
+    console.error(`Failed to load benchmark details for ${slug}:`, error)
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- add a dynamic route for individual benchmark details
- link benchmark list items to the new details pages
- load benchmark data with new `loadBenchmarkDetails` helper
- test new loader functionality

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6867ed8ece588320b209bf71a628e908