### PR TITLE
Fix about link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This project aggregates scores from popular large language model benchmarks into
 
 The goal is to provide a clear comparison of how leading models perform across different tasks. Benchmark results are scraped from official leaderboards, normalized, and averaged so that each benchmark contributes equally to the overall ranking.
 
-Visit `/about` for more details on the methodology.
+Visit the [About page](https://all-the-benchmarks.vercel.app/about) for more details on the methodology.


### PR DESCRIPTION
## Summary
- link directly to the hosted about page in the README using markdown link syntax

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686f8baf38888320a6e473d8386463ae