### PR TITLE
Add zod validation for YAML files

### DIFF
--- a/lib/__tests__/mapping-slugs.test.ts
+++ b/lib/__tests__/mapping-slugs.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest"
 import fs from "fs/promises"
 import path from "path"
 import { parse } from "yaml"
+import { MappingFileSchema, ModelFileSchema } from "../yaml-schemas"
 
 // Ensure all mapping files only reference slugs that exist under data/models
 
@@ -17,16 +18,14 @@ test("mapping files only reference existing slugs", async () => {
   )
   for (const file of modelFiles) {
     const text = await fs.readFile(path.join(modelsDir, file), "utf8")
-    const data = parse(text) as {
-      models: Record<string, string>
-    }
+    const data = ModelFileSchema.parse(parse(text))
     for (const slug of Object.keys(data.models)) {
       knownSlugs.add(slug)
     }
   }
   for (const file of files) {
     const text = await fs.readFile(path.join(mappingsDir, file), "utf8")
-    const mapping = parse(text) as Record<string, string | null>
+    const mapping = MappingFileSchema.parse(parse(text))
     for (const slug of Object.values(mapping)) {
       if (!slug) continue
       expect(knownSlugs.has(slug), `${file} maps to missing slug ${slug}`).toBe(

--- a/lib/benchmark-loader.ts
+++ b/lib/benchmark-loader.ts
@@ -1,6 +1,7 @@
 import { parse } from "yaml"
 import fs from "fs/promises"
 import path from "path"
+import { BenchmarkFileSchema } from "./yaml-schemas"
 
 export interface BenchmarkInfo {
   slug: string
@@ -21,10 +22,7 @@ export async function loadBenchmarks(): Promise<BenchmarkInfo[]> {
         path.join(benchmarkDir, `${slug}.yaml`),
         "utf8",
       )
-      const data = parse(text) as { benchmark: string; description: string }
-      if (!data.benchmark) {
-        throw new Error(`Invalid benchmark structure for ${slug}`)
-      }
+      const data = BenchmarkFileSchema.parse(parse(text))
       benchmarks.push({
         slug,
         benchmark: data.benchmark,
@@ -52,16 +50,7 @@ export async function loadBenchmarkDetails(
       path.join(benchmarkDir, `${slug}.yaml`),
       "utf8",
     )
-    const data = parse(text) as {
-      benchmark: string
-      description: string
-      results: Record<string, number>
-      cost_per_task?: Record<string, number>
-      model_name_mapping_file: string
-    }
-    if (!data.benchmark || !data.results) {
-      throw new Error(`Invalid benchmark structure for ${slug}`)
-    }
+    const data = BenchmarkFileSchema.parse(parse(text))
     return {
       slug,
       benchmark: data.benchmark,

--- a/lib/yaml-schemas.ts
+++ b/lib/yaml-schemas.ts
@@ -1,0 +1,20 @@
+import { z } from "zod"
+
+export const MappingFileSchema = z.record(z.string().nullable())
+export type MappingFile = z.infer<typeof MappingFileSchema>
+
+export const ModelFileSchema = z.object({
+  provider: z.string(),
+  models: z.record(z.string()),
+  deprecated: z.boolean().optional(),
+})
+export type ModelFile = z.infer<typeof ModelFileSchema>
+
+export const BenchmarkFileSchema = z.object({
+  benchmark: z.string(),
+  description: z.string(),
+  results: z.record(z.number()),
+  model_name_mapping_file: z.string(),
+  cost_per_task: z.record(z.number()).optional(),
+})
+export type BenchmarkFile = z.infer<typeof BenchmarkFileSchema>

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -2,6 +2,11 @@ import { execSync } from "child_process"
 import fs from "fs/promises"
 import path from "path"
 import YAML from "yaml"
+import {
+  BenchmarkFileSchema,
+  MappingFileSchema,
+  type BenchmarkFile,
+} from "../lib/yaml-schemas"
 
 export function curl(url: string): string {
   return execSync(`curl -sL ${url}`, { encoding: "utf8" })
@@ -18,10 +23,10 @@ export async function saveBenchmarkResults(
   results: Record<string, number>,
   costPerTask?: Record<string, number>,
 ): Promise<void> {
-  let yamlObj: Record<string, unknown> = {}
+  let yamlObj: Partial<BenchmarkFile> = {}
   try {
     const existing = await fs.readFile(outPath, "utf8")
-    yamlObj = YAML.parse(existing) as Record<string, unknown>
+    yamlObj = BenchmarkFileSchema.partial().parse(YAML.parse(existing))
   } catch (err: any) {
     if (err.code !== "ENOENT") throw err
   }
@@ -42,10 +47,7 @@ export async function saveBenchmarkResults(
   )
   try {
     const mapText = await fs.readFile(mapPath, "utf8")
-    Object.assign(
-      existingMap,
-      YAML.parse(mapText) as Record<string, string | null>,
-    )
+    Object.assign(existingMap, MappingFileSchema.parse(YAML.parse(mapText)))
   } catch (err: any) {
     if (err.code !== "ENOENT") throw err
   }


### PR DESCRIPTION
## Summary
- add `yaml-schemas.ts` with zod schemas for benchmark, model and mapping YAML files
- validate data against those schemas when parsing YAML
- apply schemas inside scraping utilities and tests

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686d9436682883209c9c8a921a293b57