### PR TITLE
Expand cost axis ticks

### DIFF
--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -6,7 +6,9 @@ import { LLMData } from "@/lib/data-loader"
 import { PROVIDER_COLORS } from "@/lib/provider-colors"
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "./ui/chart"
 
-const BASE_TICKS = [0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 1, 3, 10, 30] as const
+const BASE_TICKS = [
+  0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 1, 3, 10, 30, 100, 300, 1000, 3000, 10000,
+] as const
 
 const MIN_BENCHMARKS = 5
 const MIN_COST_BENCHMARKS = 3


### PR DESCRIPTION
## Summary
- expand chart tick range to support high cost values

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_68733b8bf9cc8320bd0e90ecbd88eab3