### PR TITLE
Add benchmark counts to tooltip

### DIFF
--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -111,9 +111,21 @@ export default function CostScoreChart({
           <ZAxis range={[144, 144]} />
           <ChartTooltip
             cursor={false}
-            labelFormatter={(_, payload) =>
-              (payload?.[0]?.payload as LLMData).model
-            }
+            labelFormatter={(_, payload) => {
+              const llm = payload?.[0]?.payload as LLMData
+              if (!llm) return null
+              const scoreCount = Object.keys(llm.benchmarks).length
+              const costCount = countCostBenchmarks(llm)
+              return (
+                <div className="grid gap-0.5">
+                  <span>{llm.model}</span>
+                  <span className="text-xs font-normal text-muted-foreground">
+                    {scoreCount} score benchmark{scoreCount === 1 ? "" : "s"},{" "}
+                    {costCount} cost benchmark{costCount === 1 ? "" : "s"}
+                  </span>
+                </div>
+              )
+            }}
             itemSorter={(a, b) => {
               const order: Record<string, number> = { Score: 0, Cost: 1 }
               return (


### PR DESCRIPTION
## Summary
- show how many benchmarks contributed to score and cost in tooltip

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686d9e6efa3c8320861b81832a4ec688