### PR TITLE
Add test for valid mapping slugs

### DIFF
--- a/data/mappings/artificial-analysis.yaml
+++ b/data/mappings/artificial-analysis.yaml
@@ -154,7 +154,7 @@ o1-pro: null
 o3: o3-medium
 o3-mini: null
 o3-mini (high): null
-o3-pro: o3-pro-medium
+o3-pro: null
 o4-mini (high): o4-mini-high
 OpenChat 3.5: null
 PALM-2: null

--- a/data/mappings/humanitys-last-exam.yaml
+++ b/data/mappings/humanitys-last-exam.yaml
@@ -23,4 +23,4 @@ o1 Pro: null
 o3 (high) (April 2025): o3-high
 o3 (medium) (April 2025): o3-medium
 o4-mini (high) (April 2025): o4-mini-high
-o4-mini (medium) (April 2025): o4-mini-medium
+o4-mini (medium) (April 2025): null

--- a/data/mappings/livebench.yaml
+++ b/data/mappings/livebench.yaml
@@ -41,7 +41,7 @@ o3-2025-04-16-high: o3-high
 o3-2025-04-16-medium: o3-medium
 o3-pro-2025-06-10-high: o3-pro-high
 o4-mini-2025-04-16-high: o4-mini-high
-o4-mini-2025-04-16-medium: o4-mini-medium
+o4-mini-2025-04-16-medium: null
 phi-4-reasoning-plus: null
 qwen2.5-72b-instruct-turbo: null
 qwen2.5-max: null

--- a/data/mappings/lmarena-text.yaml
+++ b/data/mappings/lmarena-text.yaml
@@ -151,7 +151,7 @@ o1-preview: null
 o3-2025-04-16: o3-medium
 o3-mini: null
 o3-mini-high: null
-o4-mini-2025-04-16: o4-mini-medium
+o4-mini-2025-04-16: null
 oasst-pythia-12b: null
 olmo-2-0325-32b-instruct: null
 olmo-7b-instruct: null

--- a/lib/__tests__/model-mapping.test.ts
+++ b/lib/__tests__/model-mapping.test.ts
@@ -1,0 +1,34 @@
+import fs from "fs/promises"
+import path from "path"
+import { parse } from "yaml"
+import { expect, test } from "vitest"
+
+// Ensure every mapping file only points to existing model slugs
+
+test("mapping files reference valid slugs", async () => {
+  const modelsDir = path.join(process.cwd(), "data", "models")
+  const mappingsDir = path.join(process.cwd(), "data", "mappings")
+
+  const modelSlugs = new Set(
+    (await fs.readdir(modelsDir))
+      .filter((f) => f.endsWith(".yaml"))
+      .map((f) => f.replace(/\.yaml$/, "")),
+  )
+
+  const mappingFiles = (await fs.readdir(mappingsDir)).filter((f) =>
+    f.endsWith(".yaml"),
+  )
+
+  const invalid: string[] = []
+  for (const file of mappingFiles) {
+    const text = await fs.readFile(path.join(mappingsDir, file), "utf8")
+    const mapping = parse(text) as Record<string, string | null>
+    for (const slug of Object.values(mapping)) {
+      if (slug && !modelSlugs.has(slug)) {
+        invalid.push(`${file}: ${slug}`)
+      }
+    }
+  }
+
+  expect(invalid).toEqual([])
+})


### PR DESCRIPTION
## Summary
- ensure mapping files only reference existing model slugs
- set unmapped aliases that pointed at missing slugs to `null`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686d3d4bd11c8320a2772a7c5bd81d3d