### PR TITLE
Fix scatter plot point identity

### DIFF
--- a/components/cost-performance-chart.tsx
+++ b/components/cost-performance-chart.tsx
@@ -138,6 +138,7 @@ export default function CostPerformanceChart({
               data={items}
               name={provider}
               fill={PROVIDER_COLORS[provider]}
+              isAnimationActive={false}
             />
           ))}
           {Object.entries(lineGroups).map(([key, items]) =>
@@ -152,6 +153,7 @@ export default function CostPerformanceChart({
                   stroke: PROVIDER_COLORS[items[0].provider],
                 }}
                 shape={() => <></>}
+                isAnimationActive={false}
               />
             ) : null,
           )}


### PR DESCRIPTION
## Summary
- disable animation on scatter chart points to keep models tied to the same dots when toggling

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_687530d4883883208ad2d0e1e8e6a111