### PR TITLE
Add Llama 4 models

### DIFF
--- a/data/mappings/livebench.yaml
+++ b/data/mappings/livebench.yaml
@@ -33,7 +33,7 @@ gpt-4o-2024-11-20: gpt-4o
 grok-3-beta: grok-3
 grok-3-mini-beta-high: grok-3-mini-high
 hunyuan-turbos-20250313: null
-llama4-maverick-instruct-basic: null
+llama4-maverick-instruct-basic: llama-4-maverick
 mistral-large-2411: null
 mistral-medium-2505: null
 mistral-small-2503: null

--- a/data/mappings/lmarena-text.yaml
+++ b/data/mappings/lmarena-text.yaml
@@ -123,8 +123,8 @@ llama-3.2-1b-instruct: null
 llama-3.2-3b-instruct: null
 llama-3.3-70b-instruct: null
 llama-3.3-nemotron-49b-super-v1: null
-llama-4-maverick-17b-128e-instruct: null
-llama-4-scout-17b-16e-instruct: null
+llama-4-maverick-17b-128e-instruct: llama-4-maverick
+llama-4-scout-17b-16e-instruct: llama-4-scout
 llama2-70b-steerlm-chat: null
 magistral-medium-2506: null
 minimax-m1: null

--- a/data/models/llama-4-maverick.yaml
+++ b/data/models/llama-4-maverick.yaml
@@ -1,0 +1,3 @@
+provider: Meta
+reasoning_efforts:
+  llama-4-maverick: Llama 4 Maverick

--- a/data/models/llama-4-scout.yaml
+++ b/data/models/llama-4-scout.yaml
@@ -1,0 +1,3 @@
+provider: Meta
+reasoning_efforts:
+  llama-4-scout: Llama 4 Scout

--- a/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
+++ b/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
@@ -22,7 +22,7 @@
   slug: o3-medium
   model: o3 (medium)
   provider: OpenAI
-  averageScore: 83.77
+  averageScore: 83.78
   costPerTask: 1.01
   costBenchmarkCount: 4
   benchmarkCount: 8
@@ -52,7 +52,7 @@
   slug: deepseek-r1-0528
   model: DeepSeek R1 (05/28)
   provider: DeepSeek
-  averageScore: 63.85
+  averageScore: 63.88
   costPerTask: 0.28
   costBenchmarkCount: 4
   benchmarkCount: 8
@@ -72,7 +72,7 @@
   slug: gemini-2.5-flash-0520-thinking
   model: Gemini 2.5 Flash 05-20 (thinking)
   provider: Google
-  averageScore: 59.43
+  averageScore: 59.46
   costPerTask: 0.71
   costBenchmarkCount: 4
   benchmarkCount: 8
@@ -82,7 +82,7 @@
   slug: claude-opus-4-nothinking
   model: Claude 4 Opus (no thinking)
   provider: Anthropic
-  averageScore: 49.36
+  averageScore: 49.38
   costPerTask: 2.01
   costBenchmarkCount: 4
   benchmarkCount: 8


### PR DESCRIPTION
## Summary
- add new model definitions for Llama 4 Maverick and Llama 4 Scout
- map benchmark aliases for these models in livebench and lmarena mappings
- update snapshots

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686dc9b622e88320ae1881ae77007698