### PR TITLE
Add SVD based cost normalization

### DIFF
--- a/data/benchmarks_processed/aider-polyglot.yaml
+++ b/data/benchmarks_processed/aider-polyglot.yaml
@@ -1,93 +1,124 @@
 o3-pro-high:
   score: 84.9
   cost: 0.6503
+  normalized_cost: 1104.4659199854607
 o3-high:
   score: 81.3
   cost: 0.0943
+  normalized_cost: 160.15859796190824
 grok-4:
   score: 79.6
   cost: 0.265
+  normalized_cost: 450.07453297885144
 gemini-2.5-pro-06-05:
   score: 79.1
   cost: 0.2026
-o3-medium:
-  score: 76.9
-  cost: 0.0611
+  normalized_cost: 344.09471842081246
 gemini-2.5-pro-preview-05-06:
   score: 76.9
   cost: 0.1663
+  normalized_cost: 282.4429993750302
+o3-medium:
+  score: 76.9
+  cost: 0.0611
+  normalized_cost: 103.77190175474651
 gemini-2.5-pro-preview-03-25:
   score: 72.9
   cost: 0.0
-claude-opus-4-thinking:
-  score: 72.0
-  cost: 0.2922
+  normalized_cost: 0.0
 o4-mini-high:
   score: 72.0
   cost: 0.0873
+  normalized_cost: 148.2698367134103
+claude-opus-4-thinking:
+  score: 72.0
+  cost: 0.2922
+  normalized_cost: 496.2708624015864
 deepseek-r1-0528:
   score: 71.4
   cost: 0.0214
+  normalized_cost: 36.34564153112234
 claude-opus-4-nothinking:
   score: 70.7
   cost: 0.305
+  normalized_cost: 518.0103115416969
 claude-sonnet-4-thinking:
   score: 61.3
   cost: 0.1181
+  normalized_cost: 200.58038620680134
 qwen-3-235b-a22b-nothinking:
   score: 59.6
   cost: 0.0
+  normalized_cost: 0.0
 deepseek-r1-0120:
   score: 56.9
   cost: 0.0241
+  normalized_cost: 40.93130658411441
 claude-sonnet-4-nothinking:
   score: 56.4
   cost: 0.0703
+  normalized_cost: 119.39713082420097
 deepseek-v3-0324:
   score: 55.1
   cost: 0.005
+  normalized_cost: 8.491972320355687
 grok-3:
   score: 53.3
   cost: 0.049
+  normalized_cost: 83.22132873948574
 gpt-4.1:
   score: 52.4
   cost: 0.0438
+  normalized_cost: 74.38967752631582
 claude-3.5-sonnet-v2:
   score: 51.6
   cost: 0.064
+  normalized_cost: 108.6972457005528
 grok-3-mini-high:
   score: 49.3
   cost: 0.0033
+  normalized_cost: 5.604701731434754
 deepseek-v3-1224:
   score: 48.4
   cost: 0.0015
+  normalized_cost: 2.547591696106706
 gemini-2.5-flash-0520-thinking:
   score: 47.1
   cost: 0.0082
+  normalized_cost: 13.926834605383329
 gpt-4.5-preview:
   score: 44.9
   cost: 0.8178
+  normalized_cost: 1388.9469927173761
 gemini-2.5-flash-0520-nothinking:
   score: 44.0
   cost: 0.005
+  normalized_cost: 8.491972320355687
 grok-3-mini-low:
   score: 34.7
   cost: 0.0035
+  normalized_cost: 5.944380624248981
 gpt-4.1-mini:
   score: 32.4
   cost: 0.0089
+  normalized_cost: 15.115710730233124
 claude-3.5-haiku:
   score: 28.0
   cost: 0.0269
+  normalized_cost: 45.6868110835136
 gpt-4o-2024-08-06:
   score: 23.1
   cost: 0.0312
+  normalized_cost: 52.989907279019484
 gpt-4o-2024-11-20:
   score: 18.2
   cost: 0.0299
+  normalized_cost: 50.78199447572701
 llama-4-maverick:
   score: 15.6
   cost: 0.0
+  normalized_cost: 0.0
 gpt-4.1-nano:
   score: 8.9
   cost: 0.0019
+  normalized_cost: 3.2269494817351614

--- a/data/benchmarks_processed/arc-agi-1.yaml
+++ b/data/benchmarks_processed/arc-agi-1.yaml
@@ -1,84 +1,112 @@
 grok-4:
   score: 66.7
   cost: 1.0136
+  normalized_cost: 364.2613363807411
 o3-high:
   score: 60.8
   cost: 0.5002
+  normalized_cost: 179.7588007672126
 o3-pro-high:
   score: 59.3
   cost: 4.16
+  normalized_cost: 1494.9952242934914
 o4-mini-high:
   score: 58.7
   cost: 0.4058
+  normalized_cost: 145.83390913901414
 o3-pro-medium:
   score: 57.0
   cost: 3.1766
+  normalized_cost: 1141.586978242958
 o3-medium:
   score: 53.8
   cost: 0.2882
+  normalized_cost: 103.57154414456352
 o3-pro-low:
   score: 44.3
   cost: 1.6382
+  normalized_cost: 588.726244335961
 o4-mini-medium:
   score: 41.8
   cost: 0.15
+  normalized_cost: 53.90607779904416
 o3-low:
   score: 41.5
   cost: 0.1764
+  normalized_cost: 63.39354749167593
 claude-sonnet-4-thinking:
   score: 40.0
   cost: 0.3658
+  normalized_cost: 131.45895505926904
 gemini-2.5-pro-06-05:
   score: 37.0
   cost: 0.5123
+  normalized_cost: 184.1072243763355
 claude-opus-4-thinking:
   score: 35.7
   cost: 1.2496
+  normalized_cost: 449.07356545123724
 gemini-2.5-flash-0520-nothinking:
   score: 33.3
   cost: 0.0371
+  normalized_cost: 13.33276990896359
 gemini-2.5-flash-0520-thinking:
   score: 32.3
   cost: 0.1971
+  normalized_cost: 70.83258622794402
 claude-sonnet-4-nothinking:
   score: 23.8
   cost: 0.0806
+  normalized_cost: 28.965532470686398
 claude-opus-4-nothinking:
   score: 22.5
   cost: 0.4036
+  normalized_cost: 145.04328666462817
 o4-mini-low:
   score: 21.3
   cost: 0.0406
+  normalized_cost: 14.590578390941285
 deepseek-r1-0528:
   score: 21.2
   cost: 0.0464
+  normalized_cost: 16.674946732504328
 grok-3-mini-low:
   score: 16.5
   cost: 0.0099
+  normalized_cost: 3.557801134736915
 deepseek-r1-0120:
   score: 15.8
   cost: 0.06
+  normalized_cost: 21.562431119617663
 gpt-4.5-preview:
   score: 10.3
   cost: 0.29
+  normalized_cost: 104.21841707815204
 gpt-4.1:
   score: 5.5
   cost: 0.039
+  normalized_cost: 14.015580227751482
 grok-3:
   score: 5.5
   cost: 0.0931
+  normalized_cost: 33.457705620606745
 gpt-4o-2024-05-13:
   score: 4.5
   cost: 0.05
+  normalized_cost: 17.968692599681386
 llama-4-maverick:
   score: 4.4
   cost: 0.0078
+  normalized_cost: 2.803116045550296
 gpt-4.1-mini:
   score: 3.5
   cost: 0.0078
+  normalized_cost: 2.803116045550296
 llama-4-scout:
   score: 0.5
   cost: 0.0041
+  normalized_cost: 1.4734327931738738
 gpt-4.1-nano:
   score: 0.0
   cost: 0.0021
+  normalized_cost: 0.7546850891866183

--- a/data/benchmarks_processed/arc-agi-2.yaml
+++ b/data/benchmarks_processed/arc-agi-2.yaml
@@ -1,84 +1,112 @@
 grok-4:
   score: 16.0
   cost: 2.1659
+  normalized_cost: 444.1286958219677
 claude-opus-4-thinking:
   score: 8.6
   cost: 1.9284
+  normalized_cost: 395.4281255012154
 o3-high:
   score: 6.5
   cost: 0.8339
+  normalized_cost: 170.99539195989604
 o4-mini-high:
   score: 6.1
   cost: 0.856
+  normalized_cost: 175.52710818763762
 claude-sonnet-4-thinking:
   score: 5.9
   cost: 0.4857
+  normalized_cost: 99.59522949385
 o3-pro-high:
   score: 4.9
   cost: 7.5516
+  normalized_cost: 1548.4935866702854
 gemini-2.5-pro-06-05:
   score: 4.9
   cost: 0.757
+  normalized_cost: 155.22665992761878
 o3-medium:
   score: 3.0
   cost: 0.4787
+  normalized_cost: 98.15984426334362
 gemini-2.5-flash-0520-thinking:
   score: 2.5
   cost: 0.3191
+  normalized_cost: 65.43306100779809
 o4-mini-medium:
   score: 2.4
   cost: 0.2311
+  normalized_cost: 47.38821811000357
 o3-pro-low:
   score: 2.1
   cost: 2.2293
+  normalized_cost: 457.1291849096969
 o3-low:
   score: 2.0
   cost: 0.2343
+  normalized_cost: 48.04439421537792
 o3-pro-medium:
   score: 1.9
   cost: 4.7441
-o4-mini-low:
-  score: 1.7
-  cost: 0.05
+  normalized_cost: 972.8015817207614
 gemini-2.5-flash-0520-nothinking:
   score: 1.7
   cost: 0.057
+  normalized_cost: 11.688136876980543
+o4-mini-low:
+  score: 1.7
+  cost: 0.05
+  normalized_cost: 10.252751646474161
 deepseek-r1-0120:
   score: 1.3
   cost: 0.08
+  normalized_cost: 16.404402634358657
 claude-sonnet-4-nothinking:
   score: 1.3
   cost: 0.1272
+  normalized_cost: 26.083000188630265
 claude-opus-4-nothinking:
   score: 1.3
   cost: 0.6388
+  normalized_cost: 130.9891550353539
 deepseek-r1-0528:
   score: 1.1
   cost: 0.0527
+  normalized_cost: 10.806400235383766
 gpt-4.5-preview:
   score: 0.8
   cost: 2.1
+  normalized_cost: 430.61556915191477
 gpt-4.1:
   score: 0.4
   cost: 0.0691
+  normalized_cost: 14.169302775427289
 grok-3-mini-low:
   score: 0.4
   cost: 0.0131
+  normalized_cost: 2.6862209313762304
 gpt-4o-2024-05-13:
   score: 0.0
   cost: 0.08
+  normalized_cost: 16.404402634358657
 llama-4-maverick:
   score: 0.0
   cost: 0.0121
+  normalized_cost: 2.481165898446747
 llama-4-scout:
   score: 0.0
   cost: 0.0062
+  normalized_cost: 1.2713412041627958
 gpt-4.1-nano:
   score: 0.0
   cost: 0.0036
+  normalized_cost: 0.7381981185461396
 gpt-4.1-mini:
   score: 0.0
   cost: 0.0139
+  normalized_cost: 2.8502649577198165
 grok-3:
   score: 0.0
   cost: 0.1421
+  normalized_cost: 29.138320179279567

--- a/data/benchmarks_processed/artificial-analysis-index.yaml
+++ b/data/benchmarks_processed/artificial-analysis-index.yaml
@@ -1,98 +1,130 @@
 grok-4:
   score: 73.0
   cost: 1630.0
-o4-mini-high:
-  score: 70.0
-  cost: 323.0
+  normalized_cost: 397.8391882966624
 gemini-2.5-pro-06-05:
   score: 70.0
   cost: 971.0
+  normalized_cost: 236.9950011264167
 o3-medium:
   score: 70.0
   cost: 390.0
+  normalized_cost: 95.1885174452137
+o4-mini-high:
+  score: 70.0
+  cost: 323.0
+  normalized_cost: 78.8356182943693
 gemini-2.5-pro-preview-03-25:
   score: 69.0
   cost: 859.0
+  normalized_cost: 209.65881150112455
 deepseek-r1-0528:
   score: 68.0
   cost: 220.0
+  normalized_cost: 53.696086763966704
 gemini-2.5-pro-preview-05-06:
   score: 68.0
   cost: 1335.0
+  normalized_cost: 325.83761740861615
 grok-3-mini-high:
   score: 67.0
   cost: 49.0
+  normalized_cost: 11.959582961065312
 gemini-2.5-flash-0520-thinking:
   score: 65.0
   cost: 319.0
+  normalized_cost: 77.85932580775173
 claude-opus-4-thinking:
   score: 64.0
   cost: 2036.0
+  normalized_cost: 496.9328756883464
 qwen-3-235b-a22b-thinking:
   score: 62.0
   cost: 627.0
+  normalized_cost: 153.0338472773051
 claude-sonnet-4-thinking:
   score: 61.0
   cost: 342.0
+  normalized_cost: 83.47300760580279
 gemini-2.5-flash-preview-0417-thinking:
   score: 60.0
   cost: 445.0
+  normalized_cost: 108.61253913620538
 deepseek-r1-0120:
   score: 60.0
   cost: 291.0
+  normalized_cost: 71.0252784014287
 claude-opus-4-nothinking:
   score: 58.0
   cost: 551.0
-gpt-4.1-mini:
-  score: 53.0
-  cost: 16.0
-gpt-4.1:
-  score: 53.0
-  cost: 65.0
-deepseek-v3-0324:
-  score: 53.0
-  cost: 13.0
-claude-sonnet-4-nothinking:
-  score: 53.0
-  cost: 119.0
+  normalized_cost: 134.48429003157116
 gemini-2.5-flash-0520-nothinking:
   score: 53.0
   cost: 11.0
+  normalized_cost: 2.6848043381983353
+deepseek-v3-0324:
+  score: 53.0
+  cost: 13.0
+  normalized_cost: 3.1729505815071235
+claude-sonnet-4-nothinking:
+  score: 53.0
+  cost: 119.0
+  normalized_cost: 29.044701476872902
+gpt-4.1-mini:
+  score: 53.0
+  cost: 16.0
+  normalized_cost: 3.905169946470306
+gpt-4.1:
+  score: 53.0
+  cost: 65.0
+  normalized_cost: 15.864752907535618
 grok-3:
   score: 51.0
   cost: 154.0
+  normalized_cost: 37.5872607347767
 llama-4-maverick:
   score: 51.0
   cost: 10.0
+  normalized_cost: 2.4407312165439414
 gemini-2.5-flash-preview-0417-nothinking:
   score: 49.0
   cost: 12.0
+  normalized_cost: 2.9288774598527296
 qwen-3-235b-a22b-nothinking:
   score: 47.0
   cost: 23.0
+  normalized_cost: 5.613681798051065
 deepseek-v3-1224:
   score: 46.0
   cost: 9.0
+  normalized_cost: 2.196658094889547
 claude-3.5-sonnet-v2:
   score: 44.0
   cost: 81.0
+  normalized_cost: 19.769922854005923
 llama-4-scout:
   score: 43.0
   cost: 6.0
+  normalized_cost: 1.4644387299263648
 gpt-4o-2024-11-20:
   score: 41.0
   cost: 66.0
+  normalized_cost: 16.108826029190013
 gpt-4.1-nano:
   score: 41.0
   cost: 3.0
+  normalized_cost: 0.7322193649631824
 gpt-4o-2024-05-13:
   score: 41.0
   cost: 109.0
+  normalized_cost: 26.60397026032896
 gpt-4o-2024-08-06:
   score: 41.0
   cost: 68.0
+  normalized_cost: 16.5969722724988
 claude-3.5-sonnet:
   score: 40.0
 claude-3.5-haiku:
   score: 35.0
   cost: 20.0
+  normalized_cost: 4.881462433087883

--- a/data/benchmarks_processed/gpqa-diamond.yaml
+++ b/data/benchmarks_processed/gpqa-diamond.yaml
@@ -1,99 +1,132 @@
 grok-4:
   score: 87.0
   cost: 27.0
+  normalized_cost: 401.8748257278473
 gemini-2.5-pro-06-05:
   score: 84.0
   cost: 16.0
+  normalized_cost: 238.14804487576134
 gemini-2.5-pro-preview-03-25:
   score: 83.0
   cost: 10.0
+  normalized_cost: 148.84252804735084
 o3-medium:
   score: 82.0
   cost: 10.0
+  normalized_cost: 148.84252804735084
 gemini-2.5-pro-preview-05-06:
   score: 82.0
   cost: 25.0
+  normalized_cost: 372.1063201183771
 deepseek-r1-0528:
   score: 81.0
   cost: 4.0
+  normalized_cost: 59.537011218940336
 claude-opus-4-thinking:
   score: 79.0
   cost: 32.0
+  normalized_cost: 476.2960897515227
 grok-3-mini-high:
   score: 79.0
   cost: 1.0
+  normalized_cost: 14.884252804735084
 gemini-2.5-flash-0520-thinking:
   score: 79.0
   cost: 6.0
+  normalized_cost: 89.3055168284105
 o4-mini-high:
   score: 78.0
   cost: 7.0
+  normalized_cost: 104.18976963314559
 claude-sonnet-4-thinking:
   score: 72.0
   cost: 3.0
+  normalized_cost: 44.65275841420525
 deepseek-r1-0120:
   score: 70.0
   cost: 5.0
+  normalized_cost: 74.42126402367542
 claude-opus-4-nothinking:
   score: 70.0
   cost: 8.0
+  normalized_cost: 119.07402243788067
 qwen-3-235b-a22b-thinking:
   score: 70.0
   cost: 11.0
+  normalized_cost: 163.72678085208594
 gemini-2.5-flash-preview-0417-thinking:
   score: 69.0
   cost: 8.0
+  normalized_cost: 119.07402243788067
 grok-3:
   score: 69.0
   cost: 3.0
-claude-sonnet-4-nothinking:
-  score: 68.0
-  cost: 2.0
+  normalized_cost: 44.65275841420525
 gemini-2.5-flash-0520-nothinking:
   score: 68.0
   cost: 0.0
+  normalized_cost: 0.0
+claude-sonnet-4-nothinking:
+  score: 68.0
+  cost: 2.0
+  normalized_cost: 29.768505609470168
 llama-4-maverick:
   score: 67.0
   cost: 0.0
+  normalized_cost: 0.0
 gpt-4.1:
   score: 66.0
   cost: 1.0
+  normalized_cost: 14.884252804735084
 gpt-4.1-mini:
   score: 66.0
   cost: 0.0
+  normalized_cost: 0.0
 deepseek-v3-0324:
   score: 65.0
   cost: 0.0
+  normalized_cost: 0.0
 qwen-3-235b-a22b-nothinking:
   score: 61.0
   cost: 0.0
+  normalized_cost: 0.0
 claude-3.5-sonnet-v2:
   score: 59.0
   cost: 1.0
+  normalized_cost: 14.884252804735084
 gemini-2.5-flash-preview-0417-nothinking:
   score: 59.0
   cost: 0.0
+  normalized_cost: 0.0
 llama-4-scout:
   score: 58.0
   cost: 0.0
+  normalized_cost: 0.0
 claude-3.5-sonnet:
   score: 56.0
   cost: 1.0
+  normalized_cost: 14.884252804735084
 deepseek-v3-1224:
   score: 55.0
   cost: 0.0
+  normalized_cost: 0.0
 gpt-4o-2024-11-20:
   score: 54.0
   cost: 1.0
+  normalized_cost: 14.884252804735084
 gpt-4o-2024-05-13:
   score: 52.0
   cost: 2.0
+  normalized_cost: 29.768505609470168
 gpt-4o-2024-08-06:
   score: 52.0
   cost: 1.0
+  normalized_cost: 14.884252804735084
 gpt-4.1-nano:
   score: 51.0
   cost: 0.0
+  normalized_cost: 0.0
 claude-3.5-haiku:
   score: 40.0
   cost: 0.0
+  normalized_cost: 0.0

--- a/data/benchmarks_processed/humanitys-last-exam.yaml
+++ b/data/benchmarks_processed/humanitys-last-exam.yaml
@@ -1,99 +1,132 @@
 grok-4:
   score: 23.0
   cost: 696.0
+  normalized_cost: 558.610164820052
 gemini-2.5-pro-06-05:
   score: 21.0
   cost: 315.0
+  normalized_cost: 252.8192556297649
 o3-medium:
   score: 20.0
   cost: 165.0
+  normalized_cost: 132.42913390130542
 o4-mini-high:
   score: 17.0
   cost: 153.0
+  normalized_cost: 122.79792416302867
 gemini-2.5-pro-preview-03-25:
   score: 17.0
   cost: 309.0
+  normalized_cost: 248.00365076062653
 gemini-2.5-pro-preview-05-06:
   score: 15.0
   cost: 215.0
+  normalized_cost: 172.55917447745858
 deepseek-r1-0528:
   score: 14.0
   cost: 72.0
+  normalized_cost: 57.78725842966055
 claude-opus-4-thinking:
   score: 11.0
   cost: 546.0
+  normalized_cost: 438.2200430915925
 qwen-3-235b-a22b-thinking:
   score: 11.0
   cost: 196.0
+  normalized_cost: 157.30975905852037
 gemini-2.5-flash-preview-0417-thinking:
   score: 11.0
   cost: 150.0
+  normalized_cost: 120.39012172845948
 gemini-2.5-flash-0520-thinking:
   score: 11.0
   cost: 108.0
+  normalized_cost: 86.68088764449082
 grok-3-mini-high:
   score: 11.0
   cost: 18.0
+  normalized_cost: 14.446814607415137
 deepseek-r1-0120:
   score: 9.0
   cost: 87.0
+  normalized_cost: 69.8262706025065
 claude-sonnet-4-thinking:
   score: 8.0
   cost: 35.0
-gemini-2.5-flash-preview-0417-nothinking:
-  score: 5.0
-  cost: 4.0
-grok-3:
-  score: 5.0
-  cost: 43.0
-gemini-2.5-flash-0520-nothinking:
-  score: 5.0
-  cost: 4.0
-deepseek-v3-0324:
-  score: 5.0
-  cost: 3.0
+  normalized_cost: 28.09102840330721
 claude-opus-4-nothinking:
   score: 5.0
   cost: 110.0
+  normalized_cost: 88.28608926753695
+deepseek-v3-0324:
+  score: 5.0
+  cost: 3.0
+  normalized_cost: 2.4078024345691897
+gemini-2.5-flash-0520-nothinking:
+  score: 5.0
+  cost: 4.0
+  normalized_cost: 3.2104032460922527
+grok-3:
+  score: 5.0
+  cost: 43.0
+  normalized_cost: 34.51183489549172
+gemini-2.5-flash-preview-0417-nothinking:
+  score: 5.0
+  cost: 4.0
+  normalized_cost: 3.2104032460922527
 llama-4-maverick:
   score: 4.0
   cost: 2.0
+  normalized_cost: 1.6052016230461263
 qwen-3-235b-a22b-nothinking:
   score: 4.0
   cost: 4.0
+  normalized_cost: 3.2104032460922527
 gpt-4.1:
   score: 4.0
   cost: 19.0
+  normalized_cost: 15.2494154189382
 gpt-4.1-mini:
   score: 4.0
   cost: 4.0
+  normalized_cost: 3.2104032460922527
 llama-4-scout:
   score: 4.0
   cost: 1.0
+  normalized_cost: 0.8026008115230632
 claude-sonnet-4-nothinking:
   score: 4.0
   cost: 24.0
+  normalized_cost: 19.262419476553518
 gpt-4.1-nano:
   score: 3.0
   cost: 1.0
+  normalized_cost: 0.8026008115230632
 claude-3.5-sonnet-v2:
   score: 3.0
   cost: 15.0
+  normalized_cost: 12.039012172845947
 claude-3.5-sonnet:
   score: 3.0
   cost: 18.0
+  normalized_cost: 14.446814607415137
 deepseek-v3-1224:
   score: 3.0
   cost: 2.0
+  normalized_cost: 1.6052016230461263
 claude-3.5-haiku:
   score: 3.0
   cost: 4.0
+  normalized_cost: 3.2104032460922527
 gpt-4o-2024-11-20:
   score: 3.0
   cost: 17.0
+  normalized_cost: 13.644213795892075
 gpt-4o-2024-08-06:
   score: 2.0
   cost: 13.0
+  normalized_cost: 10.433810549799821
 gpt-4o-2024-05-13:
   score: 2.0
   cost: 22.0
+  normalized_cost: 17.65721785350739

--- a/data/benchmarks_processed/weirdml.yaml
+++ b/data/benchmarks_processed/weirdml.yaml
@@ -1,60 +1,80 @@
 o3-pro-high:
   score: 53.95
   cost: 5.228346341463414
+  normalized_cost: 1298.9177961718394
 gemini-2.5-pro-06-05:
   score: 50.3
   cost: 0.8231632972631578
+  normalized_cost: 204.5047106943054
 o3-high:
   score: 49.76
   cost: 0.4637190857142858
+  normalized_cost: 115.20525487801318
 o4-mini-high:
   score: 49.17
   cost: 0.38685772040816324
+  normalized_cost: 96.11000205544613
 claude-sonnet-4-thinking:
   score: 45.28
   cost: 0.6678551632653063
+  normalized_cost: 165.92033124334785
 claude-sonnet-4-nothinking:
   score: 43.0
   cost: 0.6080159361702128
+  normalized_cost: 151.05401751684948
 grok-4:
   score: 42.55
   cost: 0.9339984292035397
+  normalized_cost: 232.04032442683405
 claude-opus-4-thinking:
   score: 42.12
   cost: 3.3979484210526314
+  normalized_cost: 844.1781370864354
 deepseek-r1-0528:
   score: 40.88
   cost: 0.14200806421052634
+  normalized_cost: 35.28014208625216
 claude-3.5-sonnet-v2:
   score: 39.78
   cost: 0.4931495368421053
+  normalized_cost: 122.51688540564773
 grok-3-mini-high:
   score: 39.58
   cost: 0.03498513
+  normalized_cost: 8.691621593237043
 gemini-2.5-flash-0520-thinking:
   score: 38.73
   cost: 0.21184530736842108
+  normalized_cost: 52.63033888824501
 gpt-4.1:
   score: 37.88
   cost: 0.1965767234042553
+  normalized_cost: 48.83704859373714
 gpt-4.5-preview:
   score: 37.65
   cost: 3.1601368421052634
+  normalized_cost: 785.0968001098188
 gpt-4.1-mini:
   score: 37.25
   cost: 0.03296698105263158
+  normalized_cost: 8.190237520366198
 grok-3:
   score: 36.44
   cost: 0.5004218315789474
+  normalized_cost: 124.32359682753243
 qwen-3-235b-a22b-thinking:
   score: 36.25
   cost: 0.041716346870229015
+  normalized_cost: 10.363908930687096
 deepseek-v3-0324:
   score: 35.09
   cost: 0.027581992000000003
+  normalized_cost: 6.852403785599521
 llama-4-maverick:
   score: 23.62
   cost: 0.012274920000000002
+  normalized_cost: 3.0495516159939164
 gpt-4.1-nano:
   score: 19.04
   cost: 0.005178074782608696
+  normalized_cost: 1.2864284509423847

--- a/lib/yaml-schemas.ts
+++ b/lib/yaml-schemas.ts
@@ -33,6 +33,7 @@ export const ProcessedBenchmarkFileSchema = z.record(
   z.object({
     score: z.number(),
     cost: z.number().optional(),
+    normalized_cost: z.number().optional(),
   }),
 )
 export type ProcessedBenchmarkFile = z.infer<


### PR DESCRIPTION
## Summary
- compute per-benchmark normalization factors using rank‑1 SVD in `process_data.py`
- store the resulting `normalized_cost` in processed benchmark files
- extend YAML schema to allow the new optional field
- regenerate processed benchmark data

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`
- `uv run process_data.py`

------
https://chatgpt.com/codex/tasks/task_e_6872c5f040408320afe7930c79b7f264