### PR TITLE
Add reusable cost performance chart

### DIFF
--- a/components/benchmark-cost-score-chart.tsx
+++ b/components/benchmark-cost-score-chart.tsx
@@ -1,14 +1,9 @@
 "use client"
 
 import React from "react"
-import { ScatterChart, Scatter, XAxis, YAxis, ZAxis } from "recharts"
-import { ChartContainer, ChartTooltip, ChartTooltipContent } from "./ui/chart"
-import { PROVIDER_COLORS } from "@/lib/provider-colors"
-import { formatSigFig } from "@/lib/utils"
-
-const BASE_TICKS = [
-  0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 1, 3, 10, 30, 100, 300, 1000, 3000, 10000,
-] as const
+import CostPerformanceChart, {
+  CostPerformanceEntry,
+} from "./cost-performance-chart"
 
 type Entry = {
   model: string
@@ -22,87 +17,20 @@ type Props = {
 }
 
 export default function BenchmarkCostScoreChart({ entries }: Props) {
-  const data = React.useMemo(
-    () => entries.filter((e) => e.costPerTask > 0),
-    [entries],
-  )
+  const items = React.useMemo(() => {
+    return entries
+      .filter((e) => e.costPerTask > 0)
+      .map((e) => ({
+        label: e.model,
+        provider: e.provider,
+        cost: e.costPerTask,
+        score: e.score,
+      })) as CostPerformanceEntry[]
+  }, [entries])
 
-  const groups = React.useMemo(() => {
-    const map: Record<string, Entry[]> = {}
-    for (const item of data) {
-      if (!map[item.provider]) map[item.provider] = []
-      map[item.provider].push(item)
-    }
-    return map
-  }, [data])
-
-  const costDomain = React.useMemo(() => {
-    const FACTOR = 1.2
-    let min = Infinity
-    let max = -Infinity
-    for (const item of data) {
-      min = Math.min(min, item.costPerTask)
-      max = Math.max(max, item.costPerTask)
-    }
-    if (!isFinite(min) || !isFinite(max)) return [0, 1]
-    return [min / FACTOR, max * FACTOR]
-  }, [data])
-
-  const ticks = React.useMemo(
-    () => BASE_TICKS.filter((t) => t >= costDomain[0] && t <= costDomain[1]),
-    [costDomain],
-  )
-
-  if (!data.length) return null
+  if (!items.length) return null
 
   return (
-    <div className="p-6 pt-0">
-      <ChartContainer
-        config={{
-          costPerTask: { label: "Cost ($)" },
-          score: { label: "Score" },
-        }}
-      >
-        <ScatterChart margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
-          <XAxis
-            dataKey="costPerTask"
-            type="number"
-            name="Cost"
-            scale="log"
-            domain={costDomain as [number, number]}
-            ticks={ticks}
-            tickFormatter={(v) => (v ? formatSigFig(v) : "")}
-            label={{ value: "Cost ($)", position: "insideBottom", offset: -10 }}
-          />
-          <YAxis
-            dataKey="score"
-            type="number"
-            name="Score"
-            domain={[0, "dataMax"] as [number, number | string]}
-            label={{ value: "Score", angle: -90, position: "insideLeft" }}
-          />
-          <ZAxis range={[144, 144]} />
-          <ChartTooltip
-            cursor={false}
-            labelFormatter={(_, payload) => payload?.[0]?.payload.model || null}
-            formatter={(value: number | string, name: string) => (
-              <span>
-                {name}:{" "}
-                {typeof value === "number" ? formatSigFig(value) : value}
-              </span>
-            )}
-            content={<ChartTooltipContent />}
-          />
-          {Object.entries(groups).map(([provider, items]) => (
-            <Scatter
-              key={provider}
-              data={items}
-              name={provider}
-              fill={PROVIDER_COLORS[provider]}
-            />
-          ))}
-        </ScatterChart>
-      </ChartContainer>
-    </div>
+    <CostPerformanceChart entries={items} xLabel="Cost ($)" yLabel="Score" />
   )
 }

--- a/components/cost-performance-chart.tsx
+++ b/components/cost-performance-chart.tsx
@@ -1,0 +1,152 @@
+"use client"
+
+import React from "react"
+import { ScatterChart, Scatter, XAxis, YAxis, ZAxis } from "recharts"
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from "./ui/chart"
+import { PROVIDER_COLORS } from "@/lib/provider-colors"
+import { formatSigFig } from "@/lib/utils"
+
+const BASE_TICKS = [
+  0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 1, 3, 10, 30, 100, 300, 1000, 3000, 10000,
+] as const
+
+export type CostPerformanceEntry = {
+  label: string
+  provider: string
+  cost: number
+  score: number
+  connectKey?: string
+  meta?: unknown
+}
+
+type Props = {
+  entries: CostPerformanceEntry[]
+  xLabel: string
+  yLabel: string
+  renderTooltip?: (entry: CostPerformanceEntry) => React.ReactNode
+}
+
+export default function CostPerformanceChart({
+  entries,
+  xLabel,
+  yLabel,
+  renderTooltip,
+}: Props) {
+  const data = React.useMemo(() => entries.filter((e) => e.cost > 0), [entries])
+
+  const groups = React.useMemo(() => {
+    const map: Record<string, CostPerformanceEntry[]> = {}
+    for (const item of data) {
+      if (!map[item.provider]) map[item.provider] = []
+      map[item.provider].push(item)
+    }
+    return map
+  }, [data])
+
+  const lineGroups = React.useMemo(() => {
+    const map: Record<string, CostPerformanceEntry[]> = {}
+    for (const item of data) {
+      if (!item.connectKey) continue
+      if (!map[item.connectKey]) map[item.connectKey] = []
+      map[item.connectKey].push(item)
+    }
+    for (const items of Object.values(map)) {
+      items.sort((a, b) => {
+        const aOrder =
+          (a.meta as { reasoningOrder?: number })?.reasoningOrder ?? 0
+        const bOrder =
+          (b.meta as { reasoningOrder?: number })?.reasoningOrder ?? 0
+        return aOrder - bOrder
+      })
+    }
+    return map
+  }, [data])
+
+  const costDomain = React.useMemo(() => {
+    const FACTOR = 1.2
+    let min = Infinity
+    let max = -Infinity
+    for (const item of data) {
+      min = Math.min(min, item.cost)
+      max = Math.max(max, item.cost)
+    }
+    if (!isFinite(min) || !isFinite(max)) return [0, 1]
+    return [min / FACTOR, max * FACTOR]
+  }, [data])
+
+  const ticks = React.useMemo(
+    () => BASE_TICKS.filter((t) => t >= costDomain[0] && t <= costDomain[1]),
+    [costDomain],
+  )
+
+  if (!data.length) return null
+
+  return (
+    <div className="p-6 pt-0">
+      <ChartContainer
+        config={{
+          cost: { label: xLabel },
+          score: { label: yLabel },
+        }}
+      >
+        <ScatterChart margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+          <XAxis
+            dataKey="cost"
+            type="number"
+            name="Cost"
+            scale="log"
+            domain={costDomain as [number, number]}
+            ticks={ticks}
+            tickFormatter={(v) => (v ? formatSigFig(v) : "")}
+            label={{ value: xLabel, position: "insideBottom", offset: -10 }}
+          />
+          <YAxis
+            dataKey="score"
+            type="number"
+            name="Score"
+            domain={[0, "dataMax"] as [number, number | string]}
+            label={{ value: yLabel, angle: -90, position: "insideLeft" }}
+          />
+          <ZAxis range={[144, 144]} />
+          <ChartTooltip
+            cursor={false}
+            labelFormatter={(_, payload) => {
+              const entry = payload?.[0]?.payload as CostPerformanceEntry
+              return renderTooltip ? renderTooltip(entry) : entry?.label || null
+            }}
+            formatter={(value: number | string, name: string) => (
+              <span>
+                {name}:{" "}
+                {typeof value === "number" ? formatSigFig(value) : value}
+              </span>
+            )}
+            content={<ChartTooltipContent />}
+          />
+          {Object.entries(groups).map(([provider, items]) => (
+            <Scatter
+              key={provider}
+              data={items}
+              name={provider}
+              fill={PROVIDER_COLORS[provider]}
+            />
+          ))}
+          {Object.entries(lineGroups).map(([key, items]) =>
+            items.length > 1 ? (
+              <Scatter
+                key={`line-${key}`}
+                data={items}
+                name={key}
+                fill={PROVIDER_COLORS[items[0].provider]}
+                line={{
+                  strokeDasharray: "4 4",
+                  stroke: PROVIDER_COLORS[items[0].provider],
+                }}
+                shape={() => <></>}
+              />
+            ) : null,
+          )}
+        </ScatterChart>
+      </ChartContainer>
+    </div>
+  )
+}

--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -1,16 +1,11 @@
 "use client"
 
 import React from "react"
-import { ScatterChart, Scatter, XAxis, YAxis, ZAxis } from "recharts"
 import { LLMData } from "@/lib/data-loader"
-import { PROVIDER_COLORS } from "@/lib/provider-colors"
-import { ChartContainer, ChartTooltip, ChartTooltipContent } from "./ui/chart"
-import { formatSigFig } from "@/lib/utils"
+import CostPerformanceChart, {
+  CostPerformanceEntry,
+} from "./cost-performance-chart"
 import { MIN_BENCHMARKS, MIN_COST_BENCHMARKS } from "@/lib/settings"
-
-const BASE_TICKS = [
-  0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 1, 3, 10, 30, 100, 300, 1000, 3000, 10000,
-] as const
 
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
 
@@ -35,26 +30,6 @@ export default function CostScoreChart({
     () => [...llmData].sort((a, b) => a.slug.localeCompare(b.slug)),
     [llmData],
   )
-  const groups = React.useMemo(() => {
-    const map: Record<string, LLMData[]> = {}
-    for (const item of sorted) {
-      if (!map[item.provider]) map[item.provider] = []
-      map[item.provider].push(item)
-    }
-    return map
-  }, [sorted])
-
-  const modelGroups = React.useMemo(() => {
-    const map: Record<string, LLMData[]> = {}
-    for (const item of llmData) {
-      if (!map[item.modelSlug]) map[item.modelSlug] = []
-      map[item.modelSlug].push(item)
-    }
-    for (const list of Object.values(map)) {
-      list.sort((a, b) => a.reasoningOrder - b.reasoningOrder)
-    }
-    return map
-  }, [llmData])
 
   const visible = React.useMemo(
     () =>
@@ -72,141 +47,42 @@ export default function CostScoreChart({
     [sorted, showDeprecated, showIncomplete],
   )
 
-  const costDomain = React.useMemo(() => {
-    const FACTOR = 1.2
-    let min = Infinity
-    let max = -Infinity
-    for (const item of visible) {
-      if (item.normalizedCost !== undefined) {
-        min = Math.min(min, item.normalizedCost)
-        max = Math.max(max, item.normalizedCost)
-      }
-    }
-    if (!isFinite(min) || !isFinite(max)) return [0, 1]
-    return [min / FACTOR, max * FACTOR]
+  const entries = React.useMemo(() => {
+    return visible
+      .filter((m) => m.normalizedCost !== undefined)
+      .map((m) => ({
+        label: m.model,
+        provider: m.provider,
+        cost: m.normalizedCost as number,
+        score: m.averageScore ?? 0,
+        connectKey: m.modelSlug,
+        meta: m,
+      })) as CostPerformanceEntry[]
   }, [visible])
 
-  const ticks = React.useMemo(
-    () => BASE_TICKS.filter((t) => t >= costDomain[0] && t <= costDomain[1]),
-    [costDomain],
-  )
+  const renderTooltip = React.useCallback((entry: CostPerformanceEntry) => {
+    const llm = entry.meta as LLMData
+    const scoreCount = Object.keys(llm.benchmarks).length
+    const costCount = countCostBenchmarks(llm)
+    return (
+      <div className="grid gap-0.5">
+        <span>{llm.model}</span>
+        <span className="text-xs font-normal text-muted-foreground">
+          {scoreCount} score benchmark{scoreCount === 1 ? "" : "s"}, {costCount}{" "}
+          cost benchmark{costCount === 1 ? "" : "s"}
+        </span>
+      </div>
+    )
+  }, [])
 
-  if (!llmData.length) return null
+  if (!entries.length) return null
 
   return (
-    <div className="p-6 pt-0">
-      <ChartContainer
-        config={{
-          normalizedCost: { label: "Cost" },
-          averageScore: { label: "Score" },
-        }}
-      >
-        <ScatterChart margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
-          <XAxis
-            dataKey="normalizedCost"
-            type="number"
-            name="Cost"
-            scale="log"
-            domain={costDomain as [number, number]}
-            ticks={ticks}
-            tickFormatter={(v) => (v ? formatSigFig(v) : "")}
-            label={{
-              value: "Normalized Cost per Task ($)",
-              position: "insideBottom",
-              offset: -10,
-            }}
-          />
-          <YAxis
-            dataKey="averageScore"
-            type="number"
-            domain={[0, 100]}
-            name="Score"
-            label={{
-              value: "Average Normalized Score",
-              angle: -90,
-              position: "insideLeft",
-            }}
-          />
-          <ZAxis range={[144, 144]} />
-          <ChartTooltip
-            cursor={false}
-            labelFormatter={(_, payload) => {
-              const llm = payload?.[0]?.payload as LLMData
-              if (!llm) return null
-              const scoreCount = Object.keys(llm.benchmarks).length
-              const costCount = countCostBenchmarks(llm)
-              return (
-                <div className="grid gap-0.5">
-                  <span>{llm.model}</span>
-                  <span className="text-xs font-normal text-muted-foreground">
-                    {scoreCount} score benchmark{scoreCount === 1 ? "" : "s"},{" "}
-                    {costCount} cost benchmark{costCount === 1 ? "" : "s"}
-                  </span>
-                </div>
-              )
-            }}
-            itemSorter={(item) => {
-              const order: Record<string, number> = { Score: 0, Cost: 1 }
-              return order[item.name as string] ?? 0
-            }}
-            formatter={(value: number | string, name: string) => (
-              <span>
-                {name}:{" "}
-                {typeof value === "number" ? formatSigFig(value) : value}
-              </span>
-            )}
-            content={<ChartTooltipContent />}
-          />
-          {Object.entries(groups).map(([provider, data]) => (
-            <Scatter
-              key={provider}
-              data={data.map((d) => {
-                const isNew =
-                  d.releaseDate &&
-                  Date.now() - d.releaseDate.getTime() < ONE_WEEK_MS
-                return showDeprecated || !d.deprecated || isNew
-                  ? showIncomplete ||
-                    (Object.keys(d.benchmarks).length >= MIN_BENCHMARKS &&
-                      countCostBenchmarks(d) >= MIN_COST_BENCHMARKS) ||
-                    isNew
-                    ? d
-                    : { ...d, normalizedCost: NaN, averageScore: NaN }
-                  : { ...d, normalizedCost: NaN, averageScore: NaN }
-              })}
-              name={provider}
-              fill={PROVIDER_COLORS[provider]}
-            />
-          ))}
-
-          {Object.entries(modelGroups).map(([model, data]) =>
-            data.length > 1 ? (
-              <Scatter
-                key={`line-${model}`}
-                data={data.map((d) => {
-                  const isNew =
-                    d.releaseDate &&
-                    Date.now() - d.releaseDate.getTime() < ONE_WEEK_MS
-                  return showDeprecated || !d.deprecated || isNew
-                    ? showIncomplete ||
-                      (Object.keys(d.benchmarks).length >= MIN_BENCHMARKS &&
-                        countCostBenchmarks(d) >= MIN_COST_BENCHMARKS) ||
-                      isNew
-                      ? d
-                      : { ...d, normalizedCost: NaN, averageScore: NaN }
-                    : { ...d, normalizedCost: NaN, averageScore: NaN }
-                })}
-                name={model}
-                fill={PROVIDER_COLORS[data[0].provider]}
-                line={{
-                  strokeDasharray: "4 4",
-                  stroke: PROVIDER_COLORS[data[0].provider],
-                }}
-                shape={() => <></>}
-              />
-            ) : null,
-          )}
-        </ScatterChart>
-      </ChartContainer>
-    </div>
+    <CostPerformanceChart
+      entries={entries}
+      xLabel="Normalized Cost per Task ($)"
+      yLabel="Average Normalized Score"
+      renderTooltip={renderTooltip}
+    />
   )
 }


### PR DESCRIPTION
## Summary
- introduce `CostPerformanceChart` shared component
- refactor leaderboard `CostScoreChart` to use the new component
- refactor benchmark chart to reuse the component

## Testing
- `pnpm lint`
- `pnpm prettier`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_687493988a2483208fb68f8883230666