### PR TITLE
Add benchmark links

### DIFF
--- a/app/benchmarks/[slug]/page.tsx
+++ b/app/benchmarks/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import NavigationPills from "@/components/navigation-pills"
 import PageHeader from "@/components/page-header"
+import Link from "next/link"
 import {
   Table,
   TableBody,
@@ -45,6 +46,20 @@ export default async function BenchmarkPage({
   return (
     <main className="container mx-auto px-4 py-8 max-w-3xl space-y-6">
       <PageHeader title={info.benchmark} subtitle={info.description} />
+      {(info.website || info.github) && (
+        <div className="flex justify-center gap-4 text-sm">
+          {info.website && (
+            <Link href={info.website} target="_blank" className="underline">
+              Website
+            </Link>
+          )}
+          {info.github && (
+            <Link href={info.github} target="_blank" className="underline">
+              GitHub
+            </Link>
+          )}
+        </div>
+      )}
       <NavigationPills />
       <Table>
         <TableHeader>

--- a/app/benchmarks/page.tsx
+++ b/app/benchmarks/page.tsx
@@ -18,6 +18,7 @@ export const metadata = {
 
 export default async function BenchmarksPage() {
   const benchmarks = await loadBenchmarks()
+  console.log(benchmarks)
   return (
     <main className="container mx-auto px-4 py-8 max-w-3xl space-y-6">
       <PageHeader

--- a/app/benchmarks/page.tsx
+++ b/app/benchmarks/page.tsx
@@ -29,6 +29,8 @@ export default async function BenchmarksPage() {
         <TableHeader>
           <TableRow>
             <TableHead>Benchmark</TableHead>
+            <TableHead>Website</TableHead>
+            <TableHead>GitHub</TableHead>
             <TableHead className="text-right">Models</TableHead>
             <TableHead className="text-right">Cost data?</TableHead>
             <TableHead className="text-right">Private holdout?</TableHead>
@@ -49,6 +51,20 @@ export default async function BenchmarksPage() {
                     </p>
                   )}
                 </Link>
+              </TableCell>
+              <TableCell>
+                {b.website && (
+                  <Link href={b.website} target="_blank" className="underline">
+                    Website
+                  </Link>
+                )}
+              </TableCell>
+              <TableCell>
+                {b.github && (
+                  <Link href={b.github} target="_blank" className="underline">
+                    GitHub
+                  </Link>
+                )}
               </TableCell>
               <TableCell className="text-right">{b.modelCount}</TableCell>
               <TableCell className="text-right">

--- a/data/benchmarks/aider-polyglot.yaml
+++ b/data/benchmarks/aider-polyglot.yaml
@@ -1,5 +1,7 @@
 benchmark: Aider Polyglot
 description: Pass rate (PR@2) on Aider's polyglot benchmark
+website: https://aider.ai
+github: https://github.com/Aider-AI/polyglot-benchmark
 score_weight: 1
 cost_weight: 1
 results:

--- a/data/benchmarks/aider-polyglot.yaml
+++ b/data/benchmarks/aider-polyglot.yaml
@@ -1,6 +1,6 @@
 benchmark: Aider Polyglot
 description: Pass rate (PR@2) on Aider's polyglot benchmark
-website: https://aider.ai
+website: https://aider.chat/docs/leaderboards
 github: https://github.com/Aider-AI/polyglot-benchmark
 score_weight: 1
 cost_weight: 1

--- a/data/benchmarks/arc-agi-1.yaml
+++ b/data/benchmarks/arc-agi-1.yaml
@@ -1,6 +1,6 @@
 benchmark: ARC-AGI-1
 description: Accuracy on ARC-AGI-1
-website: https://arc-agi.github.io
+website: https://arcprize.org/leaderboard
 github: https://github.com/fchollet/ARC-AGI
 score_weight: 1
 cost_weight: 1

--- a/data/benchmarks/arc-agi-1.yaml
+++ b/data/benchmarks/arc-agi-1.yaml
@@ -1,5 +1,7 @@
 benchmark: ARC-AGI-1
 description: Accuracy on ARC-AGI-1
+website: https://arc-agi.github.io
+github: https://github.com/fchollet/ARC-AGI
 score_weight: 1
 cost_weight: 1
 results:

--- a/data/benchmarks/arc-agi-2.yaml
+++ b/data/benchmarks/arc-agi-2.yaml
@@ -1,5 +1,7 @@
 benchmark: ARC-AGI-2
 description: Accuracy on ARC-AGI-2
+website: https://arc-agi.github.io
+github: https://github.com/fchollet/ARC-AGI
 score_weight: 1
 cost_weight: 1
 results:

--- a/data/benchmarks/arc-agi-2.yaml
+++ b/data/benchmarks/arc-agi-2.yaml
@@ -1,7 +1,7 @@
 benchmark: ARC-AGI-2
 description: Accuracy on ARC-AGI-2
-website: https://arc-agi.github.io
-github: https://github.com/fchollet/ARC-AGI
+website: https://arcprize.org/leaderboard
+github: https://github.com/arcprize/ARC-AGI-2
 score_weight: 1
 cost_weight: 1
 results:

--- a/data/benchmarks/artificial-analysis-index.yaml
+++ b/data/benchmarks/artificial-analysis-index.yaml
@@ -1,5 +1,7 @@
 benchmark: Artificial Analysis Index
 description: Score on Artificial Analysis Index benchmark
+website: https://artificialanalysis.ai/evaluations/artificial-analysis-intelligence-index
+github: https://github.com/NokkelaAI/artificial-analysis-intelligence-index
 score_weight: 1
 cost_weight: 1
 results:

--- a/data/benchmarks/artificial-analysis-index.yaml
+++ b/data/benchmarks/artificial-analysis-index.yaml
@@ -1,7 +1,7 @@
 benchmark: Artificial Analysis Index
 description: Score on Artificial Analysis Index benchmark
 website: https://artificialanalysis.ai/evaluations/artificial-analysis-intelligence-index
-github: https://github.com/NokkelaAI/artificial-analysis-intelligence-index
+github: null
 score_weight: 1
 cost_weight: 1
 results:

--- a/data/benchmarks/gpqa-diamond.yaml
+++ b/data/benchmarks/gpqa-diamond.yaml
@@ -1,7 +1,7 @@
 benchmark: GPQA Diamond
 description: Score on GPQA Diamond benchmark
-website: https://artificialanalysis.ai/leaderboards/models
-github: https://github.com/idavidrein/gpqa
+website: https://artificialanalysis.ai/evaluations/gpqa-diamond
+github: null
 score_weight: 1
 cost_weight: 1
 results:

--- a/data/benchmarks/gpqa-diamond.yaml
+++ b/data/benchmarks/gpqa-diamond.yaml
@@ -1,5 +1,7 @@
 benchmark: GPQA Diamond
 description: Score on GPQA Diamond benchmark
+website: https://artificialanalysis.ai/leaderboards/models
+github: https://github.com/idavidrein/gpqa
 score_weight: 1
 cost_weight: 1
 results:

--- a/data/benchmarks/humanitys-last-exam.yaml
+++ b/data/benchmarks/humanitys-last-exam.yaml
@@ -1,5 +1,7 @@
 benchmark: Humanity's Last Exam
 description: Score on Scale's Humanity's Last Exam
+website: https://scale.com/leaderboard/humanitys_last_exam
+github: https://github.com/centerforaisafety/hle
 score_weight: 1
 cost_weight: 1
 results:

--- a/data/benchmarks/humanitys-last-exam.yaml
+++ b/data/benchmarks/humanitys-last-exam.yaml
@@ -1,7 +1,7 @@
 benchmark: Humanity's Last Exam
 description: Score on Scale's Humanity's Last Exam
 website: https://scale.com/leaderboard/humanitys_last_exam
-github: https://github.com/centerforaisafety/hle
+github: null
 score_weight: 1
 cost_weight: 1
 results:

--- a/data/benchmarks/livebench.yaml
+++ b/data/benchmarks/livebench.yaml
@@ -1,5 +1,7 @@
 benchmark: LiveBench
 description: Average score across LiveBench categories
+website: https://livebench.ai
+github: https://github.com/LiveBench/livebench.github.io
 score_weight: 1
 cost_weight: 1
 results:

--- a/data/benchmarks/livebench.yaml
+++ b/data/benchmarks/livebench.yaml
@@ -1,7 +1,7 @@
 benchmark: LiveBench
 description: Average score across LiveBench categories
 website: https://livebench.ai
-github: https://github.com/LiveBench/livebench.github.io
+github: https://github.com/LiveBench/LiveBench
 score_weight: 1
 cost_weight: 1
 results:

--- a/data/benchmarks/lmarena-text.yaml
+++ b/data/benchmarks/lmarena-text.yaml
@@ -1,7 +1,7 @@
 benchmark: LMArena Text
 description: Elo score on LMArena Text leaderboard
-website: https://huggingface.co/spaces/lmarena-ai/chatbot-arena-leaderboard
-github: https://github.com/lm-sys/FastChat
+website: https://lmarena.ai/leaderboard
+github: null
 score_weight: 1
 cost_weight: 1
 results:

--- a/data/benchmarks/lmarena-text.yaml
+++ b/data/benchmarks/lmarena-text.yaml
@@ -1,5 +1,7 @@
 benchmark: LMArena Text
 description: Elo score on LMArena Text leaderboard
+website: https://huggingface.co/spaces/lmarena-ai/chatbot-arena-leaderboard
+github: https://github.com/lm-sys/FastChat
 score_weight: 1
 cost_weight: 1
 results:

--- a/data/benchmarks/simplebench.yaml
+++ b/data/benchmarks/simplebench.yaml
@@ -1,5 +1,7 @@
 benchmark: SimpleBench
 description: Score (AVG@5) on SimpleBench
+website: https://simple-bench.com
+github: https://github.com/simple-bench/SimpleBench
 score_weight: 1
 cost_weight: 1
 results:

--- a/data/benchmarks/weirdml.yaml
+++ b/data/benchmarks/weirdml.yaml
@@ -1,7 +1,7 @@
 benchmark: WeirdML
 description: Average accuracy across WeirdML tasks
-website: https://weirdml.ai
-github: https://github.com/abhimanyudwivedi/weirdML
+website: https://htihle.github.io/weirdml.html
+github: null
 score_weight: 1
 cost_weight: 1
 results:

--- a/data/benchmarks/weirdml.yaml
+++ b/data/benchmarks/weirdml.yaml
@@ -1,5 +1,7 @@
 benchmark: WeirdML
 description: Average accuracy across WeirdML tasks
+website: https://weirdml.ai
+github: https://github.com/abhimanyudwivedi/weirdML
 score_weight: 1
 cost_weight: 1
 results:

--- a/lib/__tests__/cost-normalization.test.ts
+++ b/lib/__tests__/cost-normalization.test.ts
@@ -47,6 +47,8 @@ test("adding non-overlapping cost benchmark does not change costs", async () => 
         model_name_mapping_file: "test.yaml",
         private_holdout: false,
         cost_per_task: costs,
+        website: null,
+        github: null,
       }),
     )
   }

--- a/lib/__tests__/explicit-mapping.test.ts
+++ b/lib/__tests__/explicit-mapping.test.ts
@@ -36,6 +36,8 @@ test("loadLLMData ignores unmapped slugs", async () => {
       results: { A: 1, "model-a": 2 },
       model_name_mapping_file: "map.yaml",
       private_holdout: false,
+      website: null,
+      github: null,
     }),
   )
 
@@ -49,6 +51,8 @@ test("loadLLMData ignores unmapped slugs", async () => {
       results: { "model-a": 5 },
       model_name_mapping_file: "map.yaml",
       private_holdout: false,
+      website: null,
+      github: null,
     }),
   )
 

--- a/lib/benchmark-loader.ts
+++ b/lib/benchmark-loader.ts
@@ -7,6 +7,8 @@ export interface BenchmarkInfo {
   slug: string
   benchmark: string
   description: string
+  website?: string
+  github?: string
   modelCount: number
   hasCost: boolean
   privateHoldout: boolean
@@ -30,6 +32,8 @@ export async function loadBenchmarks(): Promise<BenchmarkInfo[]> {
         slug,
         benchmark: data.benchmark,
         description: data.description,
+        website: data.website,
+        github: data.github,
         modelCount: Object.keys(data.results).length,
         hasCost: !!data.cost_per_task,
         privateHoldout: data.private_holdout,
@@ -63,6 +67,8 @@ export async function loadBenchmarkDetails(
       slug,
       benchmark: data.benchmark,
       description: data.description,
+      website: data.website,
+      github: data.github,
       modelCount: Object.keys(data.results).length,
       hasCost: !!data.cost_per_task,
       privateHoldout: data.private_holdout,

--- a/lib/yaml-schemas.ts
+++ b/lib/yaml-schemas.ts
@@ -17,8 +17,8 @@ export type ModelFile = z.infer<typeof ModelFileSchema>
 export const BenchmarkFileSchema = z.object({
   benchmark: z.string(),
   description: z.string(),
-  website: z.string().url().optional(),
-  github: z.string().url().optional(),
+  website: z.string().url().nullable(),
+  github: z.string().url().nullable(),
   score_weight: z.number(),
   cost_weight: z.number(),
   results: z.record(z.string(), z.number()),

--- a/lib/yaml-schemas.ts
+++ b/lib/yaml-schemas.ts
@@ -17,6 +17,8 @@ export type ModelFile = z.infer<typeof ModelFileSchema>
 export const BenchmarkFileSchema = z.object({
   benchmark: z.string(),
   description: z.string(),
+  website: z.string().url().optional(),
+  github: z.string().url().optional(),
   score_weight: z.number(),
   cost_weight: z.number(),
   results: z.record(z.string(), z.number()),


### PR DESCRIPTION
## Summary
- add `website` and `github` fields to benchmark YAML schema
- store URLs for each benchmark
- expose link data via loader utilities
- show website and GitHub links on benchmark listing and detail pages

## Testing
- `npx pnpm prettier`
- `npx pnpm lint`
- `npx pnpm test:update`

------
https://chatgpt.com/codex/tasks/task_e_68707af464208320995f729c12d461bf