### PR TITLE
Add warning for sparse cost benchmarks

### DIFF
--- a/components/columns.tsx
+++ b/components/columns.tsx
@@ -162,9 +162,22 @@ export const columns: ColumnDef<TableRow>[] = [
     },
     cell: ({ row }) => {
       const cost = row.getValue("costPerTask") as number | null
+      const count = row.original.costBenchmarkCount
       return (
-        <div className="font-semibold">
+        <div className="font-semibold flex items-center gap-1">
           <CostCell cost={cost} />
+          {cost !== null && count < 3 && (
+            <TooltipProvider delayDuration={0}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <AlertCircle className="h-4 w-4 text-yellow-600" />
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  {`This model's cost has only been evaluated on ${count} out of ${row.original.totalBenchmarks} benchmarks`}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
         </div>
       )
     },

--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -9,6 +9,13 @@ import { ChartContainer, ChartTooltip, ChartTooltipContent } from "./ui/chart"
 const BASE_TICKS = [0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 1, 3, 10, 30] as const
 
 const MIN_BENCHMARKS = 5
+const MIN_COST_BENCHMARKS = 3
+
+function countCostBenchmarks(llm: LLMData) {
+  return Object.values(llm.benchmarks).filter(
+    (b) => b.normalizedCost !== undefined,
+  ).length
+}
 
 type Props = {
   llmData: LLMData[]
@@ -40,7 +47,8 @@ export default function CostScoreChart({
         (m) =>
           (showDeprecated || !m.deprecated) &&
           (showIncomplete ||
-            Object.keys(m.benchmarks).length >= MIN_BENCHMARKS),
+            (Object.keys(m.benchmarks).length >= MIN_BENCHMARKS &&
+              countCostBenchmarks(m) >= MIN_COST_BENCHMARKS)),
       ),
     [sorted, showDeprecated, showIncomplete],
   )
@@ -125,7 +133,8 @@ export default function CostScoreChart({
               data={data.map((d) =>
                 showDeprecated || !d.deprecated
                   ? showIncomplete ||
-                    Object.keys(d.benchmarks).length >= MIN_BENCHMARKS
+                    (Object.keys(d.benchmarks).length >= MIN_BENCHMARKS &&
+                      countCostBenchmarks(d) >= MIN_COST_BENCHMARKS)
                     ? d
                     : { ...d, normalizedCost: NaN, averageScore: NaN }
                   : { ...d, normalizedCost: NaN, averageScore: NaN },

--- a/components/leaderboard-section.tsx
+++ b/components/leaderboard-section.tsx
@@ -7,6 +7,15 @@ import LeaderboardTable from "./leaderboard-table"
 import { Switch } from "@/components/ui/switch"
 import { Label } from "@/components/ui/label"
 
+const MIN_BENCHMARKS = 5
+const MIN_COST_BENCHMARKS = 3
+
+function countCostBenchmarks(llm: LLMData) {
+  return Object.values(llm.benchmarks).filter(
+    (b) => b.normalizedCost !== undefined,
+  ).length
+}
+
 export default function LeaderboardSection({
   llmData,
 }: {
@@ -17,7 +26,9 @@ export default function LeaderboardSection({
   const visible = llmData.filter(
     (m) =>
       (showDeprecated || !m.deprecated) &&
-      (showIncomplete || Object.keys(m.benchmarks).length >= 5),
+      (showIncomplete ||
+        (Object.keys(m.benchmarks).length >= MIN_BENCHMARKS &&
+          countCostBenchmarks(m) >= MIN_COST_BENCHMARKS)),
   )
 
   return (

--- a/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
+++ b/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
@@ -4,6 +4,7 @@
   provider: OpenAI
   averageScore: 90.26
   costPerTask: 2.42
+  costBenchmarkCount: 3
   benchmarkCount: 6
   totalBenchmarks: 9
 - id: o3-pro-high
@@ -12,6 +13,7 @@
   provider: OpenAI
   averageScore: 88.63
   costPerTask: 20.08
+  costBenchmarkCount: 3
   benchmarkCount: 4
   totalBenchmarks: 9
 - id: gemini-2.5-pro-06-05
@@ -20,6 +22,7 @@
   provider: Google
   averageScore: 88.29
   costPerTask: 3.13
+  costBenchmarkCount: 4
   benchmarkCount: 9
   totalBenchmarks: 9
 - id: gemini-2.5-pro-preview-05-06
@@ -28,6 +31,7 @@
   provider: Google
   averageScore: 88.22
   costPerTask: 3.89
+  costBenchmarkCount: 2
   benchmarkCount: 4
   totalBenchmarks: 9
 - id: gemini-2.5-pro-preview-03-25
@@ -36,6 +40,7 @@
   provider: Google
   averageScore: 87.02
   costPerTask: 3.21
+  costBenchmarkCount: 1
   benchmarkCount: 5
   totalBenchmarks: 9
 - id: claude-opus-4-thinking
@@ -44,6 +49,7 @@
   provider: Anthropic
   averageScore: 85.69
   costPerTask: 6.19
+  costBenchmarkCount: 3
   benchmarkCount: 5
   totalBenchmarks: 9
 - id: o3-medium
@@ -52,6 +58,7 @@
   provider: OpenAI
   averageScore: 84.62
   costPerTask: 1.44
+  costBenchmarkCount: 4
   benchmarkCount: 8
   totalBenchmarks: 9
 - id: o4-mini-high
@@ -60,6 +67,7 @@
   provider: OpenAI
   averageScore: 80.99
   costPerTask: 1.97
+  costBenchmarkCount: 4
   benchmarkCount: 8
   totalBenchmarks: 9
 - id: claude-opus-4-nothinking
@@ -68,6 +76,7 @@
   provider: Anthropic
   averageScore: 77.81
   costPerTask: 5.13
+  costBenchmarkCount: 1
   benchmarkCount: 2
   totalBenchmarks: 9
 - id: grok-3-mini-high
@@ -76,5 +85,6 @@
   provider: xAI
   averageScore: 72.88
   costPerTask: 0.12
+  costBenchmarkCount: 2
   benchmarkCount: 4
   totalBenchmarks: 9

--- a/lib/__tests__/data-loader.test.ts
+++ b/lib/__tests__/data-loader.test.ts
@@ -24,6 +24,7 @@ test("transformToTableData converts LLMData objects to table rows", () => {
       provider: "Bar",
       averageScore: 42,
       costPerTask: null,
+      costBenchmarkCount: 0,
       benchmarkCount: 0,
       totalBenchmarks: 0,
     },

--- a/lib/table-utils.ts
+++ b/lib/table-utils.ts
@@ -1,3 +1,5 @@
+import type { BenchmarkResult } from "./data-loader"
+
 export interface TableRow {
   id: string
   slug: string
@@ -5,6 +7,7 @@ export interface TableRow {
   provider: string
   averageScore: number
   costPerTask: number | null
+  costBenchmarkCount: number
   benchmarkCount: number
   totalBenchmarks: number
 }
@@ -34,6 +37,9 @@ export function transformToTableData(
     provider: llm.provider,
     averageScore: llm.averageScore || 0,
     costPerTask: llm.normalizedCost ?? null,
+    costBenchmarkCount: Object.values(llm.benchmarks).filter(
+      (b) => (b as BenchmarkResult).normalizedCost !== undefined,
+    ).length,
     benchmarkCount: Object.keys(llm.benchmarks).length,
     totalBenchmarks,
   }))


### PR DESCRIPTION
## Summary
- track how many benchmarks contain cost data for each model
- show a warning if a model's cost is based on less than three benchmarks
- hide these models unless "Show models with limited data" is enabled
- update tests and snapshots

## Testing
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686c6e6fe0d083209ed387574c510dec