### PR TITLE
Add deepseek v3 mappings

### DIFF
--- a/data/mappings/aider-polyglot.yaml
+++ b/data/mappings/aider-polyglot.yaml
@@ -11,11 +11,11 @@ claude-sonnet-4-20250514 (no thinking): claude-sonnet-4-nothinking
 Codestral 25.01: null
 command-a-03-2025-quality: null
 DeepSeek Chat V2.5: null
-DeepSeek Chat V3 (prev): null
+DeepSeek Chat V3 (prev): deepseek-v3-1224
 DeepSeek R1: deepseek-r1-0120
 DeepSeek R1 (0528): deepseek-r1-0528
 DeepSeek R1 + claude-3-5-sonnet-20241022: null
-DeepSeek V3 (0324): null
+DeepSeek V3 (0324): deepseek-v3-0324
 Gemini 2.0 Pro exp-02-05: null
 Gemini 2.5 Pro Preview 03-25: gemini-2.5-pro-preview-03-25
 Gemini 2.5 Pro Preview 05-06: gemini-2.5-pro-preview-05-06

--- a/data/mappings/artificial-analysis.yaml
+++ b/data/mappings/artificial-analysis.yaml
@@ -37,8 +37,8 @@ DeepSeek R1 Distill Llama 8B: null
 DeepSeek R1 Distill Qwen 1.5B: null
 DeepSeek R1 Distill Qwen 14B: null
 DeepSeek R1 Distill Qwen 32B: null
-DeepSeek V3 (Dec '24): null
-DeepSeek V3 0324 (Mar '25): null
+DeepSeek V3 (Dec '24): deepseek-v3-1224
+DeepSeek V3 0324 (Mar '25): deepseek-v3-0324
 DeepSeek-Coder-V2: null
 DeepSeek-V2: null
 DeepSeek-V2.5: null

--- a/data/mappings/livebench.yaml
+++ b/data/mappings/livebench.yaml
@@ -14,7 +14,7 @@ deepseek-r1: deepseek-r1-0120
 deepseek-r1-0528: deepseek-r1-0528
 deepseek-r1-distill-llama-70b: null
 deepseek-r1-distill-qwen-32b: null
-deepseek-v3-0324: null
+deepseek-v3-0324: deepseek-v3-0324
 gemini-2.0-flash-lite-001: null
 gemini-2.5-flash-lite-preview-06-17-highthinking: null
 gemini-2.5-flash-preview-05-20: gemini-2.5-flash-0520-thinking

--- a/data/mappings/lmarena-text.yaml
+++ b/data/mappings/lmarena-text.yaml
@@ -46,8 +46,8 @@ deepseek-r1-0528: deepseek-r1-0528
 deepseek-v2-api-0628: null
 deepseek-v2.5: null
 deepseek-v2.5-1210: null
-deepseek-v3: null
-deepseek-v3-0324: null
+deepseek-v3: deepseek-v3-1224
+deepseek-v3-0324: deepseek-v3-0324
 dolly-v2-12b: null
 dolphin-2.2.1-mistral-7b: null
 early-grok-3: grok-3

--- a/data/mappings/simplebench.yaml
+++ b/data/mappings/simplebench.yaml
@@ -8,8 +8,8 @@ Claude 4 Sonnet (thinking): claude-sonnet-4-thinking
 Command R+: null
 DeepSeek R1: deepseek-r1-0120
 DeepSeek R1 05/28: deepseek-r1-0528
-DeepSeek V3: null
-DeepSeek V3 03-24: null
+DeepSeek V3: deepseek-v3-1224
+DeepSeek V3 03-24: deepseek-v3-0324
 Gemini 1.5 Pro 002: null
 Gemini 2.0 Flash Exp: null
 Gemini 2.0 Flash Thinking: null

--- a/data/mappings/weirdml.yaml
+++ b/data/mappings/weirdml.yaml
@@ -3,7 +3,7 @@ claude-4-opus-20250522 (thinking 16k): claude-opus-4-thinking
 claude-4-sonnet-20250522 (no thinking): claude-sonnet-4-nothinking
 claude-4-sonnet-20250522 (thinking 16k): claude-sonnet-4-thinking
 deepseek-r1-0528: deepseek-r1-0528
-deepseek-v3-0324: null
+deepseek-v3-0324: deepseek-v3-0324
 gemini-2.5-flash (thinking 16k): gemini-2.5-flash-0520-thinking
 gemini-2.5-flash-lite-preview-06-17 (thinking 16k): null
 gemini-2.5-pro (thinking 16k): gemini-2.5-pro-06-05

--- a/data/models/deepseek-v3-0324.yaml
+++ b/data/models/deepseek-v3-0324.yaml
@@ -1,0 +1,3 @@
+provider: DeepSeek
+reasoning_efforts:
+  deepseek-v3-0324: DeepSeek V3 03/24

--- a/data/models/deepseek-v3-1224.yaml
+++ b/data/models/deepseek-v3-1224.yaml
@@ -1,0 +1,4 @@
+provider: DeepSeek
+reasoning_efforts:
+  deepseek-v3-1224: DeepSeek V3 12/24
+deprecated: true

--- a/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
+++ b/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
@@ -1,100 +1,100 @@
+- id: o3-pro-high
+  slug: o3-pro-high
+  model: o3-pro (high)
+  provider: OpenAI
+  averageScore: 83.83
+  costPerTask: 12.22
+  costBenchmarkCount: 4
+  benchmarkCount: 5
+  totalBenchmarks: 10
+  totalCostBenchmarks: 5
 - id: o3-high
   slug: o3-high
   model: o3 (high)
   provider: OpenAI
-  averageScore: 90.45
-  costPerTask: 1.72
-  costBenchmarkCount: 3
-  benchmarkCount: 6
-  totalBenchmarks: 9
-  totalCostBenchmarks: 4
+  averageScore: 83.77
+  costPerTask: 1.41
+  costBenchmarkCount: 4
+  benchmarkCount: 7
+  totalBenchmarks: 10
+  totalCostBenchmarks: 5
 - id: gemini-2.5-pro-06-05
   slug: gemini-2.5-pro-06-05
   model: Gemini 2.5 Pro 06/05
   provider: Google
-  averageScore: 87.78
-  costPerTask: 2.19
-  costBenchmarkCount: 4
-  benchmarkCount: 9
-  totalBenchmarks: 9
-  totalCostBenchmarks: 4
+  averageScore: 83.61
+  costPerTask: 1.95
+  costBenchmarkCount: 5
+  benchmarkCount: 10
+  totalBenchmarks: 10
+  totalCostBenchmarks: 5
 - id: o3-medium
   slug: o3-medium
   model: o3 (medium)
   provider: OpenAI
-  averageScore: 82.78
-  costPerTask: 1.01
+  averageScore: 78.36
+  costPerTask: 0.96
   costBenchmarkCount: 4
   benchmarkCount: 8
-  totalBenchmarks: 9
-  totalCostBenchmarks: 4
+  totalBenchmarks: 10
+  totalCostBenchmarks: 5
 - id: o4-mini-high
   slug: o4-mini-high
   model: o4-mini (high)
   provider: OpenAI
-  averageScore: 81.35
-  costPerTask: 1.4
-  costBenchmarkCount: 4
-  benchmarkCount: 8
-  totalBenchmarks: 9
-  totalCostBenchmarks: 4
+  averageScore: 76.09
+  costPerTask: 1.18
+  costBenchmarkCount: 5
+  benchmarkCount: 9
+  totalBenchmarks: 10
+  totalCostBenchmarks: 5
 - id: claude-opus-4-thinking
   slug: claude-opus-4-thinking
   model: Claude 4 Opus (thinking)
   provider: Anthropic
-  averageScore: 80.01
-  costPerTask: 4.6
-  costBenchmarkCount: 4
-  benchmarkCount: 8
-  totalBenchmarks: 9
-  totalCostBenchmarks: 4
+  averageScore: 71.57
+  costPerTask: 4.57
+  costBenchmarkCount: 5
+  benchmarkCount: 9
+  totalBenchmarks: 10
+  totalCostBenchmarks: 5
+- id: grok-3-mini-high
+  slug: grok-3-mini-high
+  model: Grok 3 Mini (high)
+  provider: xAI
+  averageScore: 68.39
+  costPerTask: 0.07
+  costBenchmarkCount: 3
+  benchmarkCount: 5
+  totalBenchmarks: 10
+  totalCostBenchmarks: 5
 - id: deepseek-r1-0528
   slug: deepseek-r1-0528
   model: DeepSeek R1 05/28
   provider: DeepSeek
-  averageScore: 65.94
-  costPerTask: 0.28
-  costBenchmarkCount: 4
-  benchmarkCount: 8
-  totalBenchmarks: 9
-  totalCostBenchmarks: 4
+  averageScore: 63.37
+  costPerTask: 0.26
+  costBenchmarkCount: 5
+  benchmarkCount: 9
+  totalBenchmarks: 10
+  totalCostBenchmarks: 5
 - id: claude-sonnet-4-thinking
   slug: claude-sonnet-4-thinking
   model: Claude 4 Sonnet (thinking)
   provider: Anthropic
-  averageScore: 65.91
-  costPerTask: 1.23
-  costBenchmarkCount: 4
-  benchmarkCount: 8
-  totalBenchmarks: 9
-  totalCostBenchmarks: 4
+  averageScore: 61.79
+  costPerTask: 1.16
+  costBenchmarkCount: 5
+  benchmarkCount: 9
+  totalBenchmarks: 10
+  totalCostBenchmarks: 5
 - id: gemini-2.5-flash-0520-thinking
   slug: gemini-2.5-flash-0520-thinking
   model: Gemini 2.5 Flash 05/20 (thinking)
   provider: Google
-  averageScore: 61.27
-  costPerTask: 0.62
-  costBenchmarkCount: 4
-  benchmarkCount: 8
-  totalBenchmarks: 9
-  totalCostBenchmarks: 4
-- id: claude-opus-4-nothinking
-  slug: claude-opus-4-nothinking
-  model: Claude 4 Opus (no thinking)
-  provider: Anthropic
-  averageScore: 51.39
-  costPerTask: 2.03
-  costBenchmarkCount: 4
-  benchmarkCount: 8
-  totalBenchmarks: 9
-  totalCostBenchmarks: 4
-- id: gemini-2.5-flash-0520-nothinking
-  slug: gemini-2.5-flash-0520-nothinking
-  model: Gemini 2.5 Flash 05/20 (no thinking)
-  provider: Google
-  averageScore: 46.42
-  costPerTask: 0.09
-  costBenchmarkCount: 4
-  benchmarkCount: 5
-  totalBenchmarks: 9
-  totalCostBenchmarks: 4
+  averageScore: 57.59
+  costPerTask: 0.53
+  costBenchmarkCount: 5
+  benchmarkCount: 9
+  totalBenchmarks: 10
+  totalCostBenchmarks: 5


### PR DESCRIPTION
## Summary
- add model definitions for DeepSeek V3 12/24 and 03/24
- map DeepSeek V3 aliases across benchmarks
- update snapshot

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686fa972d10c83209f2fcdc464e72eda