### PR TITLE
Refactor benchmark processing

### DIFF
--- a/scripts_python/tests/test_process_data.py
+++ b/scripts_python/tests/test_process_data.py
@@ -7,13 +7,15 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from process_data import (
-    process_benchmark,
+    load_benchmark,
+    load_mapping_file,
+    normalize_benchmarks,
     build_output,
     compute_normalization_factors,
 )
 
 
-def test_process_benchmark(tmp_path: Path):
+def test_normalize_benchmarks(tmp_path: Path):
     bench_file = tmp_path / "bench.yaml"
     mapping_dir = tmp_path
 
@@ -38,15 +40,32 @@ def test_process_benchmark(tmp_path: Path):
     }
     (mapping_dir / "map.yaml").write_text(yaml.safe_dump(mapping_data, sort_keys=False))
 
-    df, costs, weight = process_benchmark(bench_file, mapping_dir)
-    output = build_output(df, None)
+    bench_df = load_benchmark(bench_file)
+    map_df = load_mapping_file(mapping_dir / "map.yaml")
+    df = bench_df.merge(map_df, on="alias", how="left", suffixes=("", "_map"))
+    if "model_name_mapping_file_map" in df.columns:
+        df = df.drop(columns=["model_name_mapping_file_map"])
+    df = normalize_benchmarks(df)
+    costs = df.set_index("slug")["cost"].dropna().to_dict()
+    output = build_output(
+        df.drop(
+            columns=[
+                "benchmark",
+                "cost_weight",
+                "score_weight",
+                "alias",
+                "model_name_mapping_file",
+            ]
+        ),
+        None,
+    )
 
     expected = {
         "slug-a": {"score": 0.9, "cost": 0.1, "normalized_score": 100.0},
         "slug-b": {"score": 0.5, "cost": 0.2, "normalized_score": 0.0},
     }
     assert output == expected
-    assert weight == 1.0
+    assert df["cost_weight"].iloc[0] == 1.0
 
 
 def test_zero_cost_ignored(tmp_path: Path):
@@ -72,8 +91,25 @@ def test_zero_cost_ignored(tmp_path: Path):
     }
     (mapping_dir / "map.yaml").write_text(yaml.safe_dump(mapping_data, sort_keys=False))
 
-    df, costs, weight = process_benchmark(bench_file, mapping_dir)
-    output = build_output(df, None)
+    bench_df = load_benchmark(bench_file)
+    map_df = load_mapping_file(mapping_dir / "map.yaml")
+    df = bench_df.merge(map_df, on="alias", how="left", suffixes=("", "_map"))
+    if "model_name_mapping_file_map" in df.columns:
+        df = df.drop(columns=["model_name_mapping_file_map"])
+    df = normalize_benchmarks(df)
+    costs = df.set_index("slug")["cost"].dropna().to_dict()
+    output = build_output(
+        df.drop(
+            columns=[
+                "benchmark",
+                "cost_weight",
+                "score_weight",
+                "alias",
+                "model_name_mapping_file",
+            ]
+        ),
+        None,
+    )
 
     expected = {
         "slug-a": {"score": 1.0, "cost": 0.1, "normalized_score": 100.0},
@@ -81,7 +117,7 @@ def test_zero_cost_ignored(tmp_path: Path):
     }
     assert output == expected
     assert costs == {"slug-a": 0.1}
-    assert weight == 1.0
+    assert df["cost_weight"].iloc[0] == 1.0
 
 
 def test_compute_normalization_factors_weighted() -> None:


### PR DESCRIPTION
## Summary
- rewrite `process_data.py` to use idiomatic pandas
- remove `process_benchmark` and add `normalize_benchmarks`
- adjust pipeline to work on a single DataFrame
- update unit tests for new API

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68749c000620832099986ed22cc3990a