### PR TITLE
Hide toggles when benchmark page lacks chart

### DIFF
--- a/components/benchmark-section.tsx
+++ b/components/benchmark-section.tsx
@@ -53,14 +53,16 @@ export default function BenchmarkSection({ llmData, benchmark }: Props) {
     return list
   }, [visible, benchmark])
 
+  const showCostChart = entries.some((e) => e.costPerTask !== undefined)
+
   return (
     <div className="space-y-4">
-      {entries.some((e) => e.costPerTask !== undefined) && (
+      {showCostChart && (
         <BenchmarkCostScoreChart
           entries={entries.filter((e) => e.costPerTask !== undefined)}
         />
       )}
-      <LeaderboardToggles />
+      {showCostChart && <LeaderboardToggles />}
       <div className="p-6">
         <div className="rounded-md border">
           <Table>


### PR DESCRIPTION
## Summary
- don't show toggles in benchmark detail section unless there's a cost chart

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_687ba57cd99883209537f37386b151a7