### PR TITLE
use explicit mappings only for benchmark match

### DIFF
--- a/lib/__tests__/explicit-mapping.test.ts
+++ b/lib/__tests__/explicit-mapping.test.ts
@@ -1,0 +1,63 @@
+import { loadLLMData } from "../data-loader"
+import { expect, test } from "vitest"
+import fs from "fs/promises"
+import path from "path"
+import os from "os"
+import { stringify } from "yaml"
+
+// Regression test ensuring benchmark results are only matched via explicit mappings
+
+test("loadLLMData ignores unmapped slugs", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "mapping-"))
+  await fs.mkdir(path.join(tmp, "data", "models"), { recursive: true })
+  await fs.mkdir(path.join(tmp, "data", "benchmarks"), { recursive: true })
+  await fs.mkdir(path.join(tmp, "data", "mappings"), { recursive: true })
+
+  await fs.writeFile(
+    path.join(tmp, "data", "models", "model.yaml"),
+    stringify({
+      provider: "Test",
+      reasoning_efforts: { "model-a": "Model A" },
+    }),
+  )
+
+  await fs.writeFile(
+    path.join(tmp, "data", "mappings", "map.yaml"),
+    stringify({ A: "model-a" }),
+  )
+
+  await fs.writeFile(
+    path.join(tmp, "data", "benchmarks", "bench.yaml"),
+    stringify({
+      benchmark: "bench",
+      description: "bench",
+      score_weight: 1,
+      cost_weight: 1,
+      results: { A: 1, "model-a": 2 },
+      model_name_mapping_file: "map.yaml",
+    }),
+  )
+
+  await fs.writeFile(
+    path.join(tmp, "data", "benchmarks", "other.yaml"),
+    stringify({
+      benchmark: "other",
+      description: "other",
+      score_weight: 1,
+      cost_weight: 1,
+      results: { "model-a": 5 },
+      model_name_mapping_file: "map.yaml",
+    }),
+  )
+
+  const cwd = process.cwd()
+  process.chdir(tmp)
+  try {
+    const llms = await loadLLMData()
+    const model = llms.find((m) => m.slug === "model-a")
+    expect(model?.benchmarks["bench"]?.score).toBe(1)
+    expect(model?.benchmarks["other"]?.score).toBeUndefined()
+  } finally {
+    process.chdir(cwd)
+  }
+})

--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -180,7 +180,6 @@ export async function loadLLMData(): Promise<LLMData[]> {
           ...(data.deprecated ? { deprecated: true } : {}),
           benchmarks: {},
         }
-        aliasMap[name] = slug
       })
     } catch (error) {
       console.error(`Failed to load model data for ${file}:`, error)
@@ -217,7 +216,8 @@ export async function loadLLMData(): Promise<LLMData[]> {
       }
       const costMap = data.cost_per_task || {}
       for (const [rawName, score] of Object.entries(data.results)) {
-        const mappedSlug = aliasMap[rawName] || rawName
+        const mappedSlug = aliasMap[rawName]
+        if (!mappedSlug) continue
         const llm = llmMap[mappedSlug]
         if (llm) {
           const hasCost = costMap[rawName] && costMap[rawName] > 0


### PR DESCRIPTION
## Summary
- only map benchmark results to models via explicit mappings
- add regression test for ignoring unmapped slugs and benchmarks

## Testing
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686f968581d4832098ad0536ef0210c0