### PR TITLE
Show new models regardless of filters

### DIFF
--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -10,6 +10,7 @@ const BASE_TICKS = [0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 1, 3, 10, 30] as const
 
 const MIN_BENCHMARKS = 5
 const MIN_COST_BENCHMARKS = 3
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
 
 function countCostBenchmarks(llm: LLMData) {
   return Object.values(llm.benchmarks).filter(
@@ -55,13 +56,17 @@ export default function CostScoreChart({
 
   const visible = React.useMemo(
     () =>
-      sorted.filter(
-        (m) =>
-          (showDeprecated || !m.deprecated) &&
-          (showIncomplete ||
-            (Object.keys(m.benchmarks).length >= MIN_BENCHMARKS &&
-              countCostBenchmarks(m) >= MIN_COST_BENCHMARKS)),
-      ),
+      sorted.filter((m) => {
+        const isNew =
+          m.releaseDate && Date.now() - m.releaseDate.getTime() < ONE_WEEK_MS
+        return (
+          isNew ||
+          ((showDeprecated || !m.deprecated) &&
+            (showIncomplete ||
+              (Object.keys(m.benchmarks).length >= MIN_BENCHMARKS &&
+                countCostBenchmarks(m) >= MIN_COST_BENCHMARKS)))
+        )
+      }),
     [sorted, showDeprecated, showIncomplete],
   )
 
@@ -154,15 +159,19 @@ export default function CostScoreChart({
           {Object.entries(groups).map(([provider, data]) => (
             <Scatter
               key={provider}
-              data={data.map((d) =>
-                showDeprecated || !d.deprecated
+              data={data.map((d) => {
+                const isNew =
+                  d.releaseDate &&
+                  Date.now() - d.releaseDate.getTime() < ONE_WEEK_MS
+                return showDeprecated || !d.deprecated || isNew
                   ? showIncomplete ||
                     (Object.keys(d.benchmarks).length >= MIN_BENCHMARKS &&
-                      countCostBenchmarks(d) >= MIN_COST_BENCHMARKS)
+                      countCostBenchmarks(d) >= MIN_COST_BENCHMARKS) ||
+                    isNew
                     ? d
                     : { ...d, normalizedCost: NaN, averageScore: NaN }
-                  : { ...d, normalizedCost: NaN, averageScore: NaN },
-              )}
+                  : { ...d, normalizedCost: NaN, averageScore: NaN }
+              })}
               name={provider}
               fill={PROVIDER_COLORS[provider]}
             />
@@ -172,15 +181,19 @@ export default function CostScoreChart({
             data.length > 1 ? (
               <Scatter
                 key={`line-${model}`}
-                data={data.map((d) =>
-                  showDeprecated || !d.deprecated
+                data={data.map((d) => {
+                  const isNew =
+                    d.releaseDate &&
+                    Date.now() - d.releaseDate.getTime() < ONE_WEEK_MS
+                  return showDeprecated || !d.deprecated || isNew
                     ? showIncomplete ||
                       (Object.keys(d.benchmarks).length >= MIN_BENCHMARKS &&
-                        countCostBenchmarks(d) >= MIN_COST_BENCHMARKS)
+                        countCostBenchmarks(d) >= MIN_COST_BENCHMARKS) ||
+                      isNew
                       ? d
                       : { ...d, normalizedCost: NaN, averageScore: NaN }
-                    : { ...d, normalizedCost: NaN, averageScore: NaN },
-                )}
+                    : { ...d, normalizedCost: NaN, averageScore: NaN }
+                })}
                 name={model}
                 fill={PROVIDER_COLORS[data[0].provider]}
                 line={{

--- a/components/leaderboard-section.tsx
+++ b/components/leaderboard-section.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label"
 
 const MIN_BENCHMARKS = 5
 const MIN_COST_BENCHMARKS = 3
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
 
 function countCostBenchmarks(llm: LLMData) {
   return Object.values(llm.benchmarks).filter(
@@ -23,13 +24,17 @@ export default function LeaderboardSection({
 }) {
   const [showDeprecated, setShowDeprecated] = useState(false)
   const [showIncomplete, setShowIncomplete] = useState(false)
-  const visible = llmData.filter(
-    (m) =>
-      (showDeprecated || !m.deprecated) &&
-      (showIncomplete ||
-        (Object.keys(m.benchmarks).length >= MIN_BENCHMARKS &&
-          countCostBenchmarks(m) >= MIN_COST_BENCHMARKS)),
-  )
+  const visible = llmData.filter((m) => {
+    const isNew =
+      m.releaseDate && Date.now() - m.releaseDate.getTime() < ONE_WEEK_MS
+    return (
+      isNew ||
+      ((showDeprecated || !m.deprecated) &&
+        (showIncomplete ||
+          (Object.keys(m.benchmarks).length >= MIN_BENCHMARKS &&
+            countCostBenchmarks(m) >= MIN_COST_BENCHMARKS)))
+    )
+  })
 
   return (
     <div className="space-y-4">

--- a/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
+++ b/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
@@ -1,3 +1,13 @@
+- id: grok-4
+  slug: grok-4
+  model: Grok 4
+  provider: xAI
+  averageScore: 100
+  costPerTask: 4.22
+  costBenchmarkCount: 3
+  benchmarkCount: 4
+  totalBenchmarks: 10
+  totalCostBenchmarks: 5
 - id: o3-pro-high
   slug: o3-pro-high
   model: o3-pro (high)
@@ -84,16 +94,6 @@
   provider: Anthropic
   averageScore: 61.79
   costPerTask: 1.16
-  costBenchmarkCount: 5
-  benchmarkCount: 9
-  totalBenchmarks: 10
-  totalCostBenchmarks: 5
-- id: gemini-2.5-flash-0520-thinking
-  slug: gemini-2.5-flash-0520-thinking
-  model: Gemini 2.5 Flash 05/20 (thinking)
-  provider: Google
-  averageScore: 57.59
-  costPerTask: 0.53
   costBenchmarkCount: 5
   benchmarkCount: 9
   totalBenchmarks: 10

--- a/lib/__tests__/default-leaderboard.snapshot.test.ts
+++ b/lib/__tests__/default-leaderboard.snapshot.test.ts
@@ -10,6 +10,7 @@ import path from "path"
 test("default leaderboard top 10 data", async () => {
   const MIN_BENCHMARKS = 5
   const MIN_COST_BENCHMARKS = 3
+  const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
   function countCostBenchmarks(llm: { benchmarks: Record<string, unknown> }) {
     return Object.values(llm.benchmarks).filter(
       (b) => (b as { normalizedCost?: number }).normalizedCost !== undefined,
@@ -17,9 +18,10 @@ test("default leaderboard top 10 data", async () => {
   }
   const llmData = (await loadLLMData()).filter(
     (m) =>
-      !m.deprecated &&
-      Object.keys(m.benchmarks).length >= MIN_BENCHMARKS &&
-      countCostBenchmarks(m) >= MIN_COST_BENCHMARKS,
+      (m.releaseDate && Date.now() - m.releaseDate.getTime() < ONE_WEEK_MS) ||
+      (!m.deprecated &&
+        Object.keys(m.benchmarks).length >= MIN_BENCHMARKS &&
+        countCostBenchmarks(m) >= MIN_COST_BENCHMARKS),
   )
   const tableRows = transformToTableData(llmData)
     .slice(0, 10)


### PR DESCRIPTION
## Summary
- make cost-score chart and leaderboard ignore filters for models released within the last week
- update snapshot and tests for new leaderboard rule

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`

------
https://chatgpt.com/codex/tasks/task_e_686feb586d988320be463c18660cfcd7