### PR TITLE
docs: improve utility documentation

### DIFF
--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -31,6 +31,13 @@ export interface LLMData {
   normalizedCost?: number
 }
 
+/**
+ * Compute weighted average benchmark scores for each language model.
+ *
+ * Each model's normalized scores are multiplied by their benchmark-specific
+ * weights to produce an overall average score. The `averageScore` field on
+ * each {@link LLMData} entry is updated in place.
+ */
 export function computeAverageScores(
   llmMap: Record<string, LLMData>,
 ): LLMData[] {
@@ -53,6 +60,12 @@ export function computeAverageScores(
   })
 }
 
+/**
+ * Load benchmark and model metadata from YAML files on disk.
+ *
+ * The returned array is sorted in descending order by average benchmark score
+ * and contains normalized cost information when available.
+ */
 export async function loadLLMData(): Promise<LLMData[]> {
   const modelDir = path.join(process.cwd(), "data", "config", "models")
   const benchmarkDir = path.join(process.cwd(), "data", "raw", "benchmarks")
@@ -149,6 +162,12 @@ export async function loadLLMData(): Promise<LLMData[]> {
   return results.sort((a, b) => (b.averageScore || 0) - (a.averageScore || 0))
 }
 
+/**
+ * Retrieve the details for a single language model by its slug.
+ *
+ * @param slug The identifier used in the YAML configuration files.
+ * @returns The matching {@link LLMData} or `null` if it is not found.
+ */
 export async function loadLLMDetails(slug: string): Promise<LLMData | null> {
   const all = await loadLLMData()
   return all.find((m) => m.slug === slug) ?? null

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,10 +1,25 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
+/**
+ * Merge a list of class names using `clsx` and `tailwind-merge`.
+ *
+ * This helper is primarily used to conditionally apply Tailwind CSS classes
+ * while ensuring that conflicting classes are resolved in a predictable way.
+ */
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+/**
+ * Format a number to a fixed number of significant figures.
+ *
+ * Non-finite values such as `Infinity` or `NaN` are returned as strings
+ * unchanged to avoid formatting errors.
+ *
+ * @param value The numeric value to format.
+ * @param sig The number of significant figures to display. Defaults to 3.
+ */
 export function formatSigFig(value: number, sig = 3): string {
   if (!isFinite(value)) return String(value)
   return Number(value.toPrecision(sig)).toString()


### PR DESCRIPTION
## Summary
- add detailed JSDoc comments for class name helper and significant figure formatter
- document data loading helpers including average score calculation and model lookup

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_688ea1e8c57c8320addad996f932a898