### PR TITLE
Create shared model filter hook

### DIFF
--- a/components/benchmark-section.tsx
+++ b/components/benchmark-section.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { useSearchParams } from "next/navigation"
 import BenchmarkCostScoreChart from "@/components/benchmark-cost-score-chart"
 import LeaderboardToggles from "@/components/leaderboard-toggles"
 import type { LLMData } from "@/lib/data-loader"
@@ -13,16 +12,8 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import { MIN_BENCHMARKS, MIN_COST_BENCHMARKS } from "@/lib/settings"
 import React from "react"
-
-const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
-
-function countCostBenchmarks(llm: LLMData) {
-  return Object.values(llm.benchmarks).filter(
-    (b) => b.normalizedCost !== undefined,
-  ).length
-}
+import { useModelFilter } from "@/hooks/use-model-filter"
 
 type Props = {
   llmData: LLMData[]
@@ -30,26 +21,7 @@ type Props = {
 }
 
 export default function BenchmarkSection({ llmData, benchmark }: Props) {
-  const searchParams = useSearchParams()
-
-  const showDeprecated = searchParams.get("deprecated") === "true"
-  const showIncomplete = searchParams.get("incomplete") === "true"
-
-  const visible = React.useMemo(
-    () =>
-      llmData.filter((m) => {
-        const isNew =
-          m.releaseDate && Date.now() - m.releaseDate.getTime() < ONE_WEEK_MS
-        return (
-          isNew ||
-          ((showDeprecated || !m.deprecated) &&
-            (showIncomplete ||
-              (Object.keys(m.benchmarks).length >= MIN_BENCHMARKS &&
-                countCostBenchmarks(m) >= MIN_COST_BENCHMARKS)))
-        )
-      }),
-    [llmData, showDeprecated, showIncomplete],
-  )
+  const { models: visible } = useModelFilter(llmData)
 
   const entries = React.useMemo(() => {
     const list = visible

--- a/components/leaderboard-section.tsx
+++ b/components/leaderboard-section.tsx
@@ -1,42 +1,21 @@
 "use client"
 
-import { useSearchParams } from "next/navigation"
 import type { LLMData } from "@/lib/data-loader"
 import CostScoreChart from "./cost-score-chart"
 import LeaderboardTable from "./leaderboard-table"
 import LeaderboardToggles from "./leaderboard-toggles"
-
-const MIN_BENCHMARKS = 5
-const MIN_COST_BENCHMARKS = 3
-const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
-
-function countCostBenchmarks(llm: LLMData) {
-  return Object.values(llm.benchmarks).filter(
-    (b) => b.normalizedCost !== undefined,
-  ).length
-}
+import { useModelFilter } from "@/hooks/use-model-filter"
 
 export default function LeaderboardSection({
   llmData,
 }: {
   llmData: LLMData[]
 }) {
-  const searchParams = useSearchParams()
-
-  const showDeprecated = searchParams.get("deprecated") === "true"
-  const showIncomplete = searchParams.get("incomplete") === "true"
-
-  const visible = llmData.filter((m) => {
-    const isNew =
-      m.releaseDate && Date.now() - m.releaseDate.getTime() < ONE_WEEK_MS
-    return (
-      isNew ||
-      ((showDeprecated || !m.deprecated) &&
-        (showIncomplete ||
-          (Object.keys(m.benchmarks).length >= MIN_BENCHMARKS &&
-            countCostBenchmarks(m) >= MIN_COST_BENCHMARKS)))
-    )
-  })
+  const {
+    models: visible,
+    showDeprecated,
+    showIncomplete,
+  } = useModelFilter(llmData)
 
   return (
     <div className="space-y-4">

--- a/hooks/use-model-filter.tsx
+++ b/hooks/use-model-filter.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import { useSearchParams } from "next/navigation"
+import * as React from "react"
+import type { LLMData } from "@/lib/data-loader"
+import { MIN_BENCHMARKS, MIN_COST_BENCHMARKS } from "@/lib/settings"
+
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
+
+function countCostBenchmarks(llm: LLMData) {
+  return Object.values(llm.benchmarks).filter(
+    (b) => b.normalizedCost !== undefined,
+  ).length
+}
+
+export function useModelFilter(llmData: LLMData[]) {
+  const searchParams = useSearchParams()
+  const showDeprecated = searchParams.get("deprecated") === "true"
+  const showIncomplete = searchParams.get("incomplete") === "true"
+
+  const models = React.useMemo(
+    () =>
+      llmData.filter((m) => {
+        const isNew =
+          m.releaseDate && Date.now() - m.releaseDate.getTime() < ONE_WEEK_MS
+        return (
+          isNew ||
+          ((showDeprecated || !m.deprecated) &&
+            (showIncomplete ||
+              (Object.keys(m.benchmarks).length >= MIN_BENCHMARKS &&
+                countCostBenchmarks(m) >= MIN_COST_BENCHMARKS)))
+        )
+      }),
+    [llmData, showDeprecated, showIncomplete],
+  )
+
+  return { models, showDeprecated, showIncomplete }
+}


### PR DESCRIPTION
## Summary
- add `useModelFilter` shared hook
- refactor benchmark and leaderboard sections to use the new hook

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687414fc844c83209cdcb4f5eebbf696