### PR TITLE
Expand benchmark page width

### DIFF
--- a/app/benchmarks/[slug]/page.tsx
+++ b/app/benchmarks/[slug]/page.tsx
@@ -45,7 +45,7 @@ export default async function BenchmarkPage({
   entries.sort((a, b) => b.score - a.score)
 
   return (
-    <main className="container mx-auto px-4 py-8 max-w-3xl space-y-6">
+    <main className="container mx-auto px-4 py-8 max-w-7xl space-y-6">
       <PageHeader title={info.benchmark} subtitle={info.description} />
       {(info.website || info.github) && (
         <div className="flex justify-center gap-4 text-sm">

--- a/app/benchmarks/page.tsx
+++ b/app/benchmarks/page.tsx
@@ -22,7 +22,7 @@ export default async function BenchmarksPage() {
     (b) => b.scoreWeight !== 0 || b.costWeight !== 0,
   )
   return (
-    <main className="container mx-auto px-4 py-8 max-w-3xl space-y-6">
+    <main className="container mx-auto px-4 py-8 max-w-7xl space-y-6">
       <PageHeader
         title="Benchmarks"
         subtitle="Models are evaluated on the following benchmarks."


### PR DESCRIPTION
## Summary
- match benchmark pages width to leaderboard page

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`

------
https://chatgpt.com/codex/tasks/task_e_6873f81d2ac483208d22ce3e95e6e346