### PR TITLE
Refactor leaderboard toggles

### DIFF
--- a/components/leaderboard-section.tsx
+++ b/components/leaderboard-section.tsx
@@ -1,11 +1,10 @@
 "use client"
 
-import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import { useSearchParams } from "next/navigation"
 import type { LLMData } from "@/lib/data-loader"
 import CostScoreChart from "./cost-score-chart"
 import LeaderboardTable from "./leaderboard-table"
-import { Switch } from "@/components/ui/switch"
-import { Label } from "@/components/ui/label"
+import LeaderboardToggles from "./leaderboard-toggles"
 
 const MIN_BENCHMARKS = 5
 const MIN_COST_BENCHMARKS = 3
@@ -23,22 +22,10 @@ export default function LeaderboardSection({
   llmData: LLMData[]
 }) {
   const searchParams = useSearchParams()
-  const router = useRouter()
-  const pathname = usePathname()
 
   const showDeprecated = searchParams.get("deprecated") === "true"
   const showIncomplete = searchParams.get("incomplete") === "true"
 
-  const updateParam = (key: string, value: boolean) => {
-    const params = new URLSearchParams(searchParams.toString())
-    if (value) {
-      params.set(key, "true")
-    } else {
-      params.delete(key)
-    }
-    const query = params.toString()
-    router.push(query ? `${pathname}?${query}` : pathname, { scroll: false })
-  }
   const visible = llmData.filter((m) => {
     const isNew =
       m.releaseDate && Date.now() - m.releaseDate.getTime() < ONE_WEEK_MS
@@ -58,26 +45,7 @@ export default function LeaderboardSection({
         showDeprecated={showDeprecated}
         showIncomplete={showIncomplete}
       />
-      <div className="flex items-center justify-center gap-2">
-        <div className="flex items-center gap-2">
-          <Switch
-            id="deprecated-toggle"
-            checked={showDeprecated}
-            onCheckedChange={(checked) => updateParam("deprecated", checked)}
-          />
-          <Label htmlFor="deprecated-toggle">Show deprecated models</Label>
-        </div>
-        <div className="flex items-center gap-2">
-          <Switch
-            id="incomplete-toggle"
-            checked={showIncomplete}
-            onCheckedChange={(checked) => updateParam("incomplete", checked)}
-          />
-          <Label htmlFor="incomplete-toggle">
-            Show models with limited data
-          </Label>
-        </div>
-      </div>
+      <LeaderboardToggles />
       <LeaderboardTable llmData={visible} />
     </div>
   )

--- a/components/leaderboard-toggles.tsx
+++ b/components/leaderboard-toggles.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import { Switch } from "@/components/ui/switch"
+import { Label } from "@/components/ui/label"
+
+export default function LeaderboardToggles() {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const pathname = usePathname()
+
+  const showDeprecated = searchParams.get("deprecated") === "true"
+  const showIncomplete = searchParams.get("incomplete") === "true"
+
+  const updateParam = (key: string, value: boolean) => {
+    const params = new URLSearchParams(searchParams.toString())
+    if (value) {
+      params.set(key, "true")
+    } else {
+      params.delete(key)
+    }
+    const query = params.toString()
+    router.push(query ? `${pathname}?${query}` : pathname, { scroll: false })
+  }
+
+  return (
+    <div className="flex items-center justify-center gap-2">
+      <div className="flex items-center gap-2">
+        <Switch
+          id="deprecated-toggle"
+          checked={showDeprecated}
+          onCheckedChange={(checked) => updateParam("deprecated", checked)}
+        />
+        <Label htmlFor="deprecated-toggle">Show deprecated models</Label>
+      </div>
+      <div className="flex items-center gap-2">
+        <Switch
+          id="incomplete-toggle"
+          checked={showIncomplete}
+          onCheckedChange={(checked) => updateParam("incomplete", checked)}
+        />
+        <Label htmlFor="incomplete-toggle">Show models with limited data</Label>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- extract toggle UI into new `LeaderboardToggles` component
- simplify `LeaderboardSection` by using `LeaderboardToggles`

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_6873662fd9e48320a8d107e9ed3b8396