### PR TITLE
Migrate gemini 2.5 pro models to new YAML format

### DIFF
--- a/data/models/gemini-2.5-pro-06-05.yaml
+++ b/data/models/gemini-2.5-pro-06-05.yaml
@@ -1,2 +1,3 @@
-model: Gemini 2.5 Pro (06-05)
 provider: Google
+models:
+  gemini-2.5-pro-06-05: Gemini 2.5 Pro (06-05)

--- a/data/models/gemini-2.5-pro-preview-03-25.yaml
+++ b/data/models/gemini-2.5-pro-preview-03-25.yaml
@@ -1,3 +1,4 @@
-model: Gemini 2.5 Pro Preview 03-25
 provider: Google
+models:
+  gemini-2.5-pro-preview-03-25: Gemini 2.5 Pro Preview 03-25
 deprecated: true

--- a/data/models/gemini-2.5-pro-preview-05-06.yaml
+++ b/data/models/gemini-2.5-pro-preview-05-06.yaml
@@ -1,3 +1,4 @@
-model: Gemini 2.5 Pro Preview 05-06
 provider: Google
+models:
+  gemini-2.5-pro-preview-05-06: Gemini 2.5 Pro Preview 05-06
 deprecated: true


### PR DESCRIPTION
## Summary
- convert gemini 2.5 pro yaml definitions to use `models:` syntax

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686d83c37f388320be89377bbce0bc61