### PR TITLE
Fix GPT-4.5-preview mapping

### DIFF
--- a/public/data/benchmarks/aider-polyglot.yaml
+++ b/public/data/benchmarks/aider-polyglot.yaml
@@ -155,7 +155,7 @@ model_name_mapping:
   DeepSeek Chat V3 (prev): null
   gemini-2.5-flash-preview-04-17 (default): null
   chatgpt-4o-latest (2025-03-29): gpt-4o
-  gpt-4.5-preview: null
+  gpt-4.5-preview: gpt-4.5-preview
   gemini-2.5-flash-preview-05-20 (no think): null
   Qwen3 32B: null
   gemini-exp-1206: null

--- a/public/data/benchmarks/artificial-analysis-index.yaml
+++ b/public/data/benchmarks/artificial-analysis-index.yaml
@@ -387,7 +387,7 @@ model_name_mapping:
   Gemini 2.5 Flash: null
   DeepSeek V3 0324 (Mar '25): null
   Claude 4 Sonnet: null
-  GPT-4.5 (Preview): null
+  GPT-4.5 (Preview): gpt-4.5-preview
   GPT-4.1 mini: gpt-4.1-mini
   GPT-4.1: gpt-4.1
   Gemini 2.0 Flash Thinking exp. (Jan '25): null

--- a/public/data/benchmarks/gpqa-diamond.yaml
+++ b/public/data/benchmarks/gpqa-diamond.yaml
@@ -204,7 +204,7 @@ model_name_mapping:
   Llama Nemotron Ultra Reasoning: null
   Claude 4 Sonnet Thinking: null
   DeepSeek R1 (Jan '25): null
-  GPT-4.5 (Preview): null
+  GPT-4.5 (Preview): gpt-4.5-preview
   MiniMax M1 80k: null
   Qwen3 235B (Reasoning): null
   Gemini 2.5 Flash (April '25) (Reasoning): null


### PR DESCRIPTION
## Summary
- map `gpt-4.5-preview` alias in Aider Polyglot benchmark
- map `GPT-4.5 (Preview)` in Artificial Analysis Index benchmark
- map `GPT-4.5 (Preview)` in GPQA Diamond benchmark

## Testing
- `pnpm lint`
- `pnpm lint:check`
- `pnpm prettier`
- `pnpm prettier:check`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686c1c8c2b4483208b9f5693b3921ef3