### PR TITLE
Add Meta provider color

### DIFF
--- a/lib/provider-colors.ts
+++ b/lib/provider-colors.ts
@@ -3,7 +3,8 @@ export const PROVIDER_COLORS: Record<string, string> = {
   OpenAI: "#555555", // dark gray
   Anthropic: "#FF7F40", // burnt orange
   Google: "#34A853", // google green
-  DeepSeek: "#2F88FF", // deepseek blue
+  DeepSeek: "#63A6FF", // lightened deepseek blue
+  Meta: "#1465CE", // slightly darkened Meta blue
   xAI: "#000000", // black
   Qwen: "#7954FF", // purple
 }


### PR DESCRIPTION
## Summary
- add a darkened Meta blue entry to provider colors
- lighten DeepSeek's blue for better contrast

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686dce7dce94832085032cd166b02942