### PR TITLE
Show cost benchmark count in tooltip

### DIFF
--- a/components/columns.tsx
+++ b/components/columns.tsx
@@ -173,7 +173,7 @@ export const columns: ColumnDef<TableRow>[] = [
                   <AlertCircle className="h-4 w-4 text-yellow-600" />
                 </TooltipTrigger>
                 <TooltipContent side="top">
-                  {`This model's cost has only been evaluated on ${count} out of ${row.original.totalBenchmarks} benchmarks`}
+                  {`This model's cost has only been evaluated on ${count} out of ${row.original.totalCostBenchmarks} benchmarks with cost data`}
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>

--- a/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
+++ b/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
@@ -7,6 +7,7 @@
   costBenchmarkCount: 3
   benchmarkCount: 6
   totalBenchmarks: 9
+  totalCostBenchmarks: 4
 - id: o3-pro-high
   slug: o3-pro-high
   model: o3-pro (high)
@@ -16,6 +17,7 @@
   costBenchmarkCount: 3
   benchmarkCount: 4
   totalBenchmarks: 9
+  totalCostBenchmarks: 4
 - id: gemini-2.5-pro-06-05
   slug: gemini-2.5-pro-06-05
   model: Gemini 2.5 Pro (06-05)
@@ -25,6 +27,7 @@
   costBenchmarkCount: 4
   benchmarkCount: 9
   totalBenchmarks: 9
+  totalCostBenchmarks: 4
 - id: gemini-2.5-pro-preview-05-06
   slug: gemini-2.5-pro-preview-05-06
   model: Gemini 2.5 Pro Preview 05-06
@@ -34,6 +37,7 @@
   costBenchmarkCount: 2
   benchmarkCount: 4
   totalBenchmarks: 9
+  totalCostBenchmarks: 4
 - id: gemini-2.5-pro-preview-03-25
   slug: gemini-2.5-pro-preview-03-25
   model: Gemini 2.5 Pro Preview 03-25
@@ -43,6 +47,7 @@
   costBenchmarkCount: 1
   benchmarkCount: 5
   totalBenchmarks: 9
+  totalCostBenchmarks: 4
 - id: claude-opus-4-thinking
   slug: claude-opus-4-thinking
   model: Claude 4 Opus (Thinking)
@@ -52,6 +57,7 @@
   costBenchmarkCount: 3
   benchmarkCount: 5
   totalBenchmarks: 9
+  totalCostBenchmarks: 4
 - id: o3-medium
   slug: o3-medium
   model: o3 (medium)
@@ -61,6 +67,7 @@
   costBenchmarkCount: 4
   benchmarkCount: 8
   totalBenchmarks: 9
+  totalCostBenchmarks: 4
 - id: o4-mini-high
   slug: o4-mini-high
   model: o4-mini (high)
@@ -70,6 +77,7 @@
   costBenchmarkCount: 4
   benchmarkCount: 8
   totalBenchmarks: 9
+  totalCostBenchmarks: 4
 - id: claude-opus-4-nothinking
   slug: claude-opus-4-nothinking
   model: Claude 4 Opus (No Thinking)
@@ -79,6 +87,7 @@
   costBenchmarkCount: 1
   benchmarkCount: 2
   totalBenchmarks: 9
+  totalCostBenchmarks: 4
 - id: grok-3-mini-high
   slug: grok-3-mini-high
   model: Grok 3 Mini (high)
@@ -88,3 +97,4 @@
   costBenchmarkCount: 2
   benchmarkCount: 4
   totalBenchmarks: 9
+  totalCostBenchmarks: 4

--- a/lib/__tests__/data-loader.test.ts
+++ b/lib/__tests__/data-loader.test.ts
@@ -27,6 +27,7 @@ test("transformToTableData converts LLMData objects to table rows", () => {
       costBenchmarkCount: 0,
       benchmarkCount: 0,
       totalBenchmarks: 0,
+      totalCostBenchmarks: 0,
     },
   ])
 })

--- a/lib/table-utils.ts
+++ b/lib/table-utils.ts
@@ -10,6 +10,7 @@ export interface TableRow {
   costBenchmarkCount: number
   benchmarkCount: number
   totalBenchmarks: number
+  totalCostBenchmarks: number
 }
 
 export function transformToTableData(
@@ -23,12 +24,18 @@ export function transformToTableData(
   }[],
 ): TableRow[] {
   const benchmarkSet = new Set<string>()
+  const costBenchmarkSet = new Set<string>()
   for (const llm of llmData) {
     for (const b of Object.keys(llm.benchmarks)) {
       benchmarkSet.add(b)
+      const res = llm.benchmarks[b] as BenchmarkResult
+      if (res.normalizedCost !== undefined) {
+        costBenchmarkSet.add(b)
+      }
     }
   }
   const totalBenchmarks = benchmarkSet.size
+  const totalCostBenchmarks = costBenchmarkSet.size
 
   return llmData.map((llm) => ({
     id: llm.slug,
@@ -42,5 +49,6 @@ export function transformToTableData(
     ).length,
     benchmarkCount: Object.keys(llm.benchmarks).length,
     totalBenchmarks,
+    totalCostBenchmarks,
   }))
 }


### PR DESCRIPTION
## Summary
- track count of benchmarks with cost data
- display that count in the cost warning tooltip
- update tests and snapshots

## Testing
- `pnpm lint`
- `pnpm prettier`
- `pnpm lint:check`
- `pnpm prettier:check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686c7a2aa14083208ef0bb8ea7c86f42