### PR TITLE
Require 3 benchmarks for new models

### DIFF
--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -5,7 +5,11 @@ import { LLMData } from "@/lib/data-loader"
 import CostPerformanceChart, {
   CostPerformanceEntry,
 } from "./cost-performance-chart"
-import { MIN_BENCHMARKS, MIN_COST_BENCHMARKS } from "@/lib/settings"
+import {
+  MIN_BENCHMARKS,
+  MIN_COST_BENCHMARKS,
+  MIN_NEW_MODEL_BENCHMARKS,
+} from "@/lib/settings"
 
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
 
@@ -36,12 +40,14 @@ export default function CostScoreChart({
       sorted.filter((m) => {
         const isNew =
           m.releaseDate && Date.now() - m.releaseDate.getTime() < ONE_WEEK_MS
+        const benchmarkCount = Object.keys(m.benchmarks).length
+        const costCount = countCostBenchmarks(m)
         return (
-          isNew ||
+          (isNew && benchmarkCount >= MIN_NEW_MODEL_BENCHMARKS) ||
           ((showDeprecated || !m.deprecated) &&
             (showIncomplete ||
-              (Object.keys(m.benchmarks).length >= MIN_BENCHMARKS &&
-                countCostBenchmarks(m) >= MIN_COST_BENCHMARKS)))
+              (benchmarkCount >= MIN_BENCHMARKS &&
+                costCount >= MIN_COST_BENCHMARKS)))
         )
       }),
     [sorted, showDeprecated, showIncomplete],

--- a/hooks/use-model-filter.tsx
+++ b/hooks/use-model-filter.tsx
@@ -3,7 +3,11 @@
 import { useSearchParams } from "next/navigation"
 import * as React from "react"
 import type { LLMData } from "@/lib/data-loader"
-import { MIN_BENCHMARKS, MIN_COST_BENCHMARKS } from "@/lib/settings"
+import {
+  MIN_BENCHMARKS,
+  MIN_COST_BENCHMARKS,
+  MIN_NEW_MODEL_BENCHMARKS,
+} from "@/lib/settings"
 
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
 
@@ -23,12 +27,14 @@ export function useModelFilter(llmData: LLMData[]) {
       llmData.filter((m) => {
         const isNew =
           m.releaseDate && Date.now() - m.releaseDate.getTime() < ONE_WEEK_MS
+        const benchmarkCount = Object.keys(m.benchmarks).length
+        const costCount = countCostBenchmarks(m)
         return (
-          isNew ||
+          (isNew && benchmarkCount >= MIN_NEW_MODEL_BENCHMARKS) ||
           ((showDeprecated || !m.deprecated) &&
             (showIncomplete ||
-              (Object.keys(m.benchmarks).length >= MIN_BENCHMARKS &&
-                countCostBenchmarks(m) >= MIN_COST_BENCHMARKS)))
+              (benchmarkCount >= MIN_BENCHMARKS &&
+                costCount >= MIN_COST_BENCHMARKS)))
         )
       }),
     [llmData, showDeprecated, showIncomplete],

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -1,2 +1,3 @@
 export const MIN_BENCHMARKS = 5
 export const MIN_COST_BENCHMARKS = 3
+export const MIN_NEW_MODEL_BENCHMARKS = 3


### PR DESCRIPTION
## Summary
- add `MIN_NEW_MODEL_BENCHMARKS` to settings
- filter out new models with fewer than three benchmarks from model list and cost/score chart

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test:update`


------
https://chatgpt.com/codex/tasks/task_e_68957c959ad483208d04c5ea604ce7a0