### PR TITLE
Update leaderboard snapshot filtering

### DIFF
--- a/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
+++ b/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
@@ -8,16 +8,6 @@
   benchmarkCount: 6
   totalBenchmarks: 9
   totalCostBenchmarks: 4
-- id: o3-pro-high
-  slug: o3-pro-high
-  model: o3-pro (high)
-  provider: OpenAI
-  averageScore: 88.63
-  costPerTask: 13.07
-  costBenchmarkCount: 3
-  benchmarkCount: 4
-  totalBenchmarks: 9
-  totalCostBenchmarks: 4
 - id: gemini-2.5-pro-06-05
   slug: gemini-2.5-pro-06-05
   model: Gemini 2.5 Pro (06-05)
@@ -26,26 +16,6 @@
   costPerTask: 1.99
   costBenchmarkCount: 4
   benchmarkCount: 9
-  totalBenchmarks: 9
-  totalCostBenchmarks: 4
-- id: gemini-2.5-pro-preview-05-06
-  slug: gemini-2.5-pro-preview-05-06
-  model: Gemini 2.5 Pro Preview 05-06
-  provider: Google
-  averageScore: 88.22
-  costPerTask: 2.42
-  costBenchmarkCount: 2
-  benchmarkCount: 4
-  totalBenchmarks: 9
-  totalCostBenchmarks: 4
-- id: gemini-2.5-pro-preview-03-25
-  slug: gemini-2.5-pro-preview-03-25
-  model: Gemini 2.5 Pro Preview 03-25
-  provider: Google
-  averageScore: 87.02
-  costPerTask: 2.04
-  costBenchmarkCount: 1
-  benchmarkCount: 5
   totalBenchmarks: 9
   totalCostBenchmarks: 4
 - id: o3-medium
@@ -78,22 +48,52 @@
   benchmarkCount: 8
   totalBenchmarks: 9
   totalCostBenchmarks: 4
-- id: grok-3-mini-high
-  slug: grok-3-mini-high
-  model: Grok 3 Mini (high)
-  provider: xAI
-  averageScore: 72.88
-  costPerTask: 0.07
-  costBenchmarkCount: 2
-  benchmarkCount: 4
-  totalBenchmarks: 9
-  totalCostBenchmarks: 4
 - id: deepseek-r1-0528
   slug: deepseek-r1-0528
   model: DeepSeek R1 (05/28)
   provider: DeepSeek
   averageScore: 64.57
   costPerTask: 0.26
+  costBenchmarkCount: 4
+  benchmarkCount: 8
+  totalBenchmarks: 9
+  totalCostBenchmarks: 4
+- id: claude-sonnet-4-thinking
+  slug: claude-sonnet-4-thinking
+  model: Claude 4 Sonnet (Thinking)
+  provider: Anthropic
+  averageScore: 63.11
+  costPerTask: 1.12
+  costBenchmarkCount: 4
+  benchmarkCount: 8
+  totalBenchmarks: 9
+  totalCostBenchmarks: 4
+- id: gemini-2.5-flash-0520-thinking
+  slug: gemini-2.5-flash-0520-thinking
+  model: Gemini 2.5 Flash 05-20 (Thinking)
+  provider: Google
+  averageScore: 58.34
+  costPerTask: 0.74
+  costBenchmarkCount: 3
+  benchmarkCount: 6
+  totalBenchmarks: 9
+  totalCostBenchmarks: 4
+- id: claude-opus-4-nothinking
+  slug: claude-opus-4-nothinking
+  model: Claude 4 Opus (No Thinking)
+  provider: Anthropic
+  averageScore: 49.81
+  costPerTask: 1.84
+  costBenchmarkCount: 4
+  benchmarkCount: 8
+  totalBenchmarks: 9
+  totalCostBenchmarks: 4
+- id: claude-sonnet-4-nothinking
+  slug: claude-sonnet-4-nothinking
+  model: Claude 4 Sonnet (No Thinking)
+  provider: Anthropic
+  averageScore: 40.9
+  costPerTask: 0.4
   costBenchmarkCount: 4
   benchmarkCount: 8
   totalBenchmarks: 9

--- a/lib/__tests__/default-leaderboard.snapshot.test.ts
+++ b/lib/__tests__/default-leaderboard.snapshot.test.ts
@@ -8,7 +8,19 @@ import path from "path"
 // This ensures data loading remains stable independent of the UI
 
 test("default leaderboard top 10 data", async () => {
-  const llmData = await loadLLMData()
+  const MIN_BENCHMARKS = 5
+  const MIN_COST_BENCHMARKS = 3
+  function countCostBenchmarks(llm: { benchmarks: Record<string, unknown> }) {
+    return Object.values(llm.benchmarks).filter(
+      (b) => (b as { normalizedCost?: number }).normalizedCost !== undefined,
+    ).length
+  }
+  const llmData = (await loadLLMData()).filter(
+    (m) =>
+      !m.deprecated &&
+      Object.keys(m.benchmarks).length >= MIN_BENCHMARKS &&
+      countCostBenchmarks(m) >= MIN_COST_BENCHMARKS,
+  )
   const tableRows = transformToTableData(llmData)
     .slice(0, 10)
     .map((row) => ({


### PR DESCRIPTION
## Summary
- filter out deprecated models and those with insufficient data when generating leaderboard top 10 snapshot
- update snapshot data

## Testing
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686d4417710c832094b7cec91a5a36b3