### PR TITLE
Fix NaN in update mappings

### DIFF
--- a/scripts_python/tests/test_update_mappings.py
+++ b/scripts_python/tests/test_update_mappings.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+import yaml
+
+# Add scripts_python directory to path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from update_mappings import update_all_mappings
+
+
+def test_new_alias_written_as_null(tmp_path: Path) -> None:
+    bench_dir = tmp_path / "bench"
+    mapping_dir = tmp_path / "map"
+    bench_dir.mkdir()
+    mapping_dir.mkdir()
+
+    bench_data = {
+        "model_name_mapping_file": "map.yaml",
+        "results": {"Model A": 1.0, "Model B": 0.5},
+    }
+    (bench_dir / "bench.yaml").write_text(yaml.safe_dump(bench_data, sort_keys=False))
+
+    mapping_data = {"Model A": "slug-a"}
+    (mapping_dir / "map.yaml").write_text(yaml.safe_dump(mapping_data, sort_keys=False))
+
+    update_all_mappings(bench_dir, mapping_dir)
+
+    updated = yaml.safe_load((mapping_dir / "map.yaml").read_text())
+    assert updated == {"Model A": "slug-a", "Model B": None}

--- a/scripts_python/update_mappings.py
+++ b/scripts_python/update_mappings.py
@@ -38,7 +38,13 @@ def update_all_mappings(bench_dir: Path, mapping_dir: Path) -> None:
     # Write to mapping files
     for model_name_mapping_file, df in merged_df.groupby("model_name_mapping_file"):
         mapping_file = mapping_dir / model_name_mapping_file
-        mapping_file.write_text(yaml.safe_dump(dict(zip(df["alias"], df["slug"])), sort_keys=False))
+        mapping_dict = {
+            alias: (None if pd.isna(slug) else slug)
+            for alias, slug in zip(df["alias"], df["slug"])
+        }
+        mapping_file.write_text(
+            yaml.safe_dump(mapping_dict, sort_keys=False)
+        )
     
 
 


### PR DESCRIPTION
## Summary
- ensure unmapped slugs are written as `null`
- test update_mappings null serialization

## Testing
- `pnpm prettier`
- `pnpm lint`
- `uv run --directory scripts_python pytest`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_687b400120108320ba33118ddbd40a48