### PR TITLE
Improve data-loader calculation readability

### DIFF
--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -30,6 +30,125 @@ export interface LLMData {
   normalizedCost?: number
 }
 
+type BenchmarkStats = Record<string, { min: number; max: number }>
+
+/**
+ * Scan benchmark results to find the min and max score for each benchmark.
+ */
+function collectScoreRanges(llmMap: Record<string, LLMData>): BenchmarkStats {
+  const stats: BenchmarkStats = {}
+  for (const llm of Object.values(llmMap)) {
+    for (const [name, result] of Object.entries(llm.benchmarks)) {
+      const s = stats[name] ?? {
+        min: Number.POSITIVE_INFINITY,
+        max: Number.NEGATIVE_INFINITY,
+      }
+      s.min = Math.min(s.min, result.score)
+      s.max = Math.max(s.max, result.score)
+      stats[name] = s
+    }
+  }
+  return stats
+}
+
+/**
+ * Normalise each benchmark score using min-max scaling and compute the
+ * weighted average for every model.
+ */
+function applyScoreNormalization(
+  llmMap: Record<string, LLMData>,
+  stats: BenchmarkStats,
+): LLMData[] {
+  return Object.values(llmMap).map((llm) => {
+    const weighted: { value: number; weight: number }[] = []
+    for (const [name, result] of Object.entries(llm.benchmarks)) {
+      const { min, max } = stats[name]
+      let value = 1
+      if (max !== min) {
+        value = (result.score - min) / (max - min)
+      }
+      result.normalizedScore = value * 100
+      weighted.push({ value, weight: result.scoreWeight })
+    }
+    const totalWeight = weighted.reduce((s, n) => s + n.weight, 0)
+    llm.averageScore =
+      (weighted.reduce((sum, n) => sum + n.value * n.weight, 0) /
+        (totalWeight || 1)) *
+      100
+    return llm
+  })
+}
+
+/**
+ * Determine a cost normalisation factor for each benchmark by comparing models
+ * that appear in multiple cost benchmarks. Each factor is the inverse of the
+ * average cost across overlapping models.
+ */
+function computeCostFactors(
+  benchmarkCostMap: Record<string, Record<string, number>>,
+): Record<string, number> {
+  const costBenchmarks = Object.keys(benchmarkCostMap)
+  const benchmarkSets: Record<string, Set<string>> = {}
+  for (const b of costBenchmarks) {
+    benchmarkSets[b] = new Set(Object.keys(benchmarkCostMap[b]))
+  }
+
+  const overlapping = costBenchmarks.filter((b) =>
+    costBenchmarks.some(
+      (other) =>
+        other !== b &&
+        [...benchmarkSets[b]].some((m) => benchmarkSets[other].has(m)),
+    ),
+  )
+
+  let intersection = new Set<string>()
+  if (overlapping.length > 0) {
+    intersection = new Set(benchmarkSets[overlapping[0]])
+    for (const b of overlapping.slice(1)) {
+      intersection = new Set(
+        [...intersection].filter((m) => benchmarkSets[b].has(m)),
+      )
+    }
+  }
+
+  const factors: Record<string, number> = {}
+  if (intersection.size > 0) {
+    for (const b of overlapping) {
+      const values = [...intersection].map((m) => benchmarkCostMap[b][m])
+      const mean = values.reduce((sum, c) => sum + c, 0) / (values.length || 1)
+      if (mean > 0) {
+        factors[b] = 1 / mean
+      }
+    }
+  }
+  return factors
+}
+
+/**
+ * Apply cost normalisation factors to each model and compute a weighted average
+ * cost. Models without cost benchmarks remain unaffected.
+ */
+function applyCostNormalization(
+  llms: LLMData[],
+  factors: Record<string, number>,
+): void {
+  for (const llm of llms) {
+    const costs: { value: number; weight: number }[] = []
+    for (const [b, res] of Object.entries(llm.benchmarks)) {
+      const factor = factors[b]
+      if (res.costPerTask && factor) {
+        res.normalizedCost = res.costPerTask * factor
+        costs.push({ value: res.normalizedCost, weight: res.costWeight })
+      }
+    }
+    if (costs.length > 0) {
+      const totalWeight = costs.reduce((s, c) => s + c.weight, 0)
+      llm.normalizedCost =
+        costs.reduce((s, c) => s + c.value * c.weight, 0) / (totalWeight || 1)
+    }
+  }
+}
+
 export async function loadLLMData(): Promise<LLMData[]> {
   const modelDir = path.join(process.cwd(), "data", "models")
   const benchmarkDir = path.join(process.cwd(), "data", "benchmarks")
@@ -124,91 +243,11 @@ export async function loadLLMData(): Promise<LLMData[]> {
     }
   }
 
-  // Determine the min and max score for each benchmark across all models
-  const benchmarkStats: Record<string, { min: number; max: number }> = {}
-  for (const llm of Object.values(llmMap)) {
-    for (const [name, result] of Object.entries(llm.benchmarks)) {
-      const stats = benchmarkStats[name] ?? {
-        min: Number.POSITIVE_INFINITY,
-        max: Number.NEGATIVE_INFINITY,
-      }
-      stats.min = Math.min(stats.min, result.score)
-      stats.max = Math.max(stats.max, result.score)
-      benchmarkStats[name] = stats
-    }
-  }
+  const benchmarkStats = collectScoreRanges(llmMap)
+  const results = applyScoreNormalization(llmMap, benchmarkStats)
 
-  // Compute each model's average using min-max normalised scores
-  const results = Object.values(llmMap).map((llm) => {
-    const norm = Object.entries(llm.benchmarks).map(([name, result]) => {
-      const { min, max } = benchmarkStats[name]
-      let value = 1
-      if (max !== min) {
-        value = (result.score - min) / (max - min)
-      }
-      result.normalizedScore = value * 100
-      const w = result.scoreWeight
-      return { value, weight: w }
-    })
-    const totalWeight = norm.reduce((s, n) => s + n.weight, 0)
-    llm.averageScore =
-      (norm.reduce((sum, n) => sum + n.value * n.weight, 0) /
-        (totalWeight || 1)) *
-      100
-    return llm
-  })
-
-  // compute normalization factors for benchmark costs
-  const costBenchmarks = Object.keys(benchmarkCostMap)
-  const benchmarkSets: Record<string, Set<string>> = {}
-  for (const b of costBenchmarks) {
-    benchmarkSets[b] = new Set(Object.keys(benchmarkCostMap[b]))
-  }
-  const overlapping = costBenchmarks.filter((b) =>
-    costBenchmarks.some(
-      (other) =>
-        other !== b &&
-        [...benchmarkSets[b]].some((m) => benchmarkSets[other].has(m)),
-    ),
-  )
-  let intersection = new Set<string>()
-  if (overlapping.length > 0) {
-    intersection = new Set(benchmarkSets[overlapping[0]])
-    for (const b of overlapping.slice(1)) {
-      intersection = new Set(
-        [...intersection].filter((m) => benchmarkSets[b].has(m)),
-      )
-    }
-  }
-
-  const normalizationFactors: Record<string, number> = {}
-  if (intersection.size > 0) {
-    for (const b of overlapping) {
-      const values = [...intersection].map((m) => benchmarkCostMap[b][m])
-      const mean = values.reduce((sum, c) => sum + c, 0) / (values.length || 1)
-      if (mean > 0) {
-        normalizationFactors[b] = 1 / mean
-      }
-    }
-  }
-
-  // apply normalization factors and compute per-model averages
-  for (const llm of results) {
-    const costs: { value: number; weight: number }[] = []
-    for (const [b, res] of Object.entries(llm.benchmarks)) {
-      const factor = normalizationFactors[b]
-      if (res.costPerTask && factor) {
-        res.normalizedCost = res.costPerTask * factor
-        const w = res.costWeight
-        costs.push({ value: res.normalizedCost, weight: w })
-      }
-    }
-    if (costs.length > 0) {
-      const totalWeight = costs.reduce((s, c) => s + c.weight, 0)
-      llm.normalizedCost =
-        costs.reduce((s, c) => s + c.value * c.weight, 0) / (totalWeight || 1)
-    }
-  }
+  const normalizationFactors = computeCostFactors(benchmarkCostMap)
+  applyCostNormalization(results, normalizationFactors)
 
   return results.sort((a, b) => (b.averageScore || 0) - (a.averageScore || 0))
 }


### PR DESCRIPTION
## Summary
- refactor calculation logic in `lib/data-loader.ts`
- split score and cost normalization into helper functions with clear comments

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686f8670338083209b9e687d495f1ee4