### PR TITLE
Update lint scripts and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 20
           cache: "pnpm"
-      - run: pnpm lint
+      - run: pnpm lint:check
 
   prettier:
     runs-on: ubuntu-latest
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: 20
           cache: "pnpm"
-      - run: pnpm prettier
+      - run: pnpm prettier:check
 
   test:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,10 @@
 
 This repository uses pnpm as package manager.
 
-- Run linting: `pnpm lint`
-- Run build: `pnpm build`
-- Run Prettier: `pnpm prettier`
+- Run linting and autofix: `pnpm lint`
+- Validate linting without fixes: `pnpm lint:check`
+- Run Prettier and write changes: `pnpm prettier`
+- Validate formatting without writing: `pnpm prettier:check`
 
 # Adding shadcn/ui components
 

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev",
-    "lint": "next lint",
-    "prettier": "prettier --check .",
+    "lint": "next lint --fix",
+    "lint:check": "next lint",
+    "prettier": "prettier --write .",
+    "prettier:check": "prettier --check .",
     "test": "vitest run",
     "scrape:livebench": "tsx scripts/scrape_livebench.ts",
     "scrape:simplebench": "tsx scripts/scrape_simplebench.ts",


### PR DESCRIPTION
## Summary
- add `lint:check` and `prettier:check` scripts
- use the new check scripts in CI
- document new scripts in `AGENTS.md`

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- `pnpm lint:check`
- `pnpm prettier:check`


------
https://chatgpt.com/codex/tasks/task_e_68684c9159ac8320887402542f94c977