### PR TITLE
Migrate o3-pro model to new YAML format

### DIFF
--- a/data/AGENTS.md
+++ b/data/AGENTS.md
@@ -10,7 +10,7 @@ This folder stores YAML files consumed by the application and populated by scrap
   model slug with `model` and `provider` fields. We are migrating to a format
   where a file can define multiple slugs using a top level `models:` mapping.
   Both formats are supported by the code while this migration is in progress.
-  Currently only the `o3` model uses the new `models:` syntax.
+  Currently the `claude-opus-4`, `claude-sonnet-4`, `o3`, `o3-pro`, and `o4-mini` models use the new `models:` syntax.
 
 ## How the code interacts with these files
 

--- a/data/models/o3-pro-high.yaml
+++ b/data/models/o3-pro-high.yaml
@@ -1,2 +1,0 @@
-model: o3-pro (high)
-provider: OpenAI

--- a/data/models/o3-pro-medium.yaml
+++ b/data/models/o3-pro-medium.yaml
@@ -1,2 +1,0 @@
-model: o3-pro (medium)
-provider: OpenAI

--- a/data/models/o3-pro.yaml
+++ b/data/models/o3-pro.yaml
@@ -1,0 +1,4 @@
+provider: OpenAI
+models:
+  o3-pro-medium: o3-pro (medium)
+  o3-pro-high: o3-pro (high)


### PR DESCRIPTION
## Summary
- consolidate o3-pro model entries into a single file using the `models:` mapping
- document additional models that now use the new format

## Testing
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686d83fbb93883209888047ac8e29424