### PR TITLE
Align chart axes across pages

### DIFF
--- a/components/cost-performance-chart.tsx
+++ b/components/cost-performance-chart.tsx
@@ -24,6 +24,7 @@ type Props = {
   xLabel: string
   yLabel: string
   renderTooltip?: (entry: CostPerformanceEntry) => React.ReactNode
+  xDomain?: [number, number]
   yDomain?: [number, number] | ["dataMin", "dataMax"]
   yTicks?: number[]
 }
@@ -33,6 +34,7 @@ export default function CostPerformanceChart({
   xLabel,
   yLabel,
   renderTooltip,
+  xDomain,
   yDomain,
   yTicks,
 }: Props) {
@@ -67,6 +69,7 @@ export default function CostPerformanceChart({
   }, [data])
 
   const costDomain = React.useMemo(() => {
+    if (xDomain) return xDomain
     const FACTOR = 1.2
     let min = Infinity
     let max = -Infinity
@@ -76,7 +79,7 @@ export default function CostPerformanceChart({
     }
     if (!isFinite(min) || !isFinite(max)) return [0, 1]
     return [min / FACTOR, max * FACTOR]
-  }, [data])
+  }, [data, xDomain])
 
   const ticks = React.useMemo(
     () => BASE_TICKS.filter((t) => t >= costDomain[0] && t <= costDomain[1]),

--- a/components/model-cost-score-chart.tsx
+++ b/components/model-cost-score-chart.tsx
@@ -14,9 +14,18 @@ type Entry = {
 type Props = {
   provider: string
   entries: Entry[]
+  xDomain: [number, number]
+  yDomain?: [number, number]
+  yTicks?: number[]
 }
 
-export default function ModelCostScoreChart({ provider, entries }: Props) {
+export default function ModelCostScoreChart({
+  provider,
+  entries,
+  xDomain,
+  yDomain = [0, 100],
+  yTicks = [0, 25, 50, 75, 100],
+}: Props) {
   const items = React.useMemo(() => {
     return entries
       .filter(
@@ -44,6 +53,9 @@ export default function ModelCostScoreChart({ provider, entries }: Props) {
       entries={items}
       xLabel="Normalized Cost per Task ($)"
       yLabel="Normalized Score"
+      xDomain={xDomain}
+      yDomain={yDomain}
+      yTicks={yTicks}
       renderTooltip={renderTooltip}
     />
   )

--- a/lib/chart-utils.ts
+++ b/lib/chart-utils.ts
@@ -1,0 +1,13 @@
+export function computeCostDomain(values: number[]): [number, number] {
+  const FACTOR = 1.2
+  let min = Infinity
+  let max = -Infinity
+  for (const value of values) {
+    if (value > 0) {
+      if (value < min) min = value
+      if (value > max) max = value
+    }
+  }
+  if (!isFinite(min) || !isFinite(max)) return [0, 1]
+  return [min / FACTOR, max * FACTOR]
+}


### PR DESCRIPTION
## Summary
- add computeCostDomain helper
- allow cost-performance chart to take xDomain prop
- expose domain props in model cost chart
- keep model page chart axes consistent with leaderboard

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_68791fa182c483208e2a7781ddde3607