### PR TITLE
Update page tables styling

### DIFF
--- a/app/benchmarks/[slug]/page.tsx
+++ b/app/benchmarks/[slug]/page.tsx
@@ -62,40 +62,44 @@ export default async function BenchmarkPage({
         </div>
       )}
       <NavigationPills />
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Model</TableHead>
-            <TableHead className="text-right">Raw Score</TableHead>
-            <TableHead className="text-right">Normalized Score</TableHead>
-            <TableHead className="text-right">Raw Cost</TableHead>
-            <TableHead className="text-right">Normalized Cost</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {entries.map((entry) => (
-            <TableRow key={entry.slug}>
-              <TableCell>{entry.model}</TableCell>
-              <TableCell className="text-right">{entry.score}</TableCell>
-              <TableCell className="text-right">
-                {entry.normalizedScore !== undefined
-                  ? entry.normalizedScore.toFixed(1)
-                  : "—"}
-              </TableCell>
-              <TableCell className="text-right">
-                {entry.costPerTask !== undefined
-                  ? formatSigFig(entry.costPerTask)
-                  : "—"}
-              </TableCell>
-              <TableCell className="text-right">
-                {entry.normalizedCost !== undefined
-                  ? entry.normalizedCost.toFixed(2)
-                  : "—"}
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+      <div className="p-6">
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Model</TableHead>
+                <TableHead className="text-right">Raw Score</TableHead>
+                <TableHead className="text-right">Normalized Score</TableHead>
+                <TableHead className="text-right">Raw Cost</TableHead>
+                <TableHead className="text-right">Normalized Cost</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {entries.map((entry) => (
+                <TableRow key={entry.slug}>
+                  <TableCell>{entry.model}</TableCell>
+                  <TableCell className="text-right">{entry.score}</TableCell>
+                  <TableCell className="text-right">
+                    {entry.normalizedScore !== undefined
+                      ? entry.normalizedScore.toFixed(1)
+                      : "—"}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {entry.costPerTask !== undefined
+                      ? formatSigFig(entry.costPerTask)
+                      : "—"}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {entry.normalizedCost !== undefined
+                      ? entry.normalizedCost.toFixed(2)
+                      : "—"}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
     </main>
   )
 }

--- a/app/benchmarks/page.tsx
+++ b/app/benchmarks/page.tsx
@@ -28,66 +28,78 @@ export default async function BenchmarksPage() {
         subtitle="Models are evaluated on the following benchmarks."
       />
       <NavigationPills />
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Benchmark</TableHead>
-            <TableHead>Website</TableHead>
-            <TableHead>GitHub</TableHead>
-            <TableHead className="text-right">Score weight</TableHead>
-            <TableHead className="text-right">Cost weight</TableHead>
-            <TableHead className="text-right">Models</TableHead>
-            <TableHead className="text-right">Cost data?</TableHead>
-            <TableHead className="text-right">Private holdout?</TableHead>
-            <TableHead className="text-right">Details</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {benchmarks.map((b) => (
-            <TableRow key={b.slug}>
-              <TableCell className="space-y-1">
-                <div className="font-semibold">{b.benchmark}</div>
-                {b.description && (
-                  <p className="text-muted-foreground text-sm">
-                    {b.description}
-                  </p>
-                )}
-              </TableCell>
-              <TableCell>
-                {b.website && (
-                  <Link href={b.website} target="_blank" className="underline">
-                    Website
-                  </Link>
-                )}
-              </TableCell>
-              <TableCell>
-                {b.github && (
-                  <Link href={b.github} target="_blank" className="underline">
-                    GitHub
-                  </Link>
-                )}
-              </TableCell>
-              <TableCell className="text-right">{b.scoreWeight}</TableCell>
-              <TableCell className="text-right">{b.costWeight}</TableCell>
-              <TableCell className="text-right">{b.modelCount}</TableCell>
-              <TableCell className="text-right">
-                {b.hasCost ? "Yes" : "No"}
-              </TableCell>
-              <TableCell className="text-right">
-                {b.privateHoldout ? "Yes" : "No"}
-              </TableCell>
-              <TableCell className="text-right">
-                <Link
-                  href={`/benchmarks/${b.slug}`}
-                  className="text-primary underline flex justify-end"
-                >
-                  <ChevronRight className="h-4 w-4" />
-                </Link>
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+      <div className="p-6">
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Benchmark</TableHead>
+                <TableHead>Website</TableHead>
+                <TableHead>GitHub</TableHead>
+                <TableHead className="text-right">Score weight</TableHead>
+                <TableHead className="text-right">Cost weight</TableHead>
+                <TableHead className="text-right">Models</TableHead>
+                <TableHead className="text-right">Cost data?</TableHead>
+                <TableHead className="text-right">Private holdout?</TableHead>
+                <TableHead className="text-right">Details</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {benchmarks.map((b) => (
+                <TableRow key={b.slug}>
+                  <TableCell className="space-y-1">
+                    <div className="font-semibold">{b.benchmark}</div>
+                    {b.description && (
+                      <p className="text-muted-foreground text-sm">
+                        {b.description}
+                      </p>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {b.website && (
+                      <Link
+                        href={b.website}
+                        target="_blank"
+                        className="underline"
+                      >
+                        Website
+                      </Link>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {b.github && (
+                      <Link
+                        href={b.github}
+                        target="_blank"
+                        className="underline"
+                      >
+                        GitHub
+                      </Link>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right">{b.scoreWeight}</TableCell>
+                  <TableCell className="text-right">{b.costWeight}</TableCell>
+                  <TableCell className="text-right">{b.modelCount}</TableCell>
+                  <TableCell className="text-right">
+                    {b.hasCost ? "Yes" : "No"}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {b.privateHoldout ? "Yes" : "No"}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Link
+                      href={`/benchmarks/${b.slug}`}
+                      className="text-primary underline flex justify-end"
+                    >
+                      <ChevronRight className="h-4 w-4" />
+                    </Link>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
     </main>
   )
 }

--- a/app/models/[slug]/page.tsx
+++ b/app/models/[slug]/page.tsx
@@ -39,42 +39,46 @@ export default async function ModelPage({
     <main className="container mx-auto px-4 py-8 max-w-7xl space-y-6">
       <PageHeader title={model.model} subtitle={model.provider} />
       <NavigationPills />
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Benchmark</TableHead>
-            <TableHead className="text-right">Raw Score</TableHead>
-            <TableHead className="text-right">Normalized Score</TableHead>
-            <TableHead className="text-right">Raw Cost</TableHead>
-            <TableHead className="text-right">Normalized Cost</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {entries.map(([name, res]) => (
-            <TableRow key={name}>
-              <TableCell>{name}</TableCell>
-              <TableCell className="text-right">
-                {res?.score !== undefined ? res.score : "—"}
-              </TableCell>
-              <TableCell className="text-right">
-                {res?.normalizedScore !== undefined
-                  ? res.normalizedScore.toFixed(1)
-                  : "—"}
-              </TableCell>
-              <TableCell className="text-right">
-                {res?.costPerTask !== undefined
-                  ? formatSigFig(res.costPerTask)
-                  : "—"}
-              </TableCell>
-              <TableCell className="text-right">
-                {res?.normalizedCost !== undefined
-                  ? res.normalizedCost.toFixed(2)
-                  : "—"}
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+      <div className="p-6">
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Benchmark</TableHead>
+                <TableHead className="text-right">Raw Score</TableHead>
+                <TableHead className="text-right">Normalized Score</TableHead>
+                <TableHead className="text-right">Raw Cost</TableHead>
+                <TableHead className="text-right">Normalized Cost</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {entries.map(([name, res]) => (
+                <TableRow key={name}>
+                  <TableCell>{name}</TableCell>
+                  <TableCell className="text-right">
+                    {res?.score !== undefined ? res.score : "—"}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {res?.normalizedScore !== undefined
+                      ? res.normalizedScore.toFixed(1)
+                      : "—"}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {res?.costPerTask !== undefined
+                      ? formatSigFig(res.costPerTask)
+                      : "—"}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {res?.normalizedCost !== undefined
+                      ? res.normalizedCost.toFixed(2)
+                      : "—"}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- style benchmark list table
- add leaderboard table style to benchmark page
- match leaderboard table styling on model details page

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_6873fef6dfd083209403e1744f52e8ea