### PR TITLE
Add benchmark count tooltip

### DIFF
--- a/components/columns.tsx
+++ b/components/columns.tsx
@@ -12,6 +12,12 @@ import {
   PopoverContent,
 } from "@/components/ui/popover"
 import { Input } from "@/components/ui/input"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 
 import type { TableRow } from "@/lib/data-loader"
 
@@ -126,10 +132,16 @@ export const columns: ColumnDef<TableRow>[] = [
             {score.toFixed(1)}
           </Badge>
           {count < 5 && (
-            <AlertCircle
-              className="h-4 w-4 text-yellow-600"
-              title="Fewer than 5 benchmarks"
-            />
+            <TooltipProvider delayDuration={0}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <AlertCircle className="h-4 w-4 text-yellow-600" />
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  {`This model has only been evaluated on ${count} out of ${row.original.totalBenchmarks} benchmarks`}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
         </div>
       )

--- a/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
+++ b/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
@@ -5,6 +5,7 @@
   averageScore: 90.25715218004336
   costPerTask: 2.2841418057112444
   benchmarkCount: 6
+  totalBenchmarks: 9
 - id: o3-pro-high
   slug: o3-pro-high
   model: o3-pro (high)
@@ -12,6 +13,7 @@
   averageScore: 88.62740973072215
   costPerTask: 18.90902309947468
   benchmarkCount: 4
+  totalBenchmarks: 9
 - id: gemini-2.5-pro-06-05
   slug: gemini-2.5-pro-06-05
   model: Gemini 2.5 Pro (06-05)
@@ -19,6 +21,7 @@
   averageScore: 88.29113207784194
   costPerTask: 2.9676602891832333
   benchmarkCount: 9
+  totalBenchmarks: 9
 - id: gemini-2.5-pro-preview-05-06
   slug: gemini-2.5-pro-preview-05-06
   model: Gemini 2.5 Pro Preview 05-06
@@ -26,6 +29,7 @@
   averageScore: 88.2178015571845
   costPerTask: 3.713466866774417
   benchmarkCount: 4
+  totalBenchmarks: 9
 - id: gemini-2.5-pro-preview-03-25
   slug: gemini-2.5-pro-preview-03-25
   model: Gemini 2.5 Pro Preview 03-25
@@ -33,6 +37,7 @@
   averageScore: 87.02368647767555
   costPerTask: 3.0246478873239435
   benchmarkCount: 5
+  totalBenchmarks: 9
 - id: claude-opus-4-thinking
   slug: claude-opus-4-thinking
   model: Claude 4 Opus (Thinking)
@@ -40,6 +45,7 @@
   averageScore: 85.68785679662405
   costPerTask: 5.85368947101903
   benchmarkCount: 5
+  totalBenchmarks: 9
 - id: o3-medium
   slug: o3-medium
   model: o3 (medium)
@@ -47,6 +53,7 @@
   averageScore: 84.62371873669699
   costPerTask: 1.3566973819596049
   benchmarkCount: 8
+  totalBenchmarks: 9
 - id: o4-mini-high
   slug: o4-mini-high
   model: o4-mini (high)
@@ -54,6 +61,7 @@
   averageScore: 80.98832462713298
   costPerTask: 1.859163378301247
   benchmarkCount: 8
+  totalBenchmarks: 9
 - id: claude-opus-4-nothinking
   slug: claude-opus-4-nothinking
   model: Claude 4 Opus (No Thinking)
@@ -61,6 +69,7 @@
   averageScore: 77.8107740119079
   costPerTask: 4.999999999999999
   benchmarkCount: 2
+  totalBenchmarks: 9
 - id: claude-sonnet-4-thinking
   slug: claude-sonnet-4-thinking
   model: Claude 4 Sonnet (Thinking)
@@ -68,3 +77,4 @@
   averageScore: 71.54641495715929
   costPerTask: 1.8090906932458548
   benchmarkCount: 5
+  totalBenchmarks: 9

--- a/lib/__tests__/data-loader.test.ts
+++ b/lib/__tests__/data-loader.test.ts
@@ -25,6 +25,7 @@ test("transformToTableData converts LLMData objects to table rows", () => {
       averageScore: 42,
       costPerTask: null,
       benchmarkCount: 0,
+      totalBenchmarks: 0,
     },
   ])
 })

--- a/lib/table-utils.ts
+++ b/lib/table-utils.ts
@@ -6,6 +6,7 @@ export interface TableRow {
   averageScore: number
   costPerTask: number | null
   benchmarkCount: number
+  totalBenchmarks: number
 }
 
 export function transformToTableData(
@@ -18,6 +19,14 @@ export function transformToTableData(
     normalizedCost?: number | null
   }[],
 ): TableRow[] {
+  const benchmarkSet = new Set<string>()
+  for (const llm of llmData) {
+    for (const b of Object.keys(llm.benchmarks)) {
+      benchmarkSet.add(b)
+    }
+  }
+  const totalBenchmarks = benchmarkSet.size
+
   return llmData.map((llm) => ({
     id: llm.slug,
     slug: llm.slug,
@@ -26,5 +35,6 @@ export function transformToTableData(
     averageScore: llm.averageScore || 0,
     costPerTask: llm.normalizedCost ?? null,
     benchmarkCount: Object.keys(llm.benchmarks).length,
+    totalBenchmarks,
   }))
 }


### PR DESCRIPTION
## Summary
- improve data table rows with totalBenchmarks
- show tooltip for models with few benchmarks
- update tests and snapshots

## Testing
- `pnpm lint`
- `pnpm test:update`

------
https://chatgpt.com/codex/tasks/task_e_686c1cd35a908320b0377a15801fa349