### PR TITLE
Migrate Grok 3 Mini model definition

### DIFF
--- a/data/models/grok-3-mini-high.yaml
+++ b/data/models/grok-3-mini-high.yaml
@@ -1,2 +1,0 @@
-model: Grok 3 Mini (high)
-provider: xAI

--- a/data/models/grok-3-mini-low.yaml
+++ b/data/models/grok-3-mini-low.yaml
@@ -1,2 +1,0 @@
-model: Grok 3 Mini (low)
-provider: xAI

--- a/data/models/grok-3-mini-nothinking.yaml
+++ b/data/models/grok-3-mini-nothinking.yaml
@@ -1,2 +1,0 @@
-model: Grok 3 Mini (No Thinking)
-provider: xAI

--- a/data/models/grok-3-mini.yaml
+++ b/data/models/grok-3-mini.yaml
@@ -1,0 +1,5 @@
+provider: xAI
+models:
+  grok-3-mini-low: Grok 3 Mini (low)
+  grok-3-mini-high: Grok 3 Mini (high)
+  grok-3-mini-nothinking: Grok 3 Mini (No Thinking)


### PR DESCRIPTION
## Summary
- migrate Grok 3 Mini model YAML to multi-model syntax

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686d83f1b0348320af9ae1bc8d73d33d