### PR TITLE
Move mapping update logic to python

### DIFF
--- a/data/AGENTS.md
+++ b/data/AGENTS.md
@@ -14,7 +14,7 @@ This folder stores YAML files consumed by the application and populated by scrap
 - `lib/data-loader.ts` reads all YAML from `models/`, `benchmarks/` and `mappings/` to merge benchmark scores and compute per‑model statistics used throughout the site.
 - `lib/benchmark-loader.ts` loads benchmark metadata and details from `benchmarks/` for individual benchmark pages.
 - Next.js route handlers in `app/` call these loader functions to build pages.
-- Scraping utilities in `scripts/` (e.g. `scrape_livebench.ts`) download data from external leaderboards and call `saveBenchmarkResults` from `scripts/utils.ts` to update files in `benchmarks/` and `mappings/`.
+- Scraping utilities in `scripts/` (e.g. `scrape_livebench.ts`) download data from external leaderboards and call `saveBenchmarkResults` from `scripts/utils.ts` to update benchmark files. After scraping, run `uv run update_mappings.py` from `scripts_python/` to add any new models to the mapping files.
 
 ## Generation details
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "scrape:weirdml": "tsx scripts/scrape_weirdml.ts",
     "scrape:all": "tsx scripts/scrape_all.ts",
     "process:all": "uv run scripts_python/process_data.py",
-    "full-pipeline": "pnpm scrape:all && pnpm process:all && pnpm test:update"
+    "update:mappings": "uv run scripts_python/update_mappings.py",
+    "full-pipeline": "pnpm scrape:all && pnpm update:mappings && pnpm process:all && pnpm test:update"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -2,11 +2,7 @@ import { execSync } from "child_process"
 import fs from "fs/promises"
 import path from "path"
 import YAML from "yaml"
-import {
-  BenchmarkFileSchema,
-  MappingFileSchema,
-  type BenchmarkFile,
-} from "../lib/yaml-schemas"
+import { BenchmarkFileSchema, type BenchmarkFile } from "../lib/yaml-schemas"
 
 export function curl(url: string): string {
   return execSync(`curl -sL ${url}`, { encoding: "utf8" })
@@ -55,30 +51,6 @@ export async function saveBenchmarkResults(
   } else {
     delete yamlObj.cost_per_task
   }
-
-  const existingMap: Record<string, string | null> = {}
-  const mapPath = path.join(
-    path.dirname(outPath),
-    "..",
-    "mappings",
-    yamlObj.model_name_mapping_file as string,
-  )
-  try {
-    const mapText = await fs.readFile(mapPath, "utf8")
-    Object.assign(existingMap, MappingFileSchema.parse(YAML.parse(mapText)))
-  } catch (err: any) {
-    if (err.code !== "ENOENT") throw err
-  }
-
-  const sortedModels = Object.keys(results).sort((a, b) => a.localeCompare(b))
-  const newMap: Record<string, string | null> = {}
-  for (const name of sortedModels) {
-    newMap[name] = Object.prototype.hasOwnProperty.call(existingMap, name)
-      ? existingMap[name]
-      : null
-  }
-  await fs.writeFile(mapPath, YAML.stringify(newMap))
-  delete yamlObj.model_name_mapping
 
   await fs.writeFile(outPath, YAML.stringify(yamlObj))
   console.log(`Wrote ${outPath}`)

--- a/scripts_python/tests/test_update_mappings.py
+++ b/scripts_python/tests/test_update_mappings.py
@@ -1,0 +1,70 @@
+import sys
+from pathlib import Path
+import yaml
+
+# Add scripts_python directory to path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from update_mappings import update_mapping
+
+
+def test_update_mapping(tmp_path: Path):
+    bench_file = tmp_path / "bench.yaml"
+    mapping_dir = tmp_path
+
+    bench_data = {
+        "model_name_mapping_file": "map.yaml",
+        "results": {
+            "Model A": 0.9,
+            "Model B": 0.5,
+        },
+    }
+    bench_file.write_text(yaml.safe_dump(bench_data, sort_keys=False))
+
+    # existing mapping only has Model A
+    (mapping_dir / "map.yaml").write_text(yaml.safe_dump({"Model A": "slug-a"}, sort_keys=False))
+
+    update_mapping(bench_file, mapping_dir)
+
+    mapping = yaml.safe_load((mapping_dir / "map.yaml").read_text())
+    assert mapping == {"Model A": "slug-a", "Model B": None}
+
+
+def test_union_across_multiple_benchmarks(tmp_path: Path):
+    mapping_dir = tmp_path
+
+    bench1 = tmp_path / "b1.yaml"
+    bench1.write_text(
+        yaml.safe_dump(
+            {
+                "model_name_mapping_file": "map.yaml",
+                "results": {"Model A": 1.0},
+            },
+            sort_keys=False,
+        )
+    )
+
+    bench2 = tmp_path / "b2.yaml"
+    bench2.write_text(
+        yaml.safe_dump(
+            {
+                "model_name_mapping_file": "map.yaml",
+                "results": {"Model B": 0.5},
+            },
+            sort_keys=False,
+        )
+    )
+
+    # existing mapping has an entry for Model A
+    (mapping_dir / "map.yaml").write_text(
+        yaml.safe_dump({"Model A": "slug-a"}, sort_keys=False)
+    )
+
+    update_mapping(bench1, mapping_dir)
+    update_mapping(bench2, mapping_dir)
+
+    mapping = yaml.safe_load((mapping_dir / "map.yaml").read_text())
+    assert mapping == {
+        "Model A": "slug-a",
+        "Model B": None,
+    }

--- a/scripts_python/update_mappings.py
+++ b/scripts_python/update_mappings.py
@@ -1,0 +1,39 @@
+import yaml
+from pathlib import Path
+
+
+def update_mapping(bench_file: Path, mapping_dir: Path) -> None:
+    """Update mapping file for a single benchmark YAML."""
+    data = yaml.safe_load(bench_file.read_text()) or {}
+    mapping_name = data.get("model_name_mapping_file")
+    if not mapping_name:
+        return
+    map_path = mapping_dir / mapping_name
+    existing = {}
+    if map_path.exists():
+        existing = yaml.safe_load(map_path.read_text()) or {}
+
+    results = data.get("results", {})
+
+    # Merge new model names with existing mapping entries
+    for name in results.keys():
+        existing.setdefault(name, None)
+
+    # Write models in sorted order for stable diffs
+    sorted_map = {
+        name: existing[name] for name in sorted(existing.keys())
+    }
+    map_path.write_text(yaml.safe_dump(sorted_map, sort_keys=False))
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[1]
+    bench_dir = root / "data" / "benchmarks"
+    mapping_dir = root / "data" / "mappings"
+
+    for bench_file in bench_dir.glob("*.yaml"):
+        update_mapping(bench_file, mapping_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- move model mapping updates from TypeScript to new `scripts_python/update_mappings.py`
- add tests for updating mappings including when multiple benchmarks share the same mapping file
- expose `update:mappings` npm script and run it in the full pipeline
- adjust `saveBenchmarkResults` util and docs for the new workflow
- fix union logic when updating mappings from several benchmarks

## Testing
- `pnpm lint`
- `pnpm test:update`
- `python -m pytest tests` in `scripts_python`


------
https://chatgpt.com/codex/tasks/task_e_6872b1d42d7883208c3297e3844d3aa9