### PR TITLE
Remove inline model mapping support

### DIFF
--- a/lib/benchmark-loader.ts
+++ b/lib/benchmark-loader.ts
@@ -40,8 +40,7 @@ export async function loadBenchmarks(): Promise<BenchmarkInfo[]> {
 export interface BenchmarkDetails extends BenchmarkInfo {
   results: Record<string, number>
   cost_per_task?: Record<string, number>
-  model_name_mapping?: Record<string, string | null>
-  model_name_mapping_file?: string
+  model_name_mapping_file: string
 }
 
 export async function loadBenchmarkDetails(
@@ -58,45 +57,18 @@ export async function loadBenchmarkDetails(
       description: string
       results: Record<string, number>
       cost_per_task?: Record<string, number>
-      model_name_mapping?: Record<string, string | null>
-      model_name_mapping_file?: string
+      model_name_mapping_file: string
     }
     if (!data.benchmark || !data.results) {
       throw new Error(`Invalid benchmark structure for ${slug}`)
     }
-    let mapping: Record<string, string | null> | undefined =
-      data.model_name_mapping
-
-    if (data.model_name_mapping_file) {
-      try {
-        const mapPath = path.join(
-          process.cwd(),
-          "public",
-          "data",
-          "mappings",
-          data.model_name_mapping_file,
-        )
-        const mapText = await fs.readFile(mapPath, "utf8")
-        const fileMap = parse(mapText) as Record<string, string | null>
-        mapping = { ...fileMap, ...(mapping || {}) }
-      } catch (err) {
-        console.error(
-          `Failed to load model_name_mapping_file for ${slug}:`,
-          err,
-        )
-      }
-    }
-
     return {
       slug,
       benchmark: data.benchmark,
       description: data.description,
       results: data.results,
       cost_per_task: data.cost_per_task,
-      ...(mapping ? { model_name_mapping: mapping } : {}),
-      ...(data.model_name_mapping_file
-        ? { model_name_mapping_file: data.model_name_mapping_file }
-        : {}),
+      model_name_mapping_file: data.model_name_mapping_file,
     }
   } catch (error) {
     console.error(`Failed to load benchmark details for ${slug}:`, error)

--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -70,33 +70,28 @@ export async function loadLLMData(): Promise<LLMData[]> {
         description: string
         results: Record<string, number>
         cost_per_task?: Record<string, number>
-        model_name_mapping?: Record<string, string | null>
-        model_name_mapping_file?: string
+        model_name_mapping_file: string
       }
       if (!data.benchmark || !data.results) {
         throw new Error(`Invalid benchmark structure for ${slug}`)
       }
-      let mapping: Record<string, string | null> | undefined =
-        data.model_name_mapping
-
-      if (data.model_name_mapping_file) {
-        try {
-          const mapPath = path.join(
-            process.cwd(),
-            "public",
-            "data",
-            "mappings",
-            data.model_name_mapping_file,
-          )
-          const mapText = await fs.readFile(mapPath, "utf8")
-          const fileMap = parse(mapText) as Record<string, string | null>
-          mapping = { ...fileMap, ...(mapping || {}) }
-        } catch (err) {
-          console.error(
-            `Failed to load model_name_mapping_file for ${slug}:`,
-            err,
-          )
-        }
+      let mapping: Record<string, string | null> | undefined
+      try {
+        const mapPath = path.join(
+          process.cwd(),
+          "public",
+          "data",
+          "mappings",
+          data.model_name_mapping_file,
+        )
+        const mapText = await fs.readFile(mapPath, "utf8")
+        const fileMap = parse(mapText) as Record<string, string | null>
+        mapping = fileMap
+      } catch (err) {
+        console.error(
+          `Failed to load model_name_mapping_file for ${slug}:`,
+          err,
+        )
       }
 
       if (mapping) {


### PR DESCRIPTION
## Summary
- require `model_name_mapping_file` in benchmark details
- load aliases directly from mapping files
- drop inline mapping writes in `saveBenchmarkResults`
- remove leftover map logging

## Testing
- `pnpm prettier`
- `pnpm prettier:check`
- `pnpm lint`
- `pnpm lint:check`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686c7def02f88320bc83b4fe4b4ab6d1