### PR TITLE
feat: enforce cost benchmarks for new models

### DIFF
--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -10,6 +10,7 @@ import {
   MIN_BENCHMARKS,
   MIN_COST_BENCHMARKS,
   MIN_NEW_MODEL_BENCHMARKS,
+  MIN_NEW_MODEL_COST_BENCHMARKS,
 } from "@/lib/settings"
 
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
@@ -46,7 +47,9 @@ export default function CostScoreChart({
         const benchmarkCount = Object.keys(m.benchmarks).length
         const costCount = countCostBenchmarks(m)
         return (
-          (isNew && benchmarkCount >= MIN_NEW_MODEL_BENCHMARKS) ||
+          (isNew &&
+            benchmarkCount >= MIN_NEW_MODEL_BENCHMARKS &&
+            costCount >= MIN_NEW_MODEL_COST_BENCHMARKS) ||
           ((showDeprecated || !m.deprecated) &&
             (showIncomplete ||
               (benchmarkCount >= MIN_BENCHMARKS &&

--- a/hooks/use-model-filter.tsx
+++ b/hooks/use-model-filter.tsx
@@ -7,6 +7,7 @@ import {
   MIN_BENCHMARKS,
   MIN_COST_BENCHMARKS,
   MIN_NEW_MODEL_BENCHMARKS,
+  MIN_NEW_MODEL_COST_BENCHMARKS,
 } from "@/lib/settings"
 
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
@@ -30,7 +31,9 @@ export function useModelFilter(llmData: LLMData[]) {
         const benchmarkCount = Object.keys(m.benchmarks).length
         const costCount = countCostBenchmarks(m)
         return (
-          (isNew && benchmarkCount >= MIN_NEW_MODEL_BENCHMARKS) ||
+          (isNew &&
+            benchmarkCount >= MIN_NEW_MODEL_BENCHMARKS &&
+            costCount >= MIN_NEW_MODEL_COST_BENCHMARKS) ||
           ((showDeprecated || !m.deprecated) &&
             (showIncomplete ||
               (benchmarkCount >= MIN_BENCHMARKS &&

--- a/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
+++ b/lib/__tests__/__snapshots__/default-leaderboard-top10.yaml
@@ -1,13 +1,3 @@
-- id: claude-opus-4.1-nothinking
-  slug: claude-opus-4.1-nothinking
-  model: Claude 4.1 Opus (no thinking)
-  provider: Anthropic
-  averageScore: 94.62
-  costPerTask: null
-  costBenchmarkCount: 0
-  benchmarkCount: 1
-  totalBenchmarks: 12
-  totalCostBenchmarks: 8
 - id: gpt-5-high
   slug: gpt-5-high
   model: GPT-5 (High)
@@ -48,16 +38,6 @@
   benchmarkCount: 12
   totalBenchmarks: 12
   totalCostBenchmarks: 8
-- id: claude-opus-4.1-thinking
-  slug: claude-opus-4.1-thinking
-  model: Claude 4.1 Opus (thinking)
-  provider: Anthropic
-  averageScore: 79.32
-  costPerTask: 931
-  costBenchmarkCount: 1
-  benchmarkCount: 2
-  totalBenchmarks: 12
-  totalCostBenchmarks: 8
 - id: gpt-5-low
   slug: gpt-5-low
   model: GPT-5 (Low)
@@ -96,5 +76,25 @@
   costPerTask: 14
   costBenchmarkCount: 5
   benchmarkCount: 6
+  totalBenchmarks: 12
+  totalCostBenchmarks: 8
+- id: grok-3-mini-high
+  slug: grok-3-mini-high
+  model: Grok 3 Mini (high)
+  provider: xAI
+  averageScore: 62.47
+  costPerTask: 11.6
+  costBenchmarkCount: 6
+  benchmarkCount: 8
+  totalBenchmarks: 12
+  totalCostBenchmarks: 8
+- id: gpt-oss-120b-high
+  slug: gpt-oss-120b-high
+  model: GPT-OSS 120B (High)
+  provider: OpenAI
+  averageScore: 60.01
+  costPerTask: 2.9
+  costBenchmarkCount: 3
+  benchmarkCount: 4
   totalBenchmarks: 12
   totalCostBenchmarks: 8

--- a/lib/__tests__/default-leaderboard.snapshot.test.ts
+++ b/lib/__tests__/default-leaderboard.snapshot.test.ts
@@ -11,6 +11,8 @@ import { formatSigFig } from "../utils"
 test("default leaderboard top 10 data", async () => {
   const MIN_BENCHMARKS = 5
   const MIN_COST_BENCHMARKS = 3
+  const MIN_NEW_MODEL_BENCHMARKS = 3
+  const MIN_NEW_MODEL_COST_BENCHMARKS = 2
   const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
   function countCostBenchmarks(llm: { benchmarks: Record<string, unknown> }) {
     return Object.values(llm.benchmarks).filter(
@@ -19,7 +21,10 @@ test("default leaderboard top 10 data", async () => {
   }
   const llmData = (await loadLLMData()).filter(
     (m) =>
-      (m.releaseDate && Date.now() - m.releaseDate.getTime() < ONE_WEEK_MS) ||
+      (m.releaseDate &&
+        Date.now() - m.releaseDate.getTime() < ONE_WEEK_MS &&
+        Object.keys(m.benchmarks).length >= MIN_NEW_MODEL_BENCHMARKS &&
+        countCostBenchmarks(m) >= MIN_NEW_MODEL_COST_BENCHMARKS) ||
       (!m.deprecated &&
         Object.keys(m.benchmarks).length >= MIN_BENCHMARKS &&
         countCostBenchmarks(m) >= MIN_COST_BENCHMARKS),

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -1,3 +1,4 @@
 export const MIN_BENCHMARKS = 5
 export const MIN_COST_BENCHMARKS = 3
 export const MIN_NEW_MODEL_BENCHMARKS = 3
+export const MIN_NEW_MODEL_COST_BENCHMARKS = 2


### PR DESCRIPTION
## Summary
- require new models to have at least two cost benchmarks before display
- apply new cost benchmark check to model filter and cost score chart
- update leaderboard snapshot tests for new cost benchmark rule

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689625a43e6c83208d2ee2eb18432ec0