### PR TITLE
Fix scrape workflow label permission

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2


### PR DESCRIPTION
## Summary
- allow GitHub Actions scrape job to create labels

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686f0e7ee4ec8320a9e6ada507e1e1b3