### PR TITLE
Add Moonshot brand color

### DIFF
--- a/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
+++ b/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
@@ -2,10 +2,10 @@
   slug: grok-4
   model: Grok 4
   provider: xAI
-  averageScore: 94.31
+  averageScore: 93.47
   costPerTask: 478
   costBenchmarkCount: 8
-  benchmarkCount: 9
+  benchmarkCount: 10
   totalBenchmarks: 11
   totalCostBenchmarks: 8
 - id: gemini-2.5-pro-06-05
@@ -62,20 +62,10 @@
   slug: claude-opus-4-thinking
   model: Claude 4 Opus (thinking)
   provider: Anthropic
-  averageScore: 74.54
+  averageScore: 72.59
   costPerTask: 628
   costBenchmarkCount: 8
-  benchmarkCount: 10
-  totalBenchmarks: 11
-  totalCostBenchmarks: 8
-- id: grok-3-mini-high
-  slug: grok-3-mini-high
-  model: Grok 3 Mini (high)
-  provider: xAI
-  averageScore: 66.59
-  costPerTask: 12.8
-  costBenchmarkCount: 6
-  benchmarkCount: 7
+  benchmarkCount: 11
   totalBenchmarks: 11
   totalCostBenchmarks: 8
 - id: deepseek-r1-0528
@@ -88,13 +78,23 @@
   benchmarkCount: 11
   totalBenchmarks: 11
   totalCostBenchmarks: 8
+- id: grok-3-mini-high
+  slug: grok-3-mini-high
+  model: Grok 3 Mini (high)
+  provider: xAI
+  averageScore: 64.35
+  costPerTask: 12.8
+  costBenchmarkCount: 6
+  benchmarkCount: 8
+  totalBenchmarks: 11
+  totalCostBenchmarks: 8
 - id: claude-sonnet-4-thinking
   slug: claude-sonnet-4-thinking
   model: Claude 4 Sonnet (thinking)
   provider: Anthropic
-  averageScore: 64.81
+  averageScore: 62.94
   costPerTask: 135
   costBenchmarkCount: 8
-  benchmarkCount: 10
+  benchmarkCount: 11
   totalBenchmarks: 11
   totalCostBenchmarks: 8

--- a/lib/provider-colors.ts
+++ b/lib/provider-colors.ts
@@ -7,4 +7,5 @@ export const PROVIDER_COLORS: Record<string, string> = {
   Meta: "#1465CE", // slightly darkened Meta blue
   xAI: "#000000", // black
   Qwen: "#7954FF", // purple
+  Moonshot: "#FF539D", // hot pink
 }


### PR DESCRIPTION
## Summary
- add a Moonshot entry to provider colors
- update test snapshots

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_687a8ad45ab08320b2bc91753dacebc8