### PR TITLE
Fix links on benchmark details

### DIFF
--- a/app/benchmarks/[slug]/page.tsx
+++ b/app/benchmarks/[slug]/page.tsx
@@ -27,33 +27,36 @@ export default async function BenchmarkPage({
 
   return (
     <main className="container mx-auto px-4 py-8 max-w-7xl space-y-6">
-      <PageHeader title={info.benchmark} subtitle={info.description} />
-      {(info.website || info.github) && (
-        <div className="flex justify-center gap-2">
-          {info.website && (
-            <Link
-              href={info.website}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-primary"
-            >
-              <Globe className="h-5 w-5" />
-              <span className="sr-only">Website</span>
-            </Link>
-          )}
-          {info.github && (
-            <Link
-              href={info.github}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-primary"
-            >
-              <Github className="h-5 w-5" />
-              <span className="sr-only">GitHub</span>
-            </Link>
-          )}
-        </div>
-      )}
+      <PageHeader
+        title={
+          <span className="flex items-center justify-center gap-2">
+            {info.benchmark}
+            {info.website && (
+              <Link
+                href={info.website}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary"
+              >
+                <Globe className="h-5 w-5" />
+                <span className="sr-only">Website</span>
+              </Link>
+            )}
+            {info.github && (
+              <Link
+                href={info.github}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary"
+              >
+                <Github className="h-5 w-5" />
+                <span className="sr-only">GitHub</span>
+              </Link>
+            )}
+          </span>
+        }
+        subtitle={info.description}
+      />
       <NavigationPills />
       <Suspense>
         <BenchmarkSection llmData={relevant} benchmark={info.benchmark} />


### PR DESCRIPTION
## Summary
- restyle the benchmark details page

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687925a242e88320b3da3a4325dd6e61