### PR TITLE
Add release_date to model schema

### DIFF
--- a/data/models/grok-4.yaml
+++ b/data/models/grok-4.yaml
@@ -1,3 +1,4 @@
 provider: xAI
+release_date: 2025-07-09
 reasoning_efforts:
   grok-4: Grok 4

--- a/lib/__tests__/data-loader.test.ts
+++ b/lib/__tests__/data-loader.test.ts
@@ -58,3 +58,9 @@ test("loadLLMData marks deprecated models", async () => {
   const deprecated = llmData.find((d) => d.slug === "deepseek-r1-0120")
   expect(deprecated?.deprecated).toBe(true)
 })
+
+test("loadLLMData parses release dates", async () => {
+  const llmData = await loadLLMData()
+  const grok4 = llmData.find((d) => d.slug === "grok-4")
+  expect(grok4?.releaseDate).toEqual(new Date("2025-07-09"))
+})

--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -25,6 +25,7 @@ export interface LLMData {
   modelSlug: string
   reasoningOrder: number
   deprecated?: boolean
+  releaseDate?: Date
   benchmarks: Record<string, BenchmarkResult>
   averageScore?: number
   normalizedCost?: number
@@ -178,6 +179,7 @@ export async function loadLLMData(): Promise<LLMData[]> {
           modelSlug,
           reasoningOrder: index,
           ...(data.deprecated ? { deprecated: true } : {}),
+          ...(data.release_date ? { releaseDate: data.release_date } : {}),
           benchmarks: {},
         }
       })

--- a/lib/yaml-schemas.ts
+++ b/lib/yaml-schemas.ts
@@ -7,6 +7,10 @@ export const ModelFileSchema = z.object({
   provider: z.string(),
   reasoning_efforts: z.record(z.string(), z.string()),
   deprecated: z.boolean().optional(),
+  release_date: z.iso
+    .date()
+    .transform((str) => new Date(str))
+    .optional(),
 })
 export type ModelFile = z.infer<typeof ModelFileSchema>
 


### PR DESCRIPTION
## Summary
- allow optional `release_date` for model files in Zod schema
- expose release dates in loaded model data
- test date parsing in data loader
- note Grok 4 release date in YAML
- parse `release_date` using `z.iso.date`

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_686fde31b8ec8320b98d2d8b2e09f907