### PR TITLE
Add WeirdML benchmark scraper

### DIFF
--- a/data/benchmarks/weirdml.yaml
+++ b/data/benchmarks/weirdml.yaml
@@ -1,0 +1,49 @@
+benchmark: WeirdML
+description: Average accuracy across WeirdML tasks
+score_weight: 1
+cost_weight: 1
+results:
+  o3-pro-2025-06-10 (high): 53.95
+  gemini-2.5-pro (thinking 16k): 50.3
+  o3-2025-04-16 (high): 49.76
+  o4-mini-2025-04-16 (high): 49.17
+  claude-4-sonnet-20250522 (thinking 16k): 45.28
+  claude-4-sonnet-20250522 (no thinking): 43
+  claude-4-opus-20250522 (thinking 16k): 42.12
+  deepseek-r1-0528: 40.88
+  claude-3.6-sonnet: 39.78
+  grok-3-mini (high): 39.58
+  gemini-2.5-flash (thinking 16k): 38.73
+  gpt-4.1-2025-04-14: 37.88
+  gpt-4.5-preview: 37.65
+  gpt-4.1-mini-2025-04-14: 37.25
+  grok-3: 36.44
+  qwen3-235b-a22b (thinking): 35.88
+  deepseek-v3-0324: 35.09
+  gemini-2.5-flash-lite-preview-06-17 (thinking 16k): 33.89
+  qwen3-30b-a3b (thinking): 29.74
+  llama-4-maverick: 23.62
+  gpt-4.1-nano-2025-04-14: 19.04
+model_name_mapping_file: weirdml.yaml
+cost_per_task:
+  o3-pro-2025-06-10 (high): 5.228346341463415
+  gemini-2.5-pro (thinking 16k): 0.8231632972631578
+  o3-2025-04-16 (high): 0.4637190857142856
+  o4-mini-2025-04-16 (high): 0.38685772040816335
+  claude-4-sonnet-20250522 (thinking 16k): 0.667855163265306
+  claude-4-sonnet-20250522 (no thinking): 0.6080159361702129
+  claude-4-opus-20250522 (thinking 16k): 3.3979484210526314
+  deepseek-r1-0528: 0.1420080642105263
+  claude-3.6-sonnet: 0.4931495368421054
+  grok-3-mini (high): 0.034985129999999996
+  gemini-2.5-flash (thinking 16k): 0.21184530736842108
+  gpt-4.1-2025-04-14: 0.19657672340425536
+  gpt-4.5-preview: 3.1601368421052634
+  gpt-4.1-mini-2025-04-14: 0.03296698105263158
+  grok-3: 0.5004218315789474
+  qwen3-235b-a22b (thinking): 0.041392278230088494
+  deepseek-v3-0324: 0.027581991999999996
+  gemini-2.5-flash-lite-preview-06-17 (thinking 16k): 0.060986399999999996
+  qwen3-30b-a3b (thinking): 0.016747094143646408
+  llama-4-maverick: 0.012274920000000002
+  gpt-4.1-nano-2025-04-14: 0.005178074782608696

--- a/data/mappings/weirdml.yaml
+++ b/data/mappings/weirdml.yaml
@@ -1,0 +1,21 @@
+claude-3.6-sonnet: null
+claude-4-opus-20250522 (thinking 16k): null
+claude-4-sonnet-20250522 (no thinking): null
+claude-4-sonnet-20250522 (thinking 16k): null
+deepseek-r1-0528: null
+deepseek-v3-0324: null
+gemini-2.5-flash (thinking 16k): null
+gemini-2.5-flash-lite-preview-06-17 (thinking 16k): null
+gemini-2.5-pro (thinking 16k): null
+gpt-4.1-2025-04-14: null
+gpt-4.1-mini-2025-04-14: null
+gpt-4.1-nano-2025-04-14: null
+gpt-4.5-preview: null
+grok-3: null
+grok-3-mini (high): null
+llama-4-maverick: null
+o3-2025-04-16 (high): null
+o3-pro-2025-06-10 (high): null
+o4-mini-2025-04-16 (high): null
+qwen3-235b-a22b (thinking): null
+qwen3-30b-a3b (thinking): null

--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -211,7 +211,7 @@ export async function loadLLMData(): Promise<LLMData[]> {
 
       if (mapping) {
         for (const [alias, slugName] of Object.entries(mapping)) {
-          if (slugName) aliasMap[alias] = slugName
+          aliasMap[alias] = slugName
         }
       }
       const costMap = data.cost_per_task || {}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "scrape:hle": "tsx scripts/scrape_hle.ts",
     "scrape:gpqa-diamond": "tsx scripts/scrape_gpqa_diamond.ts",
     "scrape:artificial-analysis-index": "tsx scripts/scrape_artificial_analysis_index.ts",
+    "scrape:weirdml": "tsx scripts/scrape_weirdml.ts",
     "scrape:all": "tsx scripts/scrape_all.ts",
     "start": "next start"
   },

--- a/scripts/scrape_all.ts
+++ b/scripts/scrape_all.ts
@@ -9,6 +9,7 @@ const scripts = [
   "scrape:hle",
   "scrape:gpqa-diamond",
   "scrape:artificial-analysis-index",
+  "scrape:weirdml",
 ]
 
 for (const script of scripts) {

--- a/scripts/scrape_weirdml.ts
+++ b/scripts/scrape_weirdml.ts
@@ -1,0 +1,55 @@
+import path from "path"
+import { fileURLToPath } from "url"
+import { curl, saveBenchmarkResults } from "./utils"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+interface Row {
+  [column: string]: string
+}
+
+function parseCSV(text: string): Row[] {
+  const lines = text.trim().split(/\r?\n/)
+  const header = lines[0].split(",")
+  return lines.slice(1).map((line) => {
+    const values = line.split(",")
+    const row: Row = {}
+    header.forEach((h, i) => {
+      row[h] = values[i]
+    })
+    return row
+  })
+}
+
+async function main(): Promise<void> {
+  const csv = curl("https://htihle.github.io/data/weirdml_data.csv")
+  const rows = parseCSV(csv)
+  const results: Record<string, number> = {}
+  const costPerTask: Record<string, number> = {}
+
+  for (const row of rows) {
+    const name = row["display_name"]
+    const acc = parseFloat(row["avg_acc"])
+    const cost = parseFloat(row["cost_per_run_usd"])
+    if (!Number.isNaN(acc)) {
+      results[name] = Math.round(acc * 10000) / 100
+    }
+    if (!Number.isNaN(cost)) {
+      costPerTask[name] = cost
+    }
+  }
+
+  const outPath = path.join(
+    __dirname,
+    "..",
+    "data",
+    "benchmarks",
+    "weirdml.yaml",
+  )
+  await saveBenchmarkResults(outPath, results, costPerTask)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add `scrape_weirdml.ts` for parsing WeirdML leaderboard
- include weirdml results and mapping data
- register script in `package.json` and `scrape_all.ts`
- update snapshots
- support null overrides in mapping merge to avoid cross-benchmark leaks

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686f9b1491088320ab08452c36f76696