### PR TITLE
Show benchmark weights

### DIFF
--- a/app/benchmarks/page.tsx
+++ b/app/benchmarks/page.tsx
@@ -18,7 +18,9 @@ export const metadata = {
 }
 
 export default async function BenchmarksPage() {
-  const benchmarks = await loadBenchmarks()
+  const benchmarks = (await loadBenchmarks()).filter(
+    (b) => b.scoreWeight !== 0 || b.costWeight !== 0,
+  )
   return (
     <main className="container mx-auto px-4 py-8 max-w-3xl space-y-6">
       <PageHeader
@@ -32,6 +34,8 @@ export default async function BenchmarksPage() {
             <TableHead>Benchmark</TableHead>
             <TableHead>Website</TableHead>
             <TableHead>GitHub</TableHead>
+            <TableHead className="text-right">Score weight</TableHead>
+            <TableHead className="text-right">Cost weight</TableHead>
             <TableHead className="text-right">Models</TableHead>
             <TableHead className="text-right">Cost data?</TableHead>
             <TableHead className="text-right">Private holdout?</TableHead>
@@ -63,6 +67,8 @@ export default async function BenchmarksPage() {
                   </Link>
                 )}
               </TableCell>
+              <TableCell className="text-right">{b.scoreWeight}</TableCell>
+              <TableCell className="text-right">{b.costWeight}</TableCell>
               <TableCell className="text-right">{b.modelCount}</TableCell>
               <TableCell className="text-right">
                 {b.hasCost ? "Yes" : "No"}

--- a/lib/__tests__/benchmark-loader.test.ts
+++ b/lib/__tests__/benchmark-loader.test.ts
@@ -13,4 +13,6 @@ test("loadBenchmarks returns sorted benchmarks", async () => {
   expect(benchmarks[0].modelCount).toBeGreaterThan(0)
   expect(typeof benchmarks[0].hasCost).toBe("boolean")
   expect(typeof benchmarks[0].privateHoldout).toBe("boolean")
+  expect(typeof benchmarks[0].scoreWeight).toBe("number")
+  expect(typeof benchmarks[0].costWeight).toBe("number")
 })

--- a/lib/benchmark-loader.ts
+++ b/lib/benchmark-loader.ts
@@ -12,6 +12,8 @@ export interface BenchmarkInfo {
   description: string
   website?: string
   github?: string
+  scoreWeight: number
+  costWeight: number
   modelCount: number
   hasCost: boolean
   privateHoldout: boolean
@@ -43,6 +45,8 @@ export async function loadBenchmarks(): Promise<BenchmarkInfo[]> {
         description: data.description,
         website: data.website ?? undefined,
         github: data.github ?? undefined,
+        scoreWeight: data.score_weight,
+        costWeight: data.cost_weight,
         modelCount: Object.keys(results).length,
         hasCost: Object.values(results).some((r) => r.cost !== undefined),
         privateHoldout: data.private_holdout,
@@ -89,6 +93,8 @@ export async function loadBenchmarkDetails(
       description: data.description,
       website: data.website ?? undefined,
       github: data.github ?? undefined,
+      scoreWeight: data.score_weight,
+      costWeight: data.cost_weight,
       modelCount: Object.keys(results).length,
       hasCost: Object.keys(costMap).length > 0,
       privateHoldout: data.private_holdout,


### PR DESCRIPTION
## Summary
- display cost and score weight columns on benchmarks page
- filter out benchmarks with zero weight
- expose weights from benchmark loader
- test that the loader returns weight fields

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_6873f54162088320bc87b7e133261a12