### PR TITLE
Fix matharena HMMT scrape

### DIFF
--- a/data/benchmarks/matharena-hmmt-february-2025.yaml
+++ b/data/benchmarks/matharena-hmmt-february-2025.yaml
@@ -4,6 +4,70 @@ website: https://matharena.ai/
 github: https://github.com/eth-sri/matharena
 score_weight: 1
 cost_weight: 1
-results: {}
+results:
+  Claude-3.5-Sonnet: 1.6666666666666667
+  Claude-3.7-Sonnet (Think): 31.666666666666664
+  Claude-Opus-4.0 (Think): 58.33333333333335
+  DeepSeek-R1: 41.66666666666667
+  DeepSeek-R1-0528: 76.66666666666666
+  DeepSeek-R1-Distill-1.5B: 11.666666666666668
+  DeepSeek-R1-Distill-14B: 31.666666666666664
+  DeepSeek-R1-Distill-32B: 33.33333333333333
+  DeepSeek-R1-Distill-70B: 33.333333333333336
+  DeepSeek-V3: 13.333333333333332
+  DeepSeek-V3-03-24: 29.166666666666664
+  Grok 3 Mini (high): 74.16666666666667
+  Grok 3 Mini (low): 50.83333333333334
+  Grok 4: 92.49999999999997
+  QwQ-32B: 47.50000000000001
+  QwQ-32B-Preview: 18.333333333333336
+  Qwen3-235B-A22B: 62.50000000000001
+  Qwen3-30B-A3B: 50.83333333333334
+  gemini-2.0-flash: 13.333333333333334
+  gemini-2.0-flash-thinking: 35.83333333333333
+  gemini-2.0-pro: 7.5
+  gemini-2.5-flash (think): 64.16666666666667
+  gemini-2.5-pro: 82.49999999999999
+  gemini-2.5-pro-05-06: 80.83333333333333
+  gpt-4o: 5.833333333333334
+  o1 (medium): 48.33333333333334
+  o3 (high): 77.5
+  o3-mini (high): 67.50000000000003
+  o3-mini (low): 28.33333333333333
+  o3-mini (medium): 53.33333333333334
+  o4-mini (high): 82.5
+  o4-mini (low): 47.50000000000001
+  o4-mini (medium): 66.66666666666667
 model_name_mapping_file: matharena.yaml
 private_holdout: false
+cost_per_task:
+  Claude-3.5-Sonnet: 1.0012709999999998
+  Claude-3.7-Sonnet (Think): 46.684985999999995
+  Claude-Opus-4.0 (Think): 152.635605
+  DeepSeek-R1: 10.868137
+  DeepSeek-R1-0528: 6.674237060000001
+  DeepSeek-R1-Distill-1.5B: 0.50192892
+  DeepSeek-R1-Distill-14B: 3.0117728000000006
+  DeepSeek-R1-Distill-70B: 2.885176
+  DeepSeek-V3: 0.38610999999999995
+  DeepSeek-V3-03-24: 0.6237932
+  Grok 3 Mini (high): 1.2643894
+  Grok 3 Mini (low): 0.40256090000000005
+  Grok 4: 28.337499
+  QwQ-32B: 2.3463983999999996
+  QwQ-32B-Preview: 1.3930056000000002
+  Qwen3-235B-A22B: 1.0902295999999998
+  Qwen3-30B-A3B: 0.6690028
+  gemini-2.0-flash: 0.16042400000000004
+  gemini-2.0-pro: 1.3687496
+  gemini-2.5-flash (think): 11.412851
+  gemini-2.5-pro: 15.468389999999998
+  gpt-4o: 0.9604900000000001
+  o1 (medium): 107.0409
+  o3 (high): 71.05394
+  o3-mini (high): 9.34109
+  o3-mini (low): 1.4215740000000003
+  o3-mini (medium): 4.030259200000001
+  o4-mini (high): 9.37981
+  o4-mini (low): 1.4228588000000002
+  o4-mini (medium): 3.8701256000000006


### PR DESCRIPTION
## Summary
- rerun the MathArena scraper
- update HMMT February 2025 results with scraped values

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`
- `pnpm -s scrape:matharena`

------
https://chatgpt.com/codex/tasks/task_e_687493ea8f108320b67b93bf2e96577f