### PR TITLE
Refactor artificial analysis scrapers

### DIFF
--- a/scripts/scrape_gpqa_diamond.ts
+++ b/scripts/scrape_gpqa_diamond.ts
@@ -1,96 +1,20 @@
-import { chromium } from "playwright"
 import path from "path"
 import { fileURLToPath } from "url"
-import { saveBenchmarkResults } from "./utils"
+import {
+  saveBenchmarkResults,
+  scrapeArtificialAnalysisBenchmark,
+} from "./utils"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 async function main() {
-  const browser = await chromium.launch({
-    headless: true,
-  })
-
-  const context = await browser.newContext({ ignoreHTTPSErrors: true })
-  const page = await context.newPage()
-
   try {
-    await page.goto("https://artificialanalysis.ai/evaluations/gpqa-diamond")
-    await page.waitForLoadState("networkidle")
+    const { results, costPerTask } = await scrapeArtificialAnalysisBenchmark({
+      url: "https://artificialanalysis.ai/evaluations/gpqa-diamond",
+      resultsSelector: "#gpqa-diamond-benchmark-leaderboard-results",
+      costSelector: "#gpqa-diamond-benchmark-leaderboard-cost-breakdown",
+    })
 
-    // Open the dropdown menu
-    // Click on the first "20 of NUMBER models selected" button
-    const filterButton = await page
-      .getByText(/20 of \d+ models selected/, {
-        exact: true,
-      })
-      .nth(0)
-    await filterButton.click()
-
-    // Turn on all models
-    // Click on all the buttons with role="option" and aria-selected="false"
-    const options = await page.$$("div[role='option'][aria-selected='false']")
-    for (const option of options) {
-      await option.click()
-    }
-
-    // Get the scores
-    const scoresChartContainer = await page.locator(
-      "#gpqa-diamond-benchmark-leaderboard-results",
-    )
-    const scoresChartSvg = await scoresChartContainer
-      .locator("svg[role='img']")
-      .first()
-    const scoresSvgOuterGroup = await scoresChartSvg.locator("g").first()
-    const scoresModelNamesGroup = await scoresSvgOuterGroup
-      .locator("> g")
-      .nth(-3)
-    const scoresModelNamesTextNodes = await scoresModelNamesGroup
-      .locator("text")
-      .all()
-    const scoresModelNames = await Promise.all(
-      scoresModelNamesTextNodes.map(async (textNode) =>
-        (await textNode.locator("tspan").allTextContents()).join(" ").trim(),
-      ),
-    )
-
-    const scoresGroup = await scoresSvgOuterGroup.locator("> g").nth(-2)
-    const scores = await (
-      await scoresGroup.locator("text").allTextContents()
-    ).map((score) => parseInt(score))
-
-    // Get the costs
-    const costsChartContainer = await page.locator(
-      "#gpqa-diamond-benchmark-leaderboard-cost-breakdown",
-    )
-    const costsChartSvg = await costsChartContainer
-      .locator("svg[role='img']")
-      .first()
-    const costsSvgOuterGroup = await costsChartSvg.locator("g").first()
-    const costsModelNamesGroup = await costsSvgOuterGroup.locator("> g").nth(-3)
-    const costsModelNamesTextNodes = await costsModelNamesGroup
-      .locator("text")
-      .all()
-    const costsModelNames = await Promise.all(
-      costsModelNamesTextNodes.map(async (textNode) =>
-        (await textNode.locator("tspan").allTextContents()).join(" ").trim(),
-      ),
-    )
-    const costsGroup = await costsSvgOuterGroup.locator("> g").nth(-2)
-    const costs = await (
-      await costsGroup.locator("text").allTextContents()
-    ).map((cost) => parseInt(cost.replace(",", "")))
-
-    const resultsMap: Record<string, number> = {}
-    for (let i = 0; i < scoresModelNames.length; i++) {
-      resultsMap[scoresModelNames[i]] = scores[i]
-    }
-
-    const costPerTaskMap: Record<string, number> = {}
-    for (let i = 0; i < costsModelNames.length; i++) {
-      costPerTaskMap[costsModelNames[i]] = costs[i]
-    }
-
-    // Save results to yaml
     const outPath = path.join(
       __dirname,
       "..",
@@ -98,11 +22,9 @@ async function main() {
       "benchmarks",
       "gpqa-diamond.yaml",
     )
-    await saveBenchmarkResults(outPath, resultsMap, costPerTaskMap)
+    await saveBenchmarkResults(outPath, results, costPerTask)
   } catch (error) {
     console.error("Error during scraping:", error)
-  } finally {
-    await browser.close()
   }
 }
 

--- a/scripts/scrape_hle.ts
+++ b/scripts/scrape_hle.ts
@@ -1,98 +1,21 @@
-import { chromium } from "playwright"
 import path from "path"
 import { fileURLToPath } from "url"
-import { saveBenchmarkResults } from "./utils"
+import {
+  saveBenchmarkResults,
+  scrapeArtificialAnalysisBenchmark,
+} from "./utils"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 async function main() {
-  const browser = await chromium.launch({
-    headless: true,
-  })
-
-  const context = await browser.newContext({ ignoreHTTPSErrors: true })
-  const page = await context.newPage()
-
   try {
-    await page.goto(
-      "https://artificialanalysis.ai/evaluations/humanitys-last-exam",
-    )
-    await page.waitForLoadState("networkidle")
+    const { results, costPerTask } = await scrapeArtificialAnalysisBenchmark({
+      url: "https://artificialanalysis.ai/evaluations/humanitys-last-exam",
+      resultsSelector: "#humanitys-last-exam-benchmark-leaderboard-results",
+      costSelector: "#humanitys-last-exam-benchmark-leaderboard-cost-breakdown",
+      filterRegex: /\d+ of \d+ models selected/,
+    })
 
-    // Open the dropdown menu
-    // Click on the first "20 of NUMBER models selected" button
-    const filterButton = await page
-      .getByText(/\d+ of \d+ models selected/, {
-        exact: true,
-      })
-      .nth(0)
-    await filterButton.click()
-
-    // Turn on all models
-    // Click on all the buttons with role="option" and aria-selected="false"
-    const options = await page.$$("div[role='option'][aria-selected='false']")
-    for (const option of options) {
-      await option.click()
-    }
-
-    // Get the scores
-    const scoresChartContainer = await page.locator(
-      "#humanitys-last-exam-benchmark-leaderboard-results",
-    )
-    const scoresChartSvg = await scoresChartContainer
-      .locator("svg[role='img']")
-      .first()
-    const scoresSvgOuterGroup = await scoresChartSvg.locator("g").first()
-    const scoresModelNamesGroup = await scoresSvgOuterGroup
-      .locator("> g")
-      .nth(-3)
-    const scoresModelNamesTextNodes = await scoresModelNamesGroup
-      .locator("text")
-      .all()
-    const scoresModelNames = await Promise.all(
-      scoresModelNamesTextNodes.map(async (textNode) =>
-        (await textNode.locator("tspan").allTextContents()).join(" ").trim(),
-      ),
-    )
-
-    const scoresGroup = await scoresSvgOuterGroup.locator("> g").nth(-2)
-    const scores = await (
-      await scoresGroup.locator("text").allTextContents()
-    ).map((score) => parseInt(score))
-
-    // Get the costs
-    const costsChartContainer = await page.locator(
-      "#humanitys-last-exam-benchmark-leaderboard-cost-breakdown",
-    )
-    const costsChartSvg = await costsChartContainer
-      .locator("svg[role='img']")
-      .first()
-    const costsSvgOuterGroup = await costsChartSvg.locator("g").first()
-    const costsModelNamesGroup = await costsSvgOuterGroup.locator("> g").nth(-3)
-    const costsModelNamesTextNodes = await costsModelNamesGroup
-      .locator("text")
-      .all()
-    const costsModelNames = await Promise.all(
-      costsModelNamesTextNodes.map(async (textNode) =>
-        (await textNode.locator("tspan").allTextContents()).join(" ").trim(),
-      ),
-    )
-    const costsGroup = await costsSvgOuterGroup.locator("> g").nth(-2)
-    const costs = await (
-      await costsGroup.locator("text").allTextContents()
-    ).map((cost) => parseInt(cost.replace(",", "")))
-
-    const resultsMap: Record<string, number> = {}
-    for (let i = 0; i < scoresModelNames.length; i++) {
-      resultsMap[scoresModelNames[i]] = scores[i]
-    }
-
-    const costPerTaskMap: Record<string, number> = {}
-    for (let i = 0; i < costsModelNames.length; i++) {
-      costPerTaskMap[costsModelNames[i]] = costs[i]
-    }
-
-    // Save results to yaml
     const outPath = path.join(
       __dirname,
       "..",
@@ -100,11 +23,9 @@ async function main() {
       "benchmarks",
       "humanitys-last-exam.yaml",
     )
-    await saveBenchmarkResults(outPath, resultsMap, costPerTaskMap)
+    await saveBenchmarkResults(outPath, results, costPerTask)
   } catch (error) {
     console.error("Error during scraping:", error)
-  } finally {
-    await browser.close()
   }
 }
 

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -102,7 +102,7 @@ export async function scrapeArtificialAnalysisBenchmark(
     url,
     resultsSelector,
     costSelector,
-    filterRegex = /20 of \d+ models selected/,
+    filterRegex = /\d+ of \d+ models selected/,
   } = options
   const browser = await chromium.launch({ headless: true })
   const context = await browser.newContext({ ignoreHTTPSErrors: true })


### PR DESCRIPTION
## Summary
- add a helper `scrapeArtificialAnalysisBenchmark` for scraping Artificial Analysis leaderboards
- update gpqa diamond and HLE scrapers to use the new function

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_6872b21ca09083208e0218830460be2c