### PR TITLE
Fix benchmark chart range

### DIFF
--- a/components/cost-performance-chart.tsx
+++ b/components/cost-performance-chart.tsx
@@ -24,7 +24,7 @@ type Props = {
   xLabel: string
   yLabel: string
   renderTooltip?: (entry: CostPerformanceEntry) => React.ReactNode
-  yDomain?: [number, number]
+  yDomain?: [number, number] | ["dataMin", "dataMax"]
   yTicks?: number[]
 }
 
@@ -108,7 +108,12 @@ export default function CostPerformanceChart({
             dataKey="score"
             type="number"
             name="Score"
-            {...(yDomain ? { domain: yDomain as [number, number] } : {})}
+            domain={
+              (yDomain ?? ["dataMin", "dataMax"]) as [
+                number | "dataMin" | "dataMax",
+                number | "dataMax" | "dataMin",
+              ]
+            }
             {...(yTicks ? { ticks: yTicks } : {})}
             label={{ value: yLabel, angle: -90, position: "insideLeft" }}
           />


### PR DESCRIPTION
## Summary
- allow y-axis domain to be ['dataMin', 'dataMax']
- default benchmarks chart axis domain to dataMin/dataMax

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_6875244bb5b4832098d6f33ee4f7a8fd