### PR TITLE
Add Claude 3.5 Sonnet models

### DIFF
--- a/data/mappings/aider-polyglot.yaml
+++ b/data/mappings/aider-polyglot.yaml
@@ -1,7 +1,7 @@
 chatgpt-4o-latest (2025-02-15): null
 chatgpt-4o-latest (2025-03-29): null
 claude-3-5-haiku-20241022: claude-3.5-haiku
-claude-3-5-sonnet-20241022: null
+claude-3-5-sonnet-20241022: claude-3.5-sonnet-v2
 claude-3-7-sonnet-20250219 (32k thinking tokens): null
 claude-3-7-sonnet-20250219 (no thinking): null
 claude-opus-4-20250514 (32k thinking): claude-opus-4-thinking

--- a/data/mappings/livebench.yaml
+++ b/data/mappings/livebench.yaml
@@ -1,6 +1,6 @@
 chatgpt-4o-latest-2025-03-27: null
 claude-3-5-haiku-20241022: claude-3.5-haiku
-claude-3-5-sonnet-20241022: null
+claude-3-5-sonnet-20241022: claude-3.5-sonnet-v2
 claude-3-7-sonnet-20250219-base: null
 claude-3-7-sonnet-20250219-thinking-64k: null
 claude-4-opus-20250514-base: claude-opus-4-nothinking

--- a/data/mappings/lmarena-text.yaml
+++ b/data/mappings/lmarena-text.yaml
@@ -20,8 +20,8 @@ claude-1: null
 claude-2.0: null
 claude-2.1: null
 claude-3-5-haiku-20241022: claude-3.5-haiku
-claude-3-5-sonnet-20240620: null
-claude-3-5-sonnet-20241022: null
+claude-3-5-sonnet-20240620: claude-3.5-sonnet
+claude-3-5-sonnet-20241022: claude-3.5-sonnet-v2
 claude-3-7-sonnet-20250219: null
 claude-3-7-sonnet-20250219-thinking-32k: null
 claude-3-haiku-20240307: null

--- a/data/models/claude-3.5-sonnet-v2.yaml
+++ b/data/models/claude-3.5-sonnet-v2.yaml
@@ -1,0 +1,4 @@
+provider: Anthropic
+release_date: 2024-10-22
+reasoning_efforts:
+  claude-3.5-sonnet-v2: Claude 3.5 Sonnet v2

--- a/data/models/claude-3.5-sonnet.yaml
+++ b/data/models/claude-3.5-sonnet.yaml
@@ -1,0 +1,4 @@
+provider: Anthropic
+release_date: 2024-06-20
+reasoning_efforts:
+  claude-3.5-sonnet: Claude 3.5 Sonnet


### PR DESCRIPTION
## Summary
- add new Claude 3.5 Sonnet and Claude 3.5 Sonnet v2 YAMLs
- map new model aliases to these slugs in benchmark mappings

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_68700ed97c1883209936950b0bcd5484