### PR TITLE
Add model cost/performance chart

### DIFF
--- a/app/models/[slug]/page.tsx
+++ b/app/models/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import NavigationPills from "@/components/navigation-pills"
 import PageHeader from "@/components/page-header"
+import ModelCostScoreChart from "@/components/model-cost-score-chart"
 import {
   Table,
   TableBody,
@@ -39,6 +40,12 @@ export default async function ModelPage({
     <main className="container mx-auto px-4 py-8 max-w-7xl space-y-6">
       <PageHeader title={model.model} subtitle={model.provider} />
       <NavigationPills />
+      <ModelCostScoreChart
+        provider={model.provider}
+        entries={entries
+          .filter(([, res]) => res !== undefined)
+          .map(([benchmark, res]) => ({ benchmark, result: res! }))}
+      />
       <div className="p-6">
         <div className="rounded-md border">
           <Table>

--- a/components/model-cost-score-chart.tsx
+++ b/components/model-cost-score-chart.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import React from "react"
+import CostPerformanceChart, {
+  CostPerformanceEntry,
+} from "./cost-performance-chart"
+import { BenchmarkResult } from "@/lib/data-loader"
+
+type Entry = {
+  benchmark: string
+  result: BenchmarkResult
+}
+
+type Props = {
+  provider: string
+  entries: Entry[]
+}
+
+export default function ModelCostScoreChart({ provider, entries }: Props) {
+  const items = React.useMemo(() => {
+    return entries
+      .filter(
+        (e) =>
+          e.result.normalizedCost !== undefined &&
+          e.result.normalizedScore !== undefined,
+      )
+      .map((e) => ({
+        label: e.benchmark,
+        provider,
+        cost: e.result.normalizedCost as number,
+        score: e.result.normalizedScore as number,
+      })) as CostPerformanceEntry[]
+  }, [entries, provider])
+
+  const renderTooltip = React.useCallback(
+    (entry: CostPerformanceEntry) => <span>{entry.label}</span>,
+    [],
+  )
+
+  if (!items.length) return null
+
+  return (
+    <CostPerformanceChart
+      entries={items}
+      xLabel="Normalized Cost per Task ($)"
+      yLabel="Normalized Score"
+      renderTooltip={renderTooltip}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- add `ModelCostScoreChart` component to reuse cost/perf scatter chart
- display normalized cost and score for each benchmark on the model page

## Testing
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_6877b11c20488320a22b3930d1f8cd1b