### PR TITLE
Add guard against empty benchmark saves

### DIFF
--- a/scripts/__tests__/save-benchmark-results.test.ts
+++ b/scripts/__tests__/save-benchmark-results.test.ts
@@ -1,0 +1,64 @@
+import { saveBenchmarkResults } from "../utils"
+import fs from "fs/promises"
+import path from "path"
+import os from "os"
+import { stringify } from "yaml"
+import YAML from "yaml"
+import { expect, test, vi } from "vitest"
+
+async function setupFile() {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "savebench-"))
+  await fs.mkdir(path.join(tmp, "data", "benchmarks"), { recursive: true })
+  await fs.mkdir(path.join(tmp, "data", "mappings"), { recursive: true })
+  const benchPath = path.join(tmp, "data", "benchmarks", "test.yaml")
+  const mapPath = path.join(tmp, "data", "mappings", "map.yaml")
+  await fs.writeFile(
+    benchPath,
+    stringify({
+      benchmark: "test",
+      description: "test",
+      score_weight: 1,
+      cost_weight: 1,
+      results: { A: 1 },
+      model_name_mapping_file: "map.yaml",
+      cost_per_task: { A: 0.1 },
+    }),
+  )
+  await fs.writeFile(mapPath, stringify({ A: null }))
+  return { tmp, benchPath }
+}
+
+test("does not overwrite scores with empty object", async () => {
+  const { tmp, benchPath } = await setupFile()
+  const cwd = process.cwd()
+  process.chdir(tmp)
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+  try {
+    await saveBenchmarkResults(benchPath, {})
+    const contents = await fs.readFile(benchPath, "utf8")
+    const data = YAML.parse(contents)
+    expect(Object.keys(data.results)).toEqual(["A"]) // unchanged
+    expect(warn).toHaveBeenCalled()
+  } finally {
+    process.chdir(cwd)
+    warn.mockRestore()
+  }
+})
+
+test("does not overwrite costs with empty object", async () => {
+  const { tmp, benchPath } = await setupFile()
+  const cwd = process.cwd()
+  process.chdir(tmp)
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+  try {
+    await saveBenchmarkResults(benchPath, { A: 2 }, {})
+    const contents = await fs.readFile(benchPath, "utf8")
+    const data = YAML.parse(contents)
+    expect(data.cost_per_task.A).toBe(0.1) // unchanged
+    expect(data.results.A).toBe(1) // no update either
+    expect(warn).toHaveBeenCalled()
+  } finally {
+    process.chdir(cwd)
+    warn.mockRestore()
+  }
+})

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -31,6 +31,24 @@ export async function saveBenchmarkResults(
     if (err.code !== "ENOENT") throw err
   }
 
+  const existingResults = yamlObj.results as Record<string, number> | undefined
+  const existingCosts = yamlObj.cost_per_task as
+    | Record<string, number>
+    | undefined
+  const resultsEmpty = !results || Object.keys(results).length === 0
+  const costsEmpty =
+    costPerTask === undefined || Object.keys(costPerTask).length === 0
+
+  if (
+    (resultsEmpty &&
+      existingResults &&
+      Object.keys(existingResults).length > 0) ||
+    (costsEmpty && existingCosts && Object.keys(existingCosts).length > 0)
+  ) {
+    console.warn(`Skipping update for ${outPath} because new data is empty`)
+    return
+  }
+
   yamlObj.results = results
   if (costPerTask && Object.keys(costPerTask).length > 0) {
     yamlObj.cost_per_task = costPerTask


### PR DESCRIPTION
## Summary
- prevent overwriting benchmark YAML with empty results or costs
- add tests for saveBenchmarkResults

## Testing
- `pnpm test:update`

------
https://chatgpt.com/codex/tasks/task_e_686fa0bdb81c8320a4771dc77afdb952