### PR TITLE
Fix rounding in leaderboard snapshot

### DIFF
--- a/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
+++ b/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
@@ -2,79 +2,79 @@
   slug: o3-high
   model: o3 (high)
   provider: OpenAI
-  averageScore: 90.25715218004336
-  costPerTask: 2.4217322308296167
+  averageScore: 90.26
+  costPerTask: 2.42
   benchmarkCount: 6
   totalBenchmarks: 9
 - id: o3-pro-high
   slug: o3-pro-high
   model: o3-pro (high)
   provider: OpenAI
-  averageScore: 88.62740973072215
-  costPerTask: 20.082836146455183
+  averageScore: 88.63
+  costPerTask: 20.08
   benchmarkCount: 4
   totalBenchmarks: 9
 - id: gemini-2.5-pro-06-05
   slug: gemini-2.5-pro-06-05
   model: Gemini 2.5 Pro (06-05)
   provider: Google
-  averageScore: 88.29113207784194
-  costPerTask: 3.130512167527233
+  averageScore: 88.29
+  costPerTask: 3.13
   benchmarkCount: 9
   totalBenchmarks: 9
 - id: gemini-2.5-pro-preview-05-06
   slug: gemini-2.5-pro-preview-05-06
   model: Gemini 2.5 Pro Preview 05-06
   provider: Google
-  averageScore: 88.2178015571845
-  costPerTask: 3.890476190476191
+  averageScore: 88.22
+  costPerTask: 3.89
   benchmarkCount: 4
   totalBenchmarks: 9
 - id: gemini-2.5-pro-preview-03-25
   slug: gemini-2.5-pro-preview-03-25
   model: Gemini 2.5 Pro Preview 03-25
   provider: Google
-  averageScore: 87.02368647767555
-  costPerTask: 3.208216619981326
+  averageScore: 87.02
+  costPerTask: 3.21
   benchmarkCount: 5
   totalBenchmarks: 9
 - id: claude-opus-4-thinking
   slug: claude-opus-4-thinking
   model: Claude 4 Opus (Thinking)
   provider: Anthropic
-  averageScore: 85.68785679662405
-  costPerTask: 6.193164845164149
+  averageScore: 85.69
+  costPerTask: 6.19
   benchmarkCount: 5
   totalBenchmarks: 9
 - id: o3-medium
   slug: o3-medium
   model: o3 (medium)
   provider: OpenAI
-  averageScore: 84.62371873669699
-  costPerTask: 1.4375857289727487
+  averageScore: 84.62
+  costPerTask: 1.44
   benchmarkCount: 8
   totalBenchmarks: 9
 - id: o4-mini-high
   slug: o4-mini-high
   model: o4-mini (high)
   provider: OpenAI
-  averageScore: 80.98832462713298
-  costPerTask: 1.9717305231237856
+  averageScore: 80.99
+  costPerTask: 1.97
   benchmarkCount: 8
   totalBenchmarks: 9
 - id: claude-opus-4-nothinking
   slug: claude-opus-4-nothinking
   model: Claude 4 Opus (No Thinking)
   provider: Anthropic
-  averageScore: 77.8107740119079
-  costPerTask: 5.126050420168068
+  averageScore: 77.81
+  costPerTask: 5.13
   benchmarkCount: 2
   totalBenchmarks: 9
 - id: grok-3-mini-high
   slug: grok-3-mini-high
   model: Grok 3 Mini (high)
   provider: xAI
-  averageScore: 72.88294134675459
-  costPerTask: 0.119234360410831
+  averageScore: 72.88
+  costPerTask: 0.12
   benchmarkCount: 4
   totalBenchmarks: 9

--- a/lib/__tests__/default-leaderboard.snapshot.test.ts
+++ b/lib/__tests__/default-leaderboard.snapshot.test.ts
@@ -9,7 +9,14 @@ import path from "path"
 
 test("default leaderboard top 10 data", async () => {
   const llmData = await loadLLMData()
-  const tableRows = transformToTableData(llmData).slice(0, 10)
+  const tableRows = transformToTableData(llmData)
+    .slice(0, 10)
+    .map((row) => ({
+      ...row,
+      averageScore: Number(row.averageScore.toFixed(2)),
+      costPerTask:
+        row.costPerTask === null ? null : Number(row.costPerTask.toFixed(2)),
+    }))
   const yamlData = stringify(tableRows)
   const snapshotFile = path.join(
     __dirname,


### PR DESCRIPTION
## Summary
- round numeric fields in the snapshot test
- update the leaderboard snapshot to show two decimal places

## Testing
- `pnpm prettier:check`
- `pnpm lint:check`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686c207fa3d8832092636a3a79af5fb1