### PR TITLE
Filter benchmarks with no models

### DIFF
--- a/app/benchmarks/page.tsx
+++ b/app/benchmarks/page.tsx
@@ -19,7 +19,7 @@ export const metadata = {
 
 export default async function BenchmarksPage() {
   const benchmarks = (await loadBenchmarks()).filter(
-    (b) => b.scoreWeight !== 0 || b.costWeight !== 0,
+    (b) => (b.scoreWeight !== 0 || b.costWeight !== 0) && b.modelCount > 0,
   )
   return (
     <main className="container mx-auto px-4 py-8 max-w-7xl space-y-6">


### PR DESCRIPTION
## Summary
- hide benchmarks that don't have any associated models

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_6877dd9d265c8320bf9b4169db3f2e47