### PR TITLE
fix: set linear x-axis minimum to zero

### DIFF
--- a/components/cost-performance-chart.tsx
+++ b/components/cost-performance-chart.tsx
@@ -96,8 +96,11 @@ export default function CostPerformanceChart({
       max = Math.max(max, item.cost)
     }
     if (!isFinite(min) || !isFinite(max)) return [0, 1]
+    if (xScale === "linear") {
+      return [0, max * FACTOR]
+    }
     return [min / FACTOR, max * FACTOR]
-  }, [data, xDomain])
+  }, [data, xDomain, xScale])
 
   const ticks = React.useMemo(() => {
     if (xScale === "log") {


### PR DESCRIPTION
## Summary
- ensure CostPerformanceChart uses 0 as the minimum x-domain when in linear scale

## Testing
- `pnpm prettier components/cost-performance-chart.tsx`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689760b864cc8320b7edd382a80d61c1