### PR TITLE
Connect reasoning efforts in scatter chart

### DIFF
--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -41,6 +41,15 @@ export default function CostScoreChart({
     return map
   }, [sorted])
 
+  const modelGroups = React.useMemo(() => {
+    const map: Record<string, LLMData[]> = {}
+    for (const item of sorted) {
+      if (!map[item.modelSlug]) map[item.modelSlug] = []
+      map[item.modelSlug].push(item)
+    }
+    return map
+  }, [sorted])
+
   const visible = React.useMemo(
     () =>
       sorted.filter(
@@ -155,6 +164,27 @@ export default function CostScoreChart({
               fill={PROVIDER_COLORS[provider]}
             />
           ))}
+
+          {Object.entries(modelGroups).map(([model, data]) =>
+            data.length > 1 ? (
+              <Scatter
+                key={`line-${model}`}
+                data={data.map((d) =>
+                  showDeprecated || !d.deprecated
+                    ? showIncomplete ||
+                      (Object.keys(d.benchmarks).length >= MIN_BENCHMARKS &&
+                        countCostBenchmarks(d) >= MIN_COST_BENCHMARKS)
+                      ? d
+                      : { ...d, normalizedCost: NaN, averageScore: NaN }
+                    : { ...d, normalizedCost: NaN, averageScore: NaN },
+                )}
+                name={model}
+                fill={PROVIDER_COLORS[data[0].provider]}
+                line={{ strokeDasharray: "4 4" }}
+                shape={() => null}
+              />
+            ) : null,
+          )}
         </ScatterChart>
       </ChartContainer>
     </div>

--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -43,12 +43,15 @@ export default function CostScoreChart({
 
   const modelGroups = React.useMemo(() => {
     const map: Record<string, LLMData[]> = {}
-    for (const item of sorted) {
+    for (const item of llmData) {
       if (!map[item.modelSlug]) map[item.modelSlug] = []
       map[item.modelSlug].push(item)
     }
+    for (const list of Object.values(map)) {
+      list.sort((a, b) => a.reasoningOrder - b.reasoningOrder)
+    }
     return map
-  }, [sorted])
+  }, [llmData])
 
   const visible = React.useMemo(
     () =>
@@ -180,7 +183,10 @@ export default function CostScoreChart({
                 )}
                 name={model}
                 fill={PROVIDER_COLORS[data[0].provider]}
-                line={{ strokeDasharray: "4 4" }}
+                line={{
+                  strokeDasharray: "4 4",
+                  stroke: PROVIDER_COLORS[data[0].provider],
+                }}
                 shape={() => null}
               />
             ) : null,

--- a/lib/__tests__/data-loader.test.ts
+++ b/lib/__tests__/data-loader.test.ts
@@ -10,6 +10,7 @@ test("transformToTableData converts LLMData objects to table rows", () => {
       slug: "foo",
       model: "Foo",
       provider: "Bar",
+      modelSlug: "foo-model",
       benchmarks: {},
       averageScore: 42,
     },

--- a/lib/__tests__/data-loader.test.ts
+++ b/lib/__tests__/data-loader.test.ts
@@ -11,6 +11,7 @@ test("transformToTableData converts LLMData objects to table rows", () => {
       model: "Foo",
       provider: "Bar",
       modelSlug: "foo-model",
+      reasoningOrder: 0,
       benchmarks: {},
       averageScore: 42,
     },

--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -21,6 +21,7 @@ export interface LLMData {
   model: string
   provider: string
   modelSlug: string
+  reasoningOrder: number
   deprecated?: boolean
   benchmarks: Record<string, BenchmarkResult>
   averageScore?: number
@@ -48,17 +49,18 @@ export async function loadLLMData(): Promise<LLMData[]> {
       const text = await fs.readFile(filePath, "utf8")
       const data = ModelFileSchema.parse(parse(text))
       const modelSlug = file.replace(/\.yaml$/, "")
-      for (const [slug, name] of Object.entries(data.reasoning_efforts)) {
+      Object.entries(data.reasoning_efforts).forEach(([slug, name], index) => {
         llmMap[slug] = {
           slug,
           model: name,
           provider: data.provider,
           modelSlug,
+          reasoningOrder: index,
           ...(data.deprecated ? { deprecated: true } : {}),
           benchmarks: {},
         }
         aliasMap[name] = slug
-      }
+      })
     } catch (error) {
       console.error(`Failed to load model data for ${file}:`, error)
     }

--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -20,6 +20,7 @@ export interface LLMData {
   slug: string
   model: string
   provider: string
+  modelSlug: string
   deprecated?: boolean
   benchmarks: Record<string, BenchmarkResult>
   averageScore?: number
@@ -46,11 +47,13 @@ export async function loadLLMData(): Promise<LLMData[]> {
       const filePath = path.join(modelDir, file)
       const text = await fs.readFile(filePath, "utf8")
       const data = ModelFileSchema.parse(parse(text))
+      const modelSlug = file.replace(/\.yaml$/, "")
       for (const [slug, name] of Object.entries(data.reasoning_efforts)) {
         llmMap[slug] = {
           slug,
           model: name,
           provider: data.provider,
+          modelSlug,
           ...(data.deprecated ? { deprecated: true } : {}),
           benchmarks: {},
         }


### PR DESCRIPTION
## Summary
- track the originating model slug when loading model data
- update unit tests for new property
- group cost-score chart data by model slug and draw dashed lines between reasoning efforts

## Testing
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686da3431df0832097a1c1e450f6133b