### PR TITLE
Fix chart y-axis

### DIFF
--- a/components/cost-performance-chart.tsx
+++ b/components/cost-performance-chart.tsx
@@ -24,6 +24,8 @@ type Props = {
   xLabel: string
   yLabel: string
   renderTooltip?: (entry: CostPerformanceEntry) => React.ReactNode
+  yDomain?: [number, number]
+  yTicks?: number[]
 }
 
 export default function CostPerformanceChart({
@@ -31,6 +33,8 @@ export default function CostPerformanceChart({
   xLabel,
   yLabel,
   renderTooltip,
+  yDomain,
+  yTicks,
 }: Props) {
   const data = React.useMemo(() => entries.filter((e) => e.cost > 0), [entries])
 
@@ -104,7 +108,8 @@ export default function CostPerformanceChart({
             dataKey="score"
             type="number"
             name="Score"
-            domain={[0, "dataMax"] as [number, number | string]}
+            {...(yDomain ? { domain: yDomain as [number, number] } : {})}
+            {...(yTicks ? { ticks: yTicks } : {})}
             label={{ value: yLabel, angle: -90, position: "insideLeft" }}
           />
           <ZAxis range={[144, 144]} />

--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -82,6 +82,8 @@ export default function CostScoreChart({
       entries={entries}
       xLabel="Normalized Cost per Task ($)"
       yLabel="Average Normalized Score"
+      yDomain={[0, 100]}
+      yTicks={[0, 25, 50, 75, 100]}
       renderTooltip={renderTooltip}
     />
   )


### PR DESCRIPTION
## Summary
- configure `CostPerformanceChart` with optional `yDomain` and `yTicks`
- pin the main leaderboard chart to 0–100 using those props
- let benchmark detail pages auto-scale the y-axis

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_6874a1d1888c8320911d86ef6f2edc0b