### PR TITLE
Convert gemini 2.5 flash YAMLs to multi-model format

### DIFF
--- a/data/models/gemini-2.5-flash-0520-nothinking.yaml
+++ b/data/models/gemini-2.5-flash-0520-nothinking.yaml
@@ -1,2 +1,0 @@
-model: Gemini 2.5 Flash 05-20 (No Thinking)
-provider: Google

--- a/data/models/gemini-2.5-flash-0520-thinking.yaml
+++ b/data/models/gemini-2.5-flash-0520-thinking.yaml
@@ -1,2 +1,0 @@
-model: Gemini 2.5 Flash 05-20 (Thinking)
-provider: Google

--- a/data/models/gemini-2.5-flash-0520.yaml
+++ b/data/models/gemini-2.5-flash-0520.yaml
@@ -1,0 +1,4 @@
+provider: Google
+models:
+  gemini-2.5-flash-0520-thinking: Gemini 2.5 Flash 05-20 (Thinking)
+  gemini-2.5-flash-0520-nothinking: Gemini 2.5 Flash 05-20 (No Thinking)

--- a/data/models/gemini-2.5-flash-preview-0417-nothinking.yaml
+++ b/data/models/gemini-2.5-flash-preview-0417-nothinking.yaml
@@ -1,3 +1,0 @@
-model: Gemini 2.5 Flash Preview 04-17 (No Thinking)
-provider: Google
-deprecated: true

--- a/data/models/gemini-2.5-flash-preview-0417-thinking.yaml
+++ b/data/models/gemini-2.5-flash-preview-0417-thinking.yaml
@@ -1,3 +1,0 @@
-model: Gemini 2.5 Flash Preview 04-17 (Thinking)
-provider: Google
-deprecated: true

--- a/data/models/gemini-2.5-flash-preview-0417.yaml
+++ b/data/models/gemini-2.5-flash-preview-0417.yaml
@@ -1,0 +1,5 @@
+provider: Google
+deprecated: true
+models:
+  gemini-2.5-flash-preview-0417-thinking: Gemini 2.5 Flash Preview 04-17 (Thinking)
+  gemini-2.5-flash-preview-0417-nothinking: Gemini 2.5 Flash Preview 04-17 (No Thinking)


### PR DESCRIPTION
## Summary
- migrate gemini 2.5 flash model YAML files to the new multi-model format
- combine variants by date into single files

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686d83d7a7448320ac176d50825fd3e4