### PR TITLE
Increase spacing below toggles

### DIFF
--- a/components/leaderboard-toggles.tsx
+++ b/components/leaderboard-toggles.tsx
@@ -24,7 +24,7 @@ export default function LeaderboardToggles() {
   }
 
   return (
-    <div className="flex items-center justify-center gap-2">
+    <div className="flex items-center justify-center gap-2 mb-4">
       <div className="flex items-center gap-2">
         <Switch
           id="deprecated-toggle"


### PR DESCRIPTION
## Summary
- add a bottom margin to `LeaderboardToggles` so the table has more room

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_6873ef850fa48320beb04c2bf3e8f5f9