### PR TITLE
Fix scatter plot identity when toggling models

### DIFF
--- a/components/cost-performance-chart.tsx
+++ b/components/cost-performance-chart.tsx
@@ -38,15 +38,6 @@ export default function CostPerformanceChart({
 }: Props) {
   const data = React.useMemo(() => entries.filter((e) => e.cost > 0), [entries])
 
-  const groups = React.useMemo(() => {
-    const map: Record<string, CostPerformanceEntry[]> = {}
-    for (const item of data) {
-      if (!map[item.provider]) map[item.provider] = []
-      map[item.provider].push(item)
-    }
-    return map
-  }, [data])
-
   const lineGroups = React.useMemo(() => {
     const map: Record<string, CostPerformanceEntry[]> = {}
     for (const item of data) {
@@ -132,12 +123,14 @@ export default function CostPerformanceChart({
             )}
             content={<ChartTooltipContent />}
           />
-          {Object.entries(groups).map(([provider, items]) => (
+          {data.map((item) => (
             <Scatter
-              key={provider}
-              data={items}
-              name={provider}
-              fill={PROVIDER_COLORS[provider]}
+              key={
+                (item.meta as { modelSlug?: string })?.modelSlug ?? item.label
+              }
+              data={[item]}
+              name={item.provider}
+              fill={PROVIDER_COLORS[item.provider]}
             />
           ))}
           {Object.entries(lineGroups).map(([key, items]) =>


### PR DESCRIPTION
## Summary
- refactor cost-performance chart scatter logic
- render one `<Scatter>` per model keyed by slug so dots keep identity

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_687530d4883883208ad2d0e1e8e6a111