### PR TITLE
Support multi-model YAML format

### DIFF
--- a/data/AGENTS.md
+++ b/data/AGENTS.md
@@ -6,7 +6,11 @@ This folder stores YAML files consumed by the application and populated by scrap
 
 - `benchmarks/` – Benchmark result files. Each contains `benchmark`, `description`, `results` and optionally `cost_per_task`. The scraping scripts under `scripts/` update the `results` and `cost_per_task` sections automatically.
 - `mappings/` – Model name mapping files. When a scraping script writes a benchmark file, it also ensures the corresponding mapping YAML is updated with any new model names. Mapping values that associate an alias to a known model slug are maintained manually.
-- `models/` – Model definitions. Each YAML lists `model`, `provider` and optional `aliases`. These files are curated manually.
+- `models/` – Model definitions. Historically each YAML only described a single
+  model slug with `model` and `provider` fields. We are migrating to a format
+  where a file can define multiple slugs using a top level `models:` mapping.
+  Both formats are supported by the code while this migration is in progress.
+  Currently only the `o3` model uses the new `models:` syntax.
 
 ## How the code interacts with these files
 

--- a/data/models/o3-high.yaml
+++ b/data/models/o3-high.yaml
@@ -1,2 +1,0 @@
-model: o3 (high)
-provider: OpenAI

--- a/data/models/o3-low.yaml
+++ b/data/models/o3-low.yaml
@@ -1,2 +1,0 @@
-model: o3 (low)
-provider: OpenAI

--- a/data/models/o3-medium.yaml
+++ b/data/models/o3-medium.yaml
@@ -1,2 +1,0 @@
-model: o3 (medium)
-provider: OpenAI

--- a/data/models/o3.yaml
+++ b/data/models/o3.yaml
@@ -1,0 +1,5 @@
+provider: OpenAI
+models:
+  o3-low: o3 (low)
+  o3-medium: o3 (medium)
+  o3-high: o3 (high)


### PR DESCRIPTION
## Summary
- add support for YAML files that define multiple model slugs
- migrate `o3` model to the new `models:` syntax
- update mapping slug test to parse new model files
- document the in-progress migration in `data/AGENTS.md`

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686d5c448f9483209f1989619480e0d7