### PR TITLE
Connect reasoning efforts on benchmark charts

### DIFF
--- a/components/benchmark-cost-score-chart.tsx
+++ b/components/benchmark-cost-score-chart.tsx
@@ -10,6 +10,8 @@ type Entry = {
   provider: string
   score: number
   costPerTask: number
+  modelSlug: string
+  reasoningOrder: number
 }
 
 type Props = {
@@ -25,6 +27,8 @@ export default function BenchmarkCostScoreChart({ entries }: Props) {
         provider: e.provider,
         cost: e.costPerTask,
         score: e.score,
+        connectKey: e.modelSlug,
+        meta: { reasoningOrder: e.reasoningOrder },
       })) as CostPerformanceEntry[]
   }, [entries])
 

--- a/components/benchmark-section.tsx
+++ b/components/benchmark-section.tsx
@@ -28,11 +28,20 @@ export default function BenchmarkSection({ llmData, benchmark }: Props) {
       .map((m) => {
         const res = m.benchmarks[benchmark]
         return res
-          ? { slug: m.slug, model: m.model, provider: m.provider, ...res }
+          ? {
+              slug: m.slug,
+              modelSlug: m.modelSlug,
+              reasoningOrder: m.reasoningOrder,
+              model: m.model,
+              provider: m.provider,
+              ...res,
+            }
           : null
       })
       .filter(Boolean) as {
       slug: string
+      modelSlug: string
+      reasoningOrder: number
       model: string
       provider: string
       score: number
@@ -48,14 +57,7 @@ export default function BenchmarkSection({ llmData, benchmark }: Props) {
     <div className="space-y-4">
       {entries.some((e) => e.costPerTask !== undefined) && (
         <BenchmarkCostScoreChart
-          entries={
-            entries.filter((e) => e.costPerTask !== undefined) as {
-              model: string
-              provider: string
-              score: number
-              costPerTask: number
-            }[]
-          }
+          entries={entries.filter((e) => e.costPerTask !== undefined)}
         />
       )}
       <LeaderboardToggles />


### PR DESCRIPTION
## Summary
- add connectKey lines to BenchmarkCostScoreChart
- forward modelSlug and reasoningOrder from BenchmarkSection

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_68749c201fac8320a8300d0c5fe7b720