### PR TITLE
Add AGENTS guide for scripts folder

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,11 @@
+# Scraping scripts guidelines
+
+This directory contains TypeScript utilities for fetching benchmark results.
+
+## Adding a new script
+
+- Name the file `scrape_<benchmark>.ts`.
+- Use `curl` and `saveBenchmarkResults` from `utils.ts` to write YAML under `public/data/benchmarks`.
+- Register a command in `package.json` like `"scrape:<benchmark>": "tsx scripts/scrape_<benchmark>.ts"`.
+- Run `pnpm lint` and `pnpm prettier` before committing changes.
+- Execute `pnpm test` to confirm the repository still builds.


### PR DESCRIPTION
## Summary
- document how to add and run scraping scripts in `scripts/AGENTS.md`

## Testing
- `pnpm lint`
- `pnpm prettier:check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686c8468f6f08320980c862720df3764