### PR TITLE
Add Claude 3.5 Haiku model mapping

### DIFF
--- a/data/mappings/aider-polyglot.yaml
+++ b/data/mappings/aider-polyglot.yaml
@@ -1,6 +1,6 @@
 chatgpt-4o-latest (2025-02-15): null
 chatgpt-4o-latest (2025-03-29): null
-claude-3-5-haiku-20241022: null
+claude-3-5-haiku-20241022: claude-3.5-haiku
 claude-3-5-sonnet-20241022: null
 claude-3-7-sonnet-20250219 (32k thinking tokens): null
 claude-3-7-sonnet-20250219 (no thinking): null

--- a/data/mappings/artificial-analysis.yaml
+++ b/data/mappings/artificial-analysis.yaml
@@ -6,7 +6,7 @@ Claude 2.1: null
 Claude 3 Haiku: null
 Claude 3 Opus: null
 Claude 3 Sonnet: null
-Claude 3.5 Haiku: null
+Claude 3.5 Haiku: claude-3.5-haiku
 Claude 3.5 Sonnet (June): null
 Claude 3.5 Sonnet (Oct): null
 Claude 3.7 Sonnet: null

--- a/data/mappings/livebench.yaml
+++ b/data/mappings/livebench.yaml
@@ -1,5 +1,5 @@
 chatgpt-4o-latest-2025-03-27: null
-claude-3-5-haiku-20241022: null
+claude-3-5-haiku-20241022: claude-3.5-haiku
 claude-3-5-sonnet-20241022: null
 claude-3-7-sonnet-20250219-base: null
 claude-3-7-sonnet-20250219-thinking-64k: null

--- a/data/mappings/lmarena-text.yaml
+++ b/data/mappings/lmarena-text.yaml
@@ -11,7 +11,7 @@ chatglm-6b: null
 chatglm2-6b: null
 chatglm3-6b: null
 chatgpt-4o-latest-20250326: null
-claude-3-5-haiku-20241022: null
+claude-3-5-haiku-20241022: claude-3.5-haiku
 claude-3-5-sonnet-20240620: null
 claude-3-5-sonnet-20241022: null
 claude-3-7-sonnet-20250219: null

--- a/data/models/claude-3.5-haiku.yaml
+++ b/data/models/claude-3.5-haiku.yaml
@@ -1,0 +1,3 @@
+provider: Anthropic
+reasoning_efforts:
+  claude-3.5-haiku: Claude 3.5 Haiku

--- a/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
+++ b/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
@@ -12,7 +12,7 @@
   slug: gemini-2.5-pro-06-05
   model: Gemini 2.5 Pro 06/05
   provider: Google
-  averageScore: 87.59
+  averageScore: 87.78
   costPerTask: 2.19
   costBenchmarkCount: 4
   benchmarkCount: 9
@@ -22,7 +22,7 @@
   slug: o3-medium
   model: o3 (medium)
   provider: OpenAI
-  averageScore: 84.05
+  averageScore: 84.36
   costPerTask: 1.01
   costBenchmarkCount: 4
   benchmarkCount: 8
@@ -32,7 +32,7 @@
   slug: o4-mini-high
   model: o4-mini (high)
   provider: OpenAI
-  averageScore: 80.66
+  averageScore: 81.35
   costPerTask: 1.4
   costBenchmarkCount: 4
   benchmarkCount: 8
@@ -42,7 +42,7 @@
   slug: claude-opus-4-thinking
   model: Claude 4 Opus (thinking)
   provider: Anthropic
-  averageScore: 79.09
+  averageScore: 80.01
   costPerTask: 4.6
   costBenchmarkCount: 4
   benchmarkCount: 8
@@ -52,7 +52,7 @@
   slug: claude-sonnet-4-thinking
   model: Claude 4 Sonnet (thinking)
   provider: Anthropic
-  averageScore: 64.1
+  averageScore: 65.91
   costPerTask: 1.23
   costBenchmarkCount: 4
   benchmarkCount: 8
@@ -62,7 +62,7 @@
   slug: deepseek-r1-0528
   model: DeepSeek R1 05/28
   provider: DeepSeek
-  averageScore: 63.88
+  averageScore: 64.61
   costPerTask: 0.28
   costBenchmarkCount: 4
   benchmarkCount: 8
@@ -72,7 +72,7 @@
   slug: gemini-2.5-flash-0520-thinking
   model: Gemini 2.5 Flash 05/20 (thinking)
   provider: Google
-  averageScore: 59.31
+  averageScore: 60.47
   costPerTask: 0.62
   costBenchmarkCount: 4
   benchmarkCount: 8
@@ -82,19 +82,19 @@
   slug: claude-opus-4-nothinking
   model: Claude 4 Opus (no thinking)
   provider: Anthropic
-  averageScore: 51.02
+  averageScore: 53.4
   costPerTask: 2.03
   costBenchmarkCount: 4
   benchmarkCount: 8
   totalBenchmarks: 9
   totalCostBenchmarks: 4
-- id: claude-sonnet-4-nothinking
-  slug: claude-sonnet-4-nothinking
-  model: Claude 4 Sonnet (no thinking)
-  provider: Anthropic
-  averageScore: 42.34
-  costPerTask: 0.44
+- id: gemini-2.5-flash-0520-nothinking
+  slug: gemini-2.5-flash-0520-nothinking
+  model: Gemini 2.5 Flash 05/20 (no thinking)
+  provider: Google
+  averageScore: 46.42
+  costPerTask: 0.09
   costBenchmarkCount: 4
-  benchmarkCount: 8
+  benchmarkCount: 5
   totalBenchmarks: 9
   totalCostBenchmarks: 4


### PR DESCRIPTION
## Summary
- add `claude-3.5-haiku` model file
- map `claude-3-5-haiku-20241022` and `Claude 3.5 Haiku` aliases to the new slug across the mappings
- update snapshots

## Testing
- `npx --yes pnpm prettier`
- `npx --yes pnpm lint`
- `npx --yes pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686ddaf868908320b610afb4c38ce0d4