### PR TITLE
Show benchmark summary table

### DIFF
--- a/app/benchmarks/page.tsx
+++ b/app/benchmarks/page.tsx
@@ -2,6 +2,14 @@ import { loadBenchmarks } from "@/lib/benchmark-loader"
 import Link from "next/link"
 import NavigationPills from "@/components/navigation-pills"
 import PageHeader from "@/components/page-header"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
 
 export const metadata = {
   title: "Benchmarks",
@@ -17,18 +25,38 @@ export default async function BenchmarksPage() {
         subtitle="Models are evaluated on the following benchmarks."
       />
       <NavigationPills />
-      <ul className="space-y-4">
-        {benchmarks.map((b) => (
-          <li key={b.slug} className="border rounded-lg p-4">
-            <Link href={`/benchmarks/${b.slug}`} className="space-y-1 block">
-              <h2 className="font-semibold text-lg">{b.benchmark}</h2>
-              {b.description && (
-                <p className="text-muted-foreground text-sm">{b.description}</p>
-              )}
-            </Link>
-          </li>
-        ))}
-      </ul>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Benchmark</TableHead>
+            <TableHead className="text-right">Models</TableHead>
+            <TableHead className="text-right">Cost data?</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {benchmarks.map((b) => (
+            <TableRow key={b.slug}>
+              <TableCell>
+                <Link
+                  href={`/benchmarks/${b.slug}`}
+                  className="space-y-1 block"
+                >
+                  <div className="font-semibold">{b.benchmark}</div>
+                  {b.description && (
+                    <p className="text-muted-foreground text-sm">
+                      {b.description}
+                    </p>
+                  )}
+                </Link>
+              </TableCell>
+              <TableCell className="text-right">{b.modelCount}</TableCell>
+              <TableCell className="text-right">
+                {b.hasCost ? "Yes" : "No"}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
     </main>
   )
 }

--- a/lib/__tests__/benchmark-loader.test.ts
+++ b/lib/__tests__/benchmark-loader.test.ts
@@ -10,4 +10,6 @@ test("loadBenchmarks returns sorted benchmarks", async () => {
   const names = benchmarks.map((b) => b.benchmark)
   const sorted = [...names].sort((a, b) => a.localeCompare(b))
   expect(names).toEqual(sorted)
+  expect(benchmarks[0].modelCount).toBeGreaterThan(0)
+  expect(typeof benchmarks[0].hasCost).toBe("boolean")
 })

--- a/lib/benchmark-loader.ts
+++ b/lib/benchmark-loader.ts
@@ -7,6 +7,8 @@ export interface BenchmarkInfo {
   slug: string
   benchmark: string
   description: string
+  modelCount: number
+  hasCost: boolean
 }
 
 export async function loadBenchmarks(): Promise<BenchmarkInfo[]> {
@@ -27,6 +29,8 @@ export async function loadBenchmarks(): Promise<BenchmarkInfo[]> {
         slug,
         benchmark: data.benchmark,
         description: data.description,
+        modelCount: Object.keys(data.results).length,
+        hasCost: !!data.cost_per_task,
       })
     } catch (error) {
       console.error(`Failed to load benchmark info for ${slug}:`, error)
@@ -57,6 +61,8 @@ export async function loadBenchmarkDetails(
       slug,
       benchmark: data.benchmark,
       description: data.description,
+      modelCount: Object.keys(data.results).length,
+      hasCost: !!data.cost_per_task,
       results: data.results,
       cost_per_task: data.cost_per_task,
       model_name_mapping_file: data.model_name_mapping_file,


### PR DESCRIPTION
## Summary
- extend benchmark loader to expose model count and cost presence
- update benchmarks test for new fields
- display benchmarks in a table with counts and cost information

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68700a13e5e88320bc7c1915bebc5986