### PR TITLE
Refactor process_data to use DataFrames in memory

### DIFF
--- a/scripts_python/tests/test_process_data.py
+++ b/scripts_python/tests/test_process_data.py
@@ -5,14 +5,12 @@ import yaml
 # Add scripts_python directory to path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from process_data import process_benchmark
+from process_data import process_benchmark, build_output
 
 
 def test_process_benchmark(tmp_path: Path):
     bench_file = tmp_path / "bench.yaml"
     mapping_dir = tmp_path
-    out_dir = tmp_path / "out"
-    out_dir.mkdir()
 
     bench_data = {
         "model_name_mapping_file": "map.yaml",
@@ -35,10 +33,8 @@ def test_process_benchmark(tmp_path: Path):
     }
     (mapping_dir / "map.yaml").write_text(yaml.safe_dump(mapping_data, sort_keys=False))
 
-    process_benchmark(bench_file, mapping_dir, out_dir)
-
-    output_path = out_dir / "bench.yaml"
-    output = yaml.safe_load(output_path.read_text())
+    df, costs = process_benchmark(bench_file, mapping_dir)
+    output = build_output(df, None)
 
     expected = {
         "slug-a": {"score": 0.9, "cost": 0.1, "normalized_score": 100.0},
@@ -50,8 +46,6 @@ def test_process_benchmark(tmp_path: Path):
 def test_zero_cost_ignored(tmp_path: Path):
     bench_file = tmp_path / "bench.yaml"
     mapping_dir = tmp_path
-    out_dir = tmp_path / "out"
-    out_dir.mkdir()
 
     bench_data = {
         "model_name_mapping_file": "map.yaml",
@@ -72,10 +66,8 @@ def test_zero_cost_ignored(tmp_path: Path):
     }
     (mapping_dir / "map.yaml").write_text(yaml.safe_dump(mapping_data, sort_keys=False))
 
-    costs = process_benchmark(bench_file, mapping_dir, out_dir)
-
-    output_path = out_dir / "bench.yaml"
-    output = yaml.safe_load(output_path.read_text())
+    df, costs = process_benchmark(bench_file, mapping_dir)
+    output = build_output(df, None)
 
     expected = {
         "slug-a": {"score": 1.0, "cost": 0.1, "normalized_score": 100.0},


### PR DESCRIPTION
## Summary
- refactor `process_data.py` to build all benchmark results in memory
- add `build_output` helper for YAML formatting
- update tests for the new `process_benchmark` API
- keep formatting and linting tidy

## Testing
- `uv sync`
- `uv run pytest`
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`
- `uv run scripts_python/process_data.py`

------
https://chatgpt.com/codex/tasks/task_e_6873542d835c8320a53b02a4b28e7b71