### PR TITLE
style: increase spacing between main page toggles

### DIFF
--- a/components/leaderboard-toggles.tsx
+++ b/components/leaderboard-toggles.tsx
@@ -25,7 +25,7 @@ export default function LeaderboardToggles() {
   }
 
   return (
-    <div className="flex items-center justify-center gap-2">
+    <div className="flex items-center justify-center gap-4">
       <div className="flex items-center gap-2">
         <Switch
           id="linear-toggle"


### PR DESCRIPTION
## Summary
- increase spacing between leaderboard toggles by bumping the container gap from 8px to 16px

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68960ceb586c8320a1aa25c9d281e66e