### PR TITLE
Add test to enforce unique slug mapping

### DIFF
--- a/lib/__tests__/mapping-unique-slugs.test.ts
+++ b/lib/__tests__/mapping-unique-slugs.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "vitest"
+import fs from "fs/promises"
+import path from "path"
+import { parse } from "yaml"
+import { MappingFileSchema } from "../yaml-schemas"
+
+// Ensure no mapping file assigns multiple aliases to the same slug
+
+test("mapping files do not map multiple models to the same slug", async () => {
+  const mappingsDir = path.join(process.cwd(), "data", "mappings")
+  const files = (await fs.readdir(mappingsDir)).filter((f) =>
+    f.endsWith(".yaml"),
+  )
+
+  for (const file of files) {
+    const text = await fs.readFile(path.join(mappingsDir, file), "utf8")
+    const mapping = MappingFileSchema.parse(parse(text))
+    const seen = new Set<string>()
+    for (const slug of Object.values(mapping)) {
+      if (!slug) continue
+      expect(
+        seen.has(slug),
+        `${file} maps multiple aliases to slug ${slug}`,
+      ).toBe(false)
+      seen.add(slug)
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- add a unit test verifying each mapping file only maps one alias per slug

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`

------
https://chatgpt.com/codex/tasks/task_e_6871b91fedb883209440901eb580de90