### PR TITLE
Add test for zero cost normalization

### DIFF
--- a/scripts_python/tests/test_process_data.py
+++ b/scripts_python/tests/test_process_data.py
@@ -45,3 +45,41 @@ def test_process_benchmark(tmp_path: Path):
         "slug-b": {"score": 0.5, "cost": 0.2},
     }
     assert output == expected
+
+
+def test_zero_cost_ignored(tmp_path: Path):
+    bench_file = tmp_path / "bench.yaml"
+    mapping_dir = tmp_path
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    bench_data = {
+        "model_name_mapping_file": "map.yaml",
+        "results": {
+            "Model A": 1.0,
+            "Model B": 0.8,
+        },
+        "cost_per_task": {
+            "Model A": 0.1,
+            "Model B": 0.0,
+        },
+    }
+    bench_file.write_text(yaml.safe_dump(bench_data, sort_keys=False))
+
+    mapping_data = {
+        "Model A": "slug-a",
+        "Model B": "slug-b",
+    }
+    (mapping_dir / "map.yaml").write_text(yaml.safe_dump(mapping_data, sort_keys=False))
+
+    costs = process_benchmark(bench_file, mapping_dir, out_dir)
+
+    output_path = out_dir / "bench.yaml"
+    output = yaml.safe_load(output_path.read_text())
+
+    expected = {
+        "slug-a": {"score": 1.0, "cost": 0.1},
+        "slug-b": {"score": 0.8},
+    }
+    assert output == expected
+    assert costs == {"slug-a": 0.1}


### PR DESCRIPTION
## Summary
- ensure `process_benchmark` skips raw cost values of 0

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`
- `python3 -m pytest -q scripts_python/tests/test_process_data.py scripts_python/tests/test_update_mappings.py`

------
https://chatgpt.com/codex/tasks/task_e_6872d87729a48320834a4c606f1acd6c