### PR TITLE
Add GPT-4.1 mini/nano mappings

### DIFF
--- a/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
+++ b/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
@@ -3,58 +3,58 @@
   model: o3 (high)
   provider: OpenAI
   averageScore: 90.25715218004336
-  costPerTask: 1.6509151031300497
+  costPerTask: 2.2841418057112444
 - id: o3-pro-high
   slug: o3-pro-high
   model: o3-pro (high)
   provider: OpenAI
-  averageScore: 88.5781114461564
-  costPerTask: 13.65773764644508
+  averageScore: 88.62740973072215
+  costPerTask: 18.90902309947468
 - id: gemini-2.5-pro-06-05
   slug: gemini-2.5-pro-06-05
   model: Gemini 2.5 Pro (06-05)
   provider: Google
-  averageScore: 87.94348787853372
-  costPerTask: 2.1481629585300466
-- id: gemini-2.5-pro-preview-03-25
-  slug: gemini-2.5-pro-preview-03-25
-  model: Gemini 2.5 Pro Preview 03-25
-  provider: Google
-  averageScore: 86.66071007114198
-  costPerTask: 2.1813103098019297
+  averageScore: 88.29113207784194
+  costPerTask: 2.9676602891832333
 - id: gemini-2.5-pro-preview-05-06
   slug: gemini-2.5-pro-preview-05-06
   model: Gemini 2.5 Pro Preview 05-06
   provider: Google
-  averageScore: 85.88433558541382
-  costPerTask: 2.69394164328446
+  averageScore: 88.2178015571845
+  costPerTask: 3.713466866774417
+- id: gemini-2.5-pro-preview-03-25
+  slug: gemini-2.5-pro-preview-03-25
+  model: Gemini 2.5 Pro Preview 03-25
+  provider: Google
+  averageScore: 87.02368647767555
+  costPerTask: 3.0246478873239435
 - id: claude-opus-4-thinking
   slug: claude-opus-4-thinking
   model: Claude 4 Opus (Thinking)
   provider: Anthropic
-  averageScore: 85.02791709390367
-  costPerTask: 4.234455108098599
+  averageScore: 85.68785679662405
+  costPerTask: 5.85368947101903
 - id: o3-medium
   slug: o3-medium
   model: o3 (medium)
   provider: OpenAI
-  averageScore: 84.15218316718436
-  costPerTask: 0.9803189570449125
+  averageScore: 84.62371873669699
+  costPerTask: 1.3566973819596049
 - id: o4-mini-high
   slug: o4-mini-high
   model: o4-mini (high)
   provider: OpenAI
-  averageScore: 78.81477839478185
-  costPerTask: 1.3433438612330855
+  averageScore: 80.98832462713298
+  costPerTask: 1.859163378301247
 - id: claude-opus-4-nothinking
   slug: claude-opus-4-nothinking
   model: Claude 4 Opus (No Thinking)
   provider: Anthropic
   averageScore: 77.8107740119079
-  costPerTask: 3.664103796251802
+  costPerTask: 4.999999999999999
 - id: claude-sonnet-4-thinking
   slug: claude-sonnet-4-thinking
   model: Claude 4 Sonnet (Thinking)
   provider: Anthropic
-  averageScore: 70.99953265370974
-  costPerTask: 1.310627914284649
+  averageScore: 71.54641495715929
+  costPerTask: 1.8090906932458548

--- a/public/data/benchmarks/aider-polyglot.yaml
+++ b/public/data/benchmarks/aider-polyglot.yaml
@@ -162,7 +162,7 @@ model_name_mapping:
   Gemini 2.0 Pro exp-02-05: null
   Grok 3 Mini Beta (low): null
   o1-mini-2024-09-12: null
-  gpt-4.1-mini: null
+  gpt-4.1-mini: gpt-4.1-mini
   claude-3-5-haiku-20241022: null
   chatgpt-4o-latest (2025-02-15): gpt-4o
   QwQ-32B + Qwen 2.5 Coder Instruct: null
@@ -179,6 +179,6 @@ model_name_mapping:
   command-a-03-2025-quality: null
   Codestral 25.01: null
   openhands-lm-32b-v0.1: null
-  gpt-4.1-nano: null
+  gpt-4.1-nano: gpt-4.1-nano
   gemma-3-27b-it: null
   gpt-4o-mini-2024-07-18: null

--- a/public/data/benchmarks/arc-agi-1.yaml
+++ b/public/data/benchmarks/arc-agi-1.yaml
@@ -177,6 +177,6 @@ model_name_mapping:
   Magistral Small: null
   GPT-4o: gpt-4o
   Llama 4 Maverick: null
-  GPT-4.1-Mini: null
+  GPT-4.1-Mini: gpt-4.1-mini
   Llama 4 Scout: null
-  GPT-4.1-Nano: null
+  GPT-4.1-Nano: gpt-4.1-nano

--- a/public/data/benchmarks/arc-agi-2.yaml
+++ b/public/data/benchmarks/arc-agi-2.yaml
@@ -171,8 +171,8 @@ model_name_mapping:
   GPT-4o-mini: null
   Llama 4 Maverick: null
   Llama 4 Scout: null
-  GPT-4.1-Nano: null
-  GPT-4.1-Mini: null
+  GPT-4.1-Nano: gpt-4.1-nano
+  GPT-4.1-Mini: gpt-4.1-mini
   o3-mini (Low): null
   Claude Opus 4 (Thinking 1K): null
   Grok 3: grok-3

--- a/public/data/benchmarks/artificial-analysis-index.yaml
+++ b/public/data/benchmarks/artificial-analysis-index.yaml
@@ -388,7 +388,7 @@ model_name_mapping:
   DeepSeek V3 0324 (Mar '25): null
   Claude 4 Sonnet: null
   GPT-4.5 (Preview): null
-  GPT-4.1 mini: null
+  GPT-4.1 mini: gpt-4.1-mini
   GPT-4.1: gpt-4.1
   Gemini 2.0 Flash Thinking exp. (Jan '25): null
   DeepSeek R1 0528 Qwen3 8B: null
@@ -429,7 +429,7 @@ model_name_mapping:
   GPT-4o (Nov '24): null
   Gemini 2.0 Flash-Lite (Feb '25): null
   Llama 3.3 70B: null
-  GPT-4.1 nano: null
+  GPT-4.1 nano: gpt-4.1-nano
   Qwen3 14B: null
   GPT-4o (May '24): null
   Gemini 2.0 Flash-Lite (Preview): null

--- a/public/data/benchmarks/gpqa-diamond.yaml
+++ b/public/data/benchmarks/gpqa-diamond.yaml
@@ -219,7 +219,7 @@ model_name_mapping:
   GPT-4.1: gpt-4.1
   Llama 4 Maverick: null
   DeepSeek V3 0324 (Mar '25): null
-  GPT-4.1 mini: null
+  GPT-4.1 mini: gpt-4.1-mini
   GPT-4o (March 2025): null
   Claude 3.7 Sonnet: null
   Magistral Small: null
@@ -266,7 +266,7 @@ model_name_mapping:
   Tulu3 405B: null
   Llama 3.3 Nemotron Super 49B v1: null
   Mistral Small 3.2: null
-  GPT-4.1 nano: null
+  GPT-4.1 nano: gpt-4.1-nano
   GPT-4o (ChatGPT): null
   Grok 2: null
   Pixtral Large: null

--- a/public/data/benchmarks/humanitys-last-exam.yaml
+++ b/public/data/benchmarks/humanitys-last-exam.yaml
@@ -48,6 +48,8 @@ model_name_mapping:
   Claude Sonnet 4: null
   GPT 4.5 Preview: gpt-4.5-preview
   GPT-4.1: gpt-4.1
+  GPT-4.1-Mini: gpt-4.1-mini
+  GPT-4.1-Nano: gpt-4.1-nano
   Gemini-1.5-Pro-002: null
   Mistral Medium 3: null
   Nova Pro: null

--- a/public/data/benchmarks/livebench.yaml
+++ b/public/data/benchmarks/livebench.yaml
@@ -95,6 +95,8 @@ model_name_mapping:
   deepseek-r1-distill-qwen-32b: null
   mistral-small-2503: null
   gpt-4.1-nano-2025-04-14: gpt-4.1-nano
+  GPT-4.1-Mini: gpt-4.1-mini
+  GPT-4.1-Nano: gpt-4.1-nano
   claude-3-5-haiku-20241022: null
   gemma-3-12b-it: null
   command-r-plus-08-2024: null

--- a/public/data/benchmarks/lmarena-text.yaml
+++ b/public/data/benchmarks/lmarena-text.yaml
@@ -272,6 +272,8 @@ model_name_mapping:
   gpt-4-turbo-2024-04-09: null
   gemini-1.5-pro-001: null
   gpt-4.1-nano-2025-04-14: gpt-4.1-nano
+  GPT-4.1-Mini: gpt-4.1-mini
+  GPT-4.1-Nano: gpt-4.1-nano
   deepseek-v2.5-1210: null
   amazon-nova-experimental-chat-05-14: null
   claude-3-opus-20240229: null

--- a/public/data/benchmarks/simplebench.yaml
+++ b/public/data/benchmarks/simplebench.yaml
@@ -65,6 +65,8 @@ model_name_mapping:
   DeepSeek V3 03-24: null
   Gemini 1.5 Pro 002: null
   GPT-4.1: gpt-4.1
+  GPT-4.1-Mini: gpt-4.1-mini
+  GPT-4.1-Nano: gpt-4.1-nano
   GPT-4 Turbo: null
   Claude 3 Opus: null
   Llama 3.1 405b instruct: null


### PR DESCRIPTION
## Summary
- map GPT-4.1 mini and nano models in all benchmarks
- update leaderboard snapshot

## Testing
- `pnpm lint`
- `pnpm prettier`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686c11375e6c8320ad7ede78861d9fa0