### PR TITLE
feat: show score per cost in leaderboard tooltip

### DIFF
--- a/components/cost-performance-chart.tsx
+++ b/components/cost-performance-chart.tsx
@@ -24,6 +24,9 @@ type Props = {
   xLabel: string
   yLabel: string
   renderTooltip?: (entry: CostPerformanceEntry) => React.ReactNode
+  getExtraTooltipEntries?: (
+    entry: CostPerformanceEntry,
+  ) => { name: string; value: number | string }[]
   xDomain?: [number, number]
   yDomain?: [number, number] | ["dataMin", "dataMax"]
   yTicks?: number[]
@@ -34,6 +37,7 @@ export default function CostPerformanceChart({
   xLabel,
   yLabel,
   renderTooltip,
+  getExtraTooltipEntries,
   xDomain,
   yDomain,
   yTicks,
@@ -133,7 +137,26 @@ export default function CostPerformanceChart({
                 {typeof value === "number" ? formatSigFig(value) : value}
               </span>
             )}
-            content={<ChartTooltipContent />}
+            content={(props) => {
+              const entry = props.payload?.[0]?.payload as CostPerformanceEntry
+              const extra =
+                entry && getExtraTooltipEntries
+                  ? getExtraTooltipEntries(entry).map((e) => ({
+                      ...(props.payload?.[0] ?? {}),
+                      name: e.name,
+                      dataKey: e.name,
+                      value: e.value,
+                    }))
+                  : []
+              return (
+                <ChartTooltipContent
+                  {...props}
+                  payload={
+                    props.payload ? [...props.payload, ...extra] : props.payload
+                  }
+                />
+              )
+            }}
           />
           {Object.entries(groups).map(([provider, items]) => (
             <Scatter

--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -75,6 +75,13 @@ export default function CostScoreChart({
     )
   }, [])
 
+  const extraTooltipEntries = React.useCallback(
+    (entry: CostPerformanceEntry) => [
+      { name: "score/cost", value: entry.score / entry.cost },
+    ],
+    [],
+  )
+
   if (!entries.length) return null
 
   return (
@@ -85,6 +92,7 @@ export default function CostScoreChart({
       yDomain={[0, 100]}
       yTicks={[0, 25, 50, 75, 100]}
       renderTooltip={renderTooltip}
+      getExtraTooltipEntries={extraTooltipEntries}
     />
   )
 }


### PR DESCRIPTION
## Summary
- calculate score per cost ratio for models and display it in leaderboard chart tooltip
- support injecting extra tooltip entries in the shared cost performance chart component

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update` *(fails: artificial-analysis.yaml maps to missing slug gpt-5-mini)*

------
https://chatgpt.com/codex/tasks/task_e_68957946e0c483209c0132a45dc4160e