### PR TITLE
Fix scrape workflow missing Playwright browsers

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           node-version: 20
           cache: "pnpm"
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install
       - name: Run scraping scripts
         run: |
           pnpm scrape:livebench


### PR DESCRIPTION
## Summary
- add a step to install Playwright browsers so scraping scripts can run

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686efdfb02fc8320b5f5d88088274e2e