### PR TITLE
Format cost per task using 3 significant figures

### DIFF
--- a/app/benchmarks/[slug]/page.tsx
+++ b/app/benchmarks/[slug]/page.tsx
@@ -12,6 +12,7 @@ import {
 import { loadBenchmarks, loadBenchmarkDetails } from "@/lib/benchmark-loader"
 import { loadLLMData } from "@/lib/data-loader"
 import { notFound } from "next/navigation"
+import { formatSigFig } from "@/lib/utils"
 
 export async function generateStaticParams() {
   const benches = await loadBenchmarks()
@@ -83,7 +84,7 @@ export default async function BenchmarkPage({
               </TableCell>
               <TableCell className="text-right">
                 {entry.costPerTask !== undefined
-                  ? entry.costPerTask.toFixed(2)
+                  ? formatSigFig(entry.costPerTask)
                   : "—"}
               </TableCell>
               <TableCell className="text-right">

--- a/app/models/[slug]/page.tsx
+++ b/app/models/[slug]/page.tsx
@@ -11,6 +11,7 @@ import {
 import { loadLLMData, loadLLMDetails } from "@/lib/data-loader"
 import { loadBenchmarks } from "@/lib/benchmark-loader"
 import { notFound } from "next/navigation"
+import { formatSigFig } from "@/lib/utils"
 
 export async function generateStaticParams() {
   const data = await loadLLMData()
@@ -62,7 +63,7 @@ export default async function ModelPage({
               </TableCell>
               <TableCell className="text-right">
                 {res?.costPerTask !== undefined
-                  ? res.costPerTask.toFixed(2)
+                  ? formatSigFig(res.costPerTask)
                   : "—"}
               </TableCell>
               <TableCell className="text-right">

--- a/components/columns.tsx
+++ b/components/columns.tsx
@@ -6,6 +6,7 @@ import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { PROVIDER_COLORS } from "@/lib/provider-colors"
+import { formatSigFig } from "@/lib/utils"
 import {
   Popover,
   PopoverTrigger,
@@ -23,7 +24,7 @@ import type { TableRow } from "@/lib/data-loader"
 
 const CostCell = ({ cost }: { cost: number | null }) => {
   if (cost === null || Number.isNaN(cost)) return null
-  return <Badge variant="secondary">{cost.toFixed(2)}</Badge>
+  return <Badge variant="secondary">{formatSigFig(cost)}</Badge>
 }
 
 export const columns: ColumnDef<TableRow>[] = [

--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -5,6 +5,7 @@ import { ScatterChart, Scatter, XAxis, YAxis, ZAxis } from "recharts"
 import { LLMData } from "@/lib/data-loader"
 import { PROVIDER_COLORS } from "@/lib/provider-colors"
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "./ui/chart"
+import { formatSigFig } from "@/lib/utils"
 
 const BASE_TICKS = [0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 1, 3, 10, 30] as const
 
@@ -107,7 +108,7 @@ export default function CostScoreChart({
             scale="log"
             domain={costDomain as [number, number]}
             ticks={ticks}
-            tickFormatter={(v) => v && v.toFixed(2)}
+            tickFormatter={(v) => (v ? formatSigFig(v) : "")}
             label={{
               value: "Normalized Cost per Task ($)",
               position: "insideBottom",
@@ -149,7 +150,8 @@ export default function CostScoreChart({
             }}
             formatter={(value: number | string, name: string) => (
               <span>
-                {name}: {typeof value === "number" ? value.toFixed(2) : value}
+                {name}:{" "}
+                {typeof value === "number" ? formatSigFig(value) : value}
               </span>
             )}
             content={<ChartTooltipContent />}

--- a/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
+++ b/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
@@ -3,7 +3,7 @@
   model: Grok 4
   provider: xAI
   averageScore: 94.12
-  costPerTask: 433.45
+  costPerTask: 433
   costBenchmarkCount: 7
   benchmarkCount: 8
   totalBenchmarks: 10
@@ -13,7 +13,7 @@
   model: o3-pro (high)
   provider: OpenAI
   averageScore: 83.91
-  costPerTask: 1447.61
+  costPerTask: 1450
   costBenchmarkCount: 4
   benchmarkCount: 5
   totalBenchmarks: 10
@@ -23,7 +23,7 @@
   model: Gemini 2.5 Pro 06/05
   provider: Google
   averageScore: 82.91
-  costPerTask: 245.64
+  costPerTask: 246
   costBenchmarkCount: 7
   benchmarkCount: 10
   totalBenchmarks: 10
@@ -33,7 +33,7 @@
   model: o3 (high)
   provider: OpenAI
   averageScore: 82.31
-  costPerTask: 166.27
+  costPerTask: 166
   costBenchmarkCount: 4
   benchmarkCount: 6
   totalBenchmarks: 10
@@ -43,7 +43,7 @@
   model: o3 (medium)
   provider: OpenAI
   averageScore: 78.21
-  costPerTask: 121.09
+  costPerTask: 121
   costBenchmarkCount: 6
   benchmarkCount: 8
   totalBenchmarks: 10
@@ -53,7 +53,7 @@
   model: o4-mini (high)
   provider: OpenAI
   averageScore: 75.29
-  costPerTask: 132.54
+  costPerTask: 133
   costBenchmarkCount: 7
   benchmarkCount: 9
   totalBenchmarks: 10
@@ -63,7 +63,7 @@
   model: Claude 4 Opus (thinking)
   provider: Anthropic
   averageScore: 71.71
-  costPerTask: 547.23
+  costPerTask: 547
   costBenchmarkCount: 7
   benchmarkCount: 9
   totalBenchmarks: 10
@@ -73,7 +73,7 @@
   model: Grok 3 Mini (high)
   provider: xAI
   averageScore: 64.49
-  costPerTask: 11.86
+  costPerTask: 11.9
   costBenchmarkCount: 5
   benchmarkCount: 6
   totalBenchmarks: 10
@@ -83,7 +83,7 @@
   model: DeepSeek R1 05/28
   provider: DeepSeek
   averageScore: 62.97
-  costPerTask: 41.13
+  costPerTask: 41.1
   costBenchmarkCount: 7
   benchmarkCount: 10
   totalBenchmarks: 10
@@ -93,7 +93,7 @@
   model: Claude 4 Sonnet (thinking)
   provider: Anthropic
   averageScore: 62.29
-  costPerTask: 114.42
+  costPerTask: 114
   costBenchmarkCount: 7
   benchmarkCount: 9
   totalBenchmarks: 10

--- a/lib/__tests__/default-leaderboard.snapshot.test.ts
+++ b/lib/__tests__/default-leaderboard.snapshot.test.ts
@@ -3,6 +3,7 @@ import { transformToTableData } from "../table-utils"
 import { stringify } from "yaml"
 import { expect, test } from "vitest"
 import path from "path"
+import { formatSigFig } from "../utils"
 
 // Snapshot of the data that appears in the top 10 rows of the default leaderboard
 // This ensures data loading remains stable independent of the UI
@@ -29,7 +30,7 @@ test("default leaderboard top 10 data", async () => {
       ...row,
       averageScore: Number(row.averageScore.toFixed(2)),
       costPerTask:
-        row.costPerTask === null ? null : Number(row.costPerTask.toFixed(2)),
+        row.costPerTask === null ? null : Number(formatSigFig(row.costPerTask)),
     }))
   const yamlData = stringify(tableRows)
   const snapshotFile = path.join(

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,8 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function formatSigFig(value: number, sig = 3): string {
+  if (!isFinite(value)) return String(value)
+  return Number(value.toPrecision(sig)).toString()
+}


### PR DESCRIPTION
## Summary
- add `formatSigFig` helper
- show normalized cost with 3 significant figures in leaderboard table
- update chart axis and tooltip to use 3 significant figures
- apply same format in benchmark and model pages
- update snapshot tests

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_68733ca235c48320a15bd853276f2d86