### PR TITLE
refactor: adopt joint sigmoid scoring model

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project aggregates scores from popular large language model benchmarks into a single leaderboard.
 
-The goal is to provide a clear comparison of how leading models perform across different tasks. Benchmark results are scraped from official leaderboards, normalized, and averaged so that each benchmark contributes equally to the overall ranking.
+The goal is to provide a clear comparison of how leading models perform across different tasks. Benchmark results are scraped from official leaderboards, transformed using a joint sigmoid model, and averaged so that each benchmark contributes equally to the overall ranking.
 
 Visit the [About page](https://all-the-benchmarks.vercel.app/about) for more details on the methodology.
 

--- a/app/models/[slug]/page.tsx
+++ b/app/models/[slug]/page.tsx
@@ -63,7 +63,7 @@ export default async function ModelPage({
               <TableRow>
                 <TableHead>Benchmark</TableHead>
                 <TableHead className="text-right">Raw Score</TableHead>
-                <TableHead className="text-right">Normalized Score</TableHead>
+                <TableHead className="text-right">Sigmoid Score</TableHead>
                 <TableHead className="text-right">Raw Cost</TableHead>
                 <TableHead className="text-right">Normalized Cost</TableHead>
               </TableRow>
@@ -76,8 +76,8 @@ export default async function ModelPage({
                     {res?.score !== undefined ? res.score : "—"}
                   </TableCell>
                   <TableCell className="text-right">
-                    {res?.normalizedScore !== undefined
-                      ? res.normalizedScore.toFixed(1)
+                    {res?.sigmoidScore !== undefined
+                      ? res.sigmoidScore.toFixed(1)
                       : "—"}
                   </TableCell>
                   <TableCell className="text-right">

--- a/components/benchmark-section.tsx
+++ b/components/benchmark-section.tsx
@@ -45,7 +45,7 @@ export default function BenchmarkSection({ llmData, benchmark }: Props) {
       model: string
       provider: string
       score: number
-      normalizedScore?: number
+      sigmoidScore?: number
       normalizedCost?: number
       costPerTask?: number
     }[]
@@ -70,7 +70,7 @@ export default function BenchmarkSection({ llmData, benchmark }: Props) {
               <TableRow>
                 <TableHead>Model</TableHead>
                 <TableHead className="text-right">Raw Score</TableHead>
-                <TableHead className="text-right">Normalized Score</TableHead>
+                <TableHead className="text-right">Sigmoid Score</TableHead>
                 <TableHead className="text-right">Raw Cost</TableHead>
                 <TableHead className="text-right">Normalized Cost</TableHead>
               </TableRow>
@@ -81,8 +81,8 @@ export default function BenchmarkSection({ llmData, benchmark }: Props) {
                   <TableCell>{entry.model}</TableCell>
                   <TableCell className="text-right">{entry.score}</TableCell>
                   <TableCell className="text-right">
-                    {entry.normalizedScore !== undefined
-                      ? entry.normalizedScore.toFixed(1)
+                    {entry.sigmoidScore !== undefined
+                      ? entry.sigmoidScore.toFixed(1)
                       : "—"}
                   </TableCell>
                   <TableCell className="text-right">

--- a/components/columns.tsx
+++ b/components/columns.tsx
@@ -119,7 +119,7 @@ export const columns: ColumnDef<TableRow>[] = [
           variant="ghost"
           onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
         >
-          Average Normalized Score
+          Average Sigmoid Score
           <ArrowUpDown className="ml-2 h-4 w-4" />
         </Button>
       )

--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -104,7 +104,7 @@ export default function CostScoreChart({
     <CostPerformanceChart
       entries={entries}
       xLabel="Normalized Cost per Task ($)"
-      yLabel="Average Normalized Score"
+      yLabel="Average Sigmoid Score"
       yDomain={[0, 100]}
       yTicks={[0, 25, 50, 75, 100]}
       xScale={useLinearScale ? "linear" : "log"}

--- a/components/leaderboard.tsx
+++ b/components/leaderboard.tsx
@@ -67,7 +67,7 @@ export default async function Leaderboard() {
                     {llm.averageScore?.toFixed(1)}
                   </div>
                   <div className="text-sm text-muted-foreground">
-                    Average Normalized Score
+                    Average Sigmoid Score
                   </div>
                 </div>
               </div>

--- a/components/model-cost-score-chart.tsx
+++ b/components/model-cost-score-chart.tsx
@@ -31,13 +31,13 @@ export default function ModelCostScoreChart({
       .filter(
         (e) =>
           e.result.normalizedCost !== undefined &&
-          e.result.normalizedScore !== undefined,
+          e.result.sigmoidScore !== undefined,
       )
       .map((e) => ({
         label: e.benchmark,
         provider,
         cost: e.result.normalizedCost as number,
-        score: e.result.normalizedScore as number,
+        score: e.result.sigmoidScore as number,
       })) as CostPerformanceEntry[]
   }, [entries, provider])
 
@@ -52,7 +52,7 @@ export default function ModelCostScoreChart({
     <CostPerformanceChart
       entries={items}
       xLabel="Normalized Cost per Task ($)"
-      yLabel="Normalized Score"
+      yLabel="Sigmoid Score"
       xDomain={xDomain}
       yDomain={yDomain}
       yTicks={yTicks}

--- a/data/processed/benchmarks/aider-polyglot.yaml
+++ b/data/processed/benchmarks/aider-polyglot.yaml
@@ -1,165 +1,131 @@
 o3-pro-high:
   score: 84.9
-  normalized_score: 100.0
   cost: 0.6503
   normalized_cost: 1184.0
 o3-high:
   score: 81.3
-  normalized_score: 95.26
   cost: 0.0943
   normalized_cost: 171.8
 grok-4:
   score: 79.6
-  normalized_score: 93.03
   cost: 0.265
   normalized_cost: 482.7
 gemini-2.5-pro-06-05:
   score: 79.1
-  normalized_score: 92.37
   cost: 0.2026
   normalized_cost: 369.0
 o3-medium:
   score: 76.9
-  normalized_score: 89.47
   cost: 0.0611
   normalized_cost: 111.3
 gemini-2.5-pro-preview-05-06:
   score: 76.9
-  normalized_score: 89.47
   cost: 0.1663
   normalized_cost: 302.9
 gemini-2.5-pro-preview-03-25:
   score: 72.9
-  normalized_score: 84.21
 o4-mini-high:
   score: 72.0
-  normalized_score: 83.03
   cost: 0.0873
   normalized_cost: 159.0
 claude-opus-4-thinking:
   score: 72.0
-  normalized_score: 83.03
   cost: 0.2922
   normalized_cost: 532.2
 deepseek-r1-0528:
   score: 71.4
-  normalized_score: 82.24
   cost: 0.0214
   normalized_cost: 38.98
 claude-opus-4-nothinking:
   score: 70.7
-  normalized_score: 81.32
   cost: 0.305
   normalized_cost: 555.5
 claude-3.7-sonnet-thinking:
   score: 64.9
-  normalized_score: 73.68
   cost: 0.1637
   normalized_cost: 298.2
 claude-sonnet-4-thinking:
   score: 61.3
-  normalized_score: 68.95
   cost: 0.1181
   normalized_cost: 215.1
 claude-3.7-sonnet-nothinking:
   score: 60.4
-  normalized_score: 67.76
   cost: 0.0788
   normalized_cost: 143.5
 qwen-3-235b-a22b-nothinking:
   score: 59.6
-  normalized_score: 66.71
 kimi-k2:
   score: 59.1
-  normalized_score: 66.05
   cost: 0.0055
   normalized_cost: 10.02
 deepseek-r1-0120:
   score: 56.9
-  normalized_score: 63.16
   cost: 0.0241
   normalized_cost: 43.9
 claude-sonnet-4-nothinking:
   score: 56.4
-  normalized_score: 62.5
   cost: 0.0703
   normalized_cost: 128.0
 deepseek-v3-0324:
   score: 55.1
-  normalized_score: 60.79
   cost: 0.005
   normalized_cost: 9.107
 grok-3:
   score: 53.3
-  normalized_score: 58.42
   cost: 0.049
   normalized_cost: 89.25
 gpt-4.1:
   score: 52.4
-  normalized_score: 57.24
   cost: 0.0438
   normalized_cost: 79.78
 claude-3.5-sonnet-v2:
   score: 51.6
-  normalized_score: 56.18
   cost: 0.064
   normalized_cost: 116.6
 grok-3-mini-high:
   score: 49.3
-  normalized_score: 53.16
   cost: 0.0033
   normalized_cost: 6.011
 deepseek-v3-1224:
   score: 48.4
-  normalized_score: 51.97
   cost: 0.0015
   normalized_cost: 2.732
 gemini-2.5-flash-0520-thinking:
   score: 47.1
-  normalized_score: 50.26
   cost: 0.0082
   normalized_cost: 14.94
 gpt-4.5-preview:
   score: 44.9
-  normalized_score: 47.37
   cost: 0.8178
   normalized_cost: 1490.0
 gemini-2.5-flash-0520-nothinking:
   score: 44.0
-  normalized_score: 46.18
   cost: 0.005
   normalized_cost: 9.107
 grok-3-mini-low:
   score: 34.7
-  normalized_score: 33.95
   cost: 0.0035
   normalized_cost: 6.375
 gpt-4.1-mini:
   score: 32.4
-  normalized_score: 30.92
   cost: 0.0089
   normalized_cost: 16.21
 claude-3.5-haiku:
   score: 28.0
-  normalized_score: 25.13
   cost: 0.0269
   normalized_cost: 49.0
 gpt-4o-2024-08-06:
   score: 23.1
-  normalized_score: 18.68
   cost: 0.0312
   normalized_cost: 56.83
 gpt-4o-2024-11-20:
   score: 18.2
-  normalized_score: 12.24
   cost: 0.0299
   normalized_cost: 54.46
 llama-4-maverick:
   score: 15.6
-  normalized_score: 8.816
 gpt-4.1-nano:
   score: 8.9
-  normalized_score: 0.0
   cost: 0.0019
   normalized_cost: 3.461
 sigmoid:

--- a/data/processed/benchmarks/arc-agi-1.yaml
+++ b/data/processed/benchmarks/arc-agi-1.yaml
@@ -1,211 +1,169 @@
 grok-4:
   score: 66.7
-  normalized_score: 100.0
   cost: 1.014
   normalized_cost: 402.8
 gpt-5-high:
   score: 65.7
-  normalized_score: 98.5
   cost: 0.5087
   normalized_cost: 202.1
 o3-high:
   score: 60.8
-  normalized_score: 91.15
   cost: 0.5002
   normalized_cost: 198.8
 o3-pro-high:
   score: 59.3
-  normalized_score: 88.91
   cost: 4.16
   normalized_cost: 1653.0
 o4-mini-high:
   score: 58.7
-  normalized_score: 88.01
   cost: 0.4058
   normalized_cost: 161.3
 o3-pro-medium:
   score: 57.0
-  normalized_score: 85.46
   cost: 3.177
   normalized_cost: 1262.0
 gpt-5-medium:
   score: 56.2
-  normalized_score: 84.26
   cost: 0.3301
   normalized_cost: 131.2
 gpt-5-mini-high:
   score: 54.3
-  normalized_score: 81.41
   cost: 0.116
   normalized_cost: 46.1
 o3-medium:
   score: 53.8
-  normalized_score: 80.66
   cost: 0.2882
   normalized_cost: 114.5
 o3-pro-low:
   score: 44.3
-  normalized_score: 66.42
   cost: 1.638
   normalized_cost: 651.0
 gpt-5-low:
   score: 44.0
-  normalized_score: 65.97
   cost: 0.1531
   normalized_cost: 60.84
 o4-mini-medium:
   score: 41.8
-  normalized_score: 62.67
   cost: 0.15
   normalized_cost: 59.61
 o3-low:
   score: 41.5
-  normalized_score: 62.22
   cost: 0.1764
   normalized_cost: 70.1
 claude-sonnet-4-thinking:
   score: 40.0
-  normalized_score: 59.97
   cost: 0.3658
   normalized_cost: 145.4
 gpt-5-mini-medium:
   score: 37.3
-  normalized_score: 55.92
   cost: 0.0401
   normalized_cost: 15.93
 gemini-2.5-pro-06-05:
   score: 37.0
-  normalized_score: 55.47
   cost: 0.5123
   normalized_cost: 203.6
 claude-opus-4-thinking:
   score: 35.7
-  normalized_score: 53.52
   cost: 1.25
   normalized_cost: 496.6
 gemini-2.5-flash-0520-nothinking:
   score: 33.3
-  normalized_score: 49.93
   cost: 0.0371
   normalized_cost: 14.74
 gemini-2.5-flash-0520-thinking:
   score: 32.3
-  normalized_score: 48.43
   cost: 0.1971
   normalized_cost: 78.32
 claude-3.7-sonnet-thinking:
   score: 28.6
-  normalized_score: 42.88
   cost: 0.33
   normalized_cost: 131.1
 gpt-5-mini-low:
   score: 26.3
-  normalized_score: 39.43
   cost: 0.0135
   normalized_cost: 5.365
 claude-sonnet-4-nothinking:
   score: 23.8
-  normalized_score: 35.68
   cost: 0.0806
   normalized_cost: 32.03
 claude-opus-4-nothinking:
   score: 22.5
-  normalized_score: 33.73
   cost: 0.4036
   normalized_cost: 160.4
 o4-mini-low:
   score: 21.3
-  normalized_score: 31.93
   cost: 0.0406
   normalized_cost: 16.13
 deepseek-r1-0528:
   score: 21.2
-  normalized_score: 31.78
   cost: 0.0464
   normalized_cost: 18.44
 gpt-5-nano-medium:
   score: 20.7
-  normalized_score: 31.03
   cost: 0.0124
   normalized_cost: 4.928
 gpt-5-nano-high:
   score: 16.7
-  normalized_score: 25.04
   cost: 0.0292
   normalized_cost: 11.6
 grok-3-mini-low:
   score: 16.5
-  normalized_score: 24.74
   cost: 0.0099
   normalized_cost: 3.934
 deepseek-r1-0120:
   score: 15.8
-  normalized_score: 23.69
   cost: 0.06
   normalized_cost: 23.84
 claude-3.7-sonnet-nothinking:
   score: 13.6
-  normalized_score: 20.39
   cost: 0.058
   normalized_cost: 23.05
 gpt-4.5-preview:
   score: 10.3
-  normalized_score: 15.44
   cost: 0.29
   normalized_cost: 115.2
 gpt-5-minimal:
   score: 6.0
-  normalized_score: 8.996
   cost: 0.0335
   normalized_cost: 13.31
 gpt-4.1:
   score: 5.5
-  normalized_score: 8.246
   cost: 0.039
   normalized_cost: 15.5
 grok-3:
   score: 5.5
-  normalized_score: 8.246
   cost: 0.0931
   normalized_cost: 37.0
 gpt-5-mini-minimal:
   score: 5.3
-  normalized_score: 7.946
   cost: 0.0057
   normalized_cost: 2.265
 gpt-4o-2024-05-13:
   score: 4.5
-  normalized_score: 6.747
   cost: 0.05
   normalized_cost: 19.87
 llama-4-maverick:
   score: 4.4
-  normalized_score: 6.597
   cost: 0.0078
   normalized_cost: 3.1
 gpt-5-nano-low:
   score: 4.0
-  normalized_score: 5.997
   cost: 0.0033
   normalized_cost: 1.311
 gpt-4.1-mini:
   score: 3.5
-  normalized_score: 5.247
   cost: 0.0078
   normalized_cost: 3.1
 gpt-5-nano-minimal:
   score: 1.5
-  normalized_score: 2.249
   cost: 0.0015
   normalized_cost: 0.5961
 llama-4-scout:
   score: 0.5
-  normalized_score: 0.7496
   cost: 0.0041
   normalized_cost: 1.629
 gpt-4.1-nano:
   score: 0.0
-  normalized_score: 0.0
   cost: 0.0021
   normalized_cost: 0.8345
 sigmoid:

--- a/data/processed/benchmarks/arc-agi-2.yaml
+++ b/data/processed/benchmarks/arc-agi-2.yaml
@@ -1,211 +1,169 @@
 grok-4:
   score: 16.0
-  normalized_score: 100.0
   cost: 2.166
   normalized_cost: 493.1
 gpt-5-high:
   score: 9.9
-  normalized_score: 61.88
   cost: 0.7302
   normalized_cost: 166.3
 claude-opus-4-thinking:
   score: 8.6
-  normalized_score: 53.75
   cost: 1.928
   normalized_cost: 439.1
 gpt-5-medium:
   score: 7.5
-  normalized_score: 46.88
   cost: 0.4486
   normalized_cost: 102.1
 o3-high:
   score: 6.5
-  normalized_score: 40.62
   cost: 0.8339
   normalized_cost: 189.9
 o4-mini-high:
   score: 6.1
-  normalized_score: 38.12
   cost: 0.856
   normalized_cost: 194.9
 claude-sonnet-4-thinking:
   score: 5.9
-  normalized_score: 36.88
   cost: 0.4857
   normalized_cost: 110.6
 gemini-2.5-pro-06-05:
   score: 4.9
-  normalized_score: 30.63
   cost: 0.757
   normalized_cost: 172.4
 o3-pro-high:
   score: 4.9
-  normalized_score: 30.63
   cost: 7.552
   normalized_cost: 1719.0
 gpt-5-mini-high:
   score: 4.4
-  normalized_score: 27.5
   cost: 0.1977
   normalized_cost: 45.01
 gpt-5-mini-medium:
   score: 4.0
-  normalized_score: 25.0
   cost: 0.0629
   normalized_cost: 14.32
 o3-medium:
   score: 3.0
-  normalized_score: 18.75
   cost: 0.4787
   normalized_cost: 109.0
 gpt-5-nano-high:
   score: 2.6
-  normalized_score: 16.25
   cost: 0.0295
   normalized_cost: 6.717
 gemini-2.5-flash-0520-thinking:
   score: 2.5
-  normalized_score: 15.62
   cost: 0.3191
   normalized_cost: 72.65
 o4-mini-medium:
   score: 2.4
-  normalized_score: 15.0
   cost: 0.2311
   normalized_cost: 52.62
 o3-pro-low:
   score: 2.1
-  normalized_score: 13.12
   cost: 2.229
   normalized_cost: 507.6
 o3-low:
   score: 2.0
-  normalized_score: 12.5
   cost: 0.2343
   normalized_cost: 53.35
 gpt-5-low:
   score: 1.9
-  normalized_score: 11.88
   cost: 0.1896
   normalized_cost: 43.17
 o3-pro-medium:
   score: 1.9
-  normalized_score: 11.88
   cost: 4.744
   normalized_cost: 1080.0
 gpt-5-mini-minimal:
   score: 1.7
-  normalized_score: 10.62
   cost: 0.0094
   normalized_cost: 2.14
 o4-mini-low:
   score: 1.7
-  normalized_score: 10.62
   cost: 0.05
   normalized_cost: 11.38
 gemini-2.5-flash-0520-nothinking:
   score: 1.7
-  normalized_score: 10.62
   cost: 0.057
   normalized_cost: 12.98
 deepseek-r1-0120:
   score: 1.3
-  normalized_score: 8.125
   cost: 0.08
   normalized_cost: 18.21
 claude-sonnet-4-nothinking:
   score: 1.3
-  normalized_score: 8.125
   cost: 0.1272
   normalized_cost: 28.96
 claude-opus-4-nothinking:
   score: 1.3
-  normalized_score: 8.125
   cost: 0.6388
   normalized_cost: 145.4
 deepseek-r1-0528:
   score: 1.1
-  normalized_score: 6.875
   cost: 0.0527
   normalized_cost: 12.0
 gpt-5-nano-medium:
   score: 0.9
-  normalized_score: 5.625
   cost: 0.0137
   normalized_cost: 3.119
 gpt-5-mini-low:
   score: 0.8
-  normalized_score: 5.0
   cost: 0.0189
   normalized_cost: 4.303
 gpt-4.5-preview:
   score: 0.8
-  normalized_score: 5.0
   cost: 2.1
   normalized_cost: 478.1
 claude-3.7-sonnet-thinking:
   score: 0.7
-  normalized_score: 4.375
   cost: 0.51
   normalized_cost: 116.1
 grok-3-mini-low:
   score: 0.4
-  normalized_score: 2.5
   cost: 0.0131
   normalized_cost: 2.983
 gpt-4.1:
   score: 0.4
-  normalized_score: 2.5
   cost: 0.0691
   normalized_cost: 15.73
 gpt-5-nano-minimal:
   score: 0.0
-  normalized_score: 0.0
   cost: 0.0025
   normalized_cost: 0.5692
 gpt-5-nano-low:
   score: 0.0
-  normalized_score: 0.0
   cost: 0.0033
   normalized_cost: 0.7513
 gpt-4.1-nano:
   score: 0.0
-  normalized_score: 0.0
   cost: 0.0036
   normalized_cost: 0.8196
 llama-4-scout:
   score: 0.0
-  normalized_score: 0.0
   cost: 0.0062
   normalized_cost: 1.412
 llama-4-maverick:
   score: 0.0
-  normalized_score: 0.0
   cost: 0.0121
   normalized_cost: 2.755
 gpt-4.1-mini:
   score: 0.0
-  normalized_score: 0.0
   cost: 0.0139
   normalized_cost: 3.165
 gpt-5-minimal:
   score: 0.0
-  normalized_score: 0.0
   cost: 0.0562
   normalized_cost: 12.8
 gpt-4o-2024-05-13:
   score: 0.0
-  normalized_score: 0.0
   cost: 0.08
   normalized_cost: 18.21
 claude-3.7-sonnet-nothinking:
   score: 0.0
-  normalized_score: 0.0
   cost: 0.12
   normalized_cost: 27.32
 grok-3:
   score: 0.0
-  normalized_score: 0.0
   cost: 0.1421
   normalized_cost: 32.35
 sigmoid:

--- a/data/processed/benchmarks/artificial-analysis-index.yaml
+++ b/data/processed/benchmarks/artificial-analysis-index.yaml
@@ -1,182 +1,139 @@
 gpt-5-high:
   score: 69.0
-  normalized_score: 100.0
   cost: 823.0
   normalized_cost: 198.2
 gpt-5-medium:
   score: 68.0
-  normalized_score: 97.83
   cost: 432.0
   normalized_cost: 104.0
 grok-4:
   score: 68.0
-  normalized_score: 97.83
   cost: 1658.0
   normalized_cost: 399.2
 o3-medium:
   score: 67.0
-  normalized_score: 95.65
   cost: 410.0
   normalized_cost: 98.73
 o4-mini-high:
   score: 65.0
-  normalized_score: 91.3
   cost: 330.0
   normalized_cost: 79.46
 gemini-2.5-pro-06-05:
   score: 65.0
-  normalized_score: 91.3
   cost: 983.0
   normalized_cost: 236.7
 gpt-5-mini-medium:
   score: 64.0
-  normalized_score: 89.13
 gpt-5-low:
   score: 63.0
-  normalized_score: 86.96
   cost: 169.0
   normalized_cost: 40.69
 claude-sonnet-4-thinking:
   score: 59.0
-  normalized_score: 78.26
   cost: 650.0
   normalized_cost: 156.5
 gemini-2.5-pro-preview-03-25:
   score: 59.0
-  normalized_score: 78.26
 gpt-oss-120b-high:
   score: 58.0
-  normalized_score: 76.09
   cost: 13.0
   normalized_cost: 3.13
 grok-3-mini-high:
   score: 58.0
-  normalized_score: 76.09
   cost: 67.0
   normalized_cost: 16.13
 gemini-2.5-flash-0520-thinking:
   score: 58.0
-  normalized_score: 76.09
   cost: 229.0
   normalized_cost: 55.14
 gemini-2.5-pro-preview-05-06:
   score: 58.0
-  normalized_score: 76.09
 claude-opus-4-thinking:
   score: 55.0
-  normalized_score: 69.57
   cost: 1999.0
   normalized_cost: 481.4
 gpt-5-nano-medium:
   score: 54.0
-  normalized_score: 67.39
 gpt-oss-20b-high:
   score: 51.0
-  normalized_score: 60.87
   cost: 9.0
   normalized_cost: 2.167
 deepseek-r1-0120:
   score: 50.0
-  normalized_score: 58.7
 gemini-2.5-flash-preview-0417-thinking:
   score: 50.0
-  normalized_score: 58.7
 kimi-k2:
   score: 49.0
-  normalized_score: 56.52
   cost: 76.0
   normalized_cost: 18.3
 qwen-3-235b-a22b-thinking:
   score: 48.0
-  normalized_score: 54.35
   cost: 706.0
   normalized_cost: 170.0
 gemini-2.5-flash-0520-nothinking:
   score: 47.0
-  normalized_score: 52.17
   cost: 46.0
   normalized_cost: 11.08
 gpt-4.1:
   score: 47.0
-  normalized_score: 52.17
   cost: 63.0
   normalized_cost: 15.17
 claude-opus-4-nothinking:
   score: 47.0
-  normalized_score: 52.17
   cost: 539.0
   normalized_cost: 129.8
 claude-3.7-sonnet-thinking:
   score: 47.0
-  normalized_score: 52.17
 claude-sonnet-4-nothinking:
   score: 46.0
-  normalized_score: 50.0
   cost: 117.0
   normalized_cost: 28.17
 deepseek-v3-0324:
   score: 44.0
-  normalized_score: 45.65
   cost: 13.0
   normalized_cost: 3.13
 gpt-5-minimal:
   score: 44.0
-  normalized_score: 45.65
   cost: 41.0
   normalized_cost: 9.873
 llama-4-maverick:
   score: 42.0
-  normalized_score: 41.3
   cost: 10.0
   normalized_cost: 2.408
 gpt-4.1-mini:
   score: 42.0
-  normalized_score: 41.3
 grok-3:
   score: 40.0
-  normalized_score: 36.96
 gemini-2.5-flash-preview-0417-nothinking:
   score: 38.0
-  normalized_score: 32.61
 claude-3.7-sonnet-nothinking:
   score: 37.0
-  normalized_score: 30.43
 deepseek-v3-1224:
   score: 35.0
-  normalized_score: 26.09
 llama-4-scout:
   score: 33.0
-  normalized_score: 21.74
   cost: 6.0
   normalized_cost: 1.445
 qwen-3-235b-a22b-nothinking:
   score: 33.0
-  normalized_score: 21.74
   cost: 22.0
   normalized_cost: 5.298
 claude-3.5-sonnet-v2:
   score: 33.0
-  normalized_score: 21.74
 gpt-4o-2024-11-20:
   score: 30.0
-  normalized_score: 15.22
   cost: 63.0
   normalized_cost: 15.17
 gpt-4.1-nano:
   score: 30.0
-  normalized_score: 15.22
 gpt-4o-2024-05-13:
   score: 30.0
-  normalized_score: 15.22
 claude-3.5-sonnet:
   score: 29.0
-  normalized_score: 13.04
 gpt-4o-2024-08-06:
   score: 29.0
-  normalized_score: 13.04
 claude-3.5-haiku:
   score: 23.0
-  normalized_score: 0.0
 sigmoid:
   min: 28.00780755846265
   max: 65.5869146992636

--- a/data/processed/benchmarks/eqbench3.yaml
+++ b/data/processed/benchmarks/eqbench3.yaml
@@ -1,75 +1,51 @@
 kimi-k2:
   score: 1565.0
-  normalized_score: 100.0
 o3-medium:
   score: 1500.0
-  normalized_score: 94.04
 gemini-2.5-pro-06-05:
   score: 1470.0
-  normalized_score: 91.32
 o4-mini-medium:
   score: 1291.0
-  normalized_score: 74.97
 claude-opus-4-nothinking:
   score: 1290.0
-  normalized_score: 74.88
 gemini-2.5-pro-preview-03-25:
   score: 1284.0
-  normalized_score: 74.38
 deepseek-r1-0120:
   score: 1270.0
-  normalized_score: 73.06
 claude-sonnet-4-nothinking:
   score: 1261.0
-  normalized_score: 72.21
 gemini-2.5-pro-preview-05-06:
   score: 1247.0
-  normalized_score: 70.96
 gpt-4.1:
   score: 1235.0
-  normalized_score: 69.84
 grok-4:
   score: 1193.0
-  normalized_score: 66.05
 deepseek-v3-0324:
   score: 1170.0
-  normalized_score: 63.97
 gpt-oss-120b-medium:
   score: 1152.0
-  normalized_score: 62.3
 gpt-4.1-mini:
   score: 1144.0
-  normalized_score: 61.6
 gpt-4.5-preview:
   score: 1093.0
-  normalized_score: 56.88
 claude-3.7-sonnet-nothinking:
   score: 1083.0
-  normalized_score: 55.96
 claude-3.5-sonnet-v2:
   score: 1068.0
-  normalized_score: 54.59
 grok-3:
   score: 1066.0
-  normalized_score: 54.47
 gemini-2.5-flash-preview-0417-nothinking:
   score: 1046.0
-  normalized_score: 52.64
 grok-3-mini-nothinking:
   score: 984.7
-  normalized_score: 47.02
 gpt-4.1-nano:
   score: 903.6
-  normalized_score: 39.62
 gpt-oss-20b-medium:
   score: 800.2
-  normalized_score: 30.19
 llama-4-maverick:
   score: 627.8
-  normalized_score: 14.45
 llama-4-scout:
   score: 469.4
-  normalized_score: 0.0
 sigmoid:
   min: 422.25124980169824
   max: 1843.32914056633

--- a/data/processed/benchmarks/gpqa-diamond.yaml
+++ b/data/processed/benchmarks/gpqa-diamond.yaml
@@ -1,194 +1,151 @@
 grok-4:
   score: 87.0
-  normalized_score: 100.0
   cost: 27.0
   normalized_cost: 387.9
 gpt-5-high:
   score: 85.0
-  normalized_score: 95.74
   cost: 14.0
   normalized_cost: 201.1
 gpt-5-medium:
   score: 84.0
-  normalized_score: 93.62
   cost: 7.0
   normalized_cost: 100.6
 gemini-2.5-pro-06-05:
   score: 84.0
-  normalized_score: 93.62
   cost: 16.0
   normalized_cost: 229.9
 gemini-2.5-pro-preview-03-25:
   score: 83.0
-  normalized_score: 91.49
   cost: 10.0
   normalized_cost: 143.7
 o3-medium:
   score: 82.0
-  normalized_score: 89.36
   cost: 10.0
   normalized_cost: 143.7
 gemini-2.5-pro-preview-05-06:
   score: 82.0
-  normalized_score: 89.36
   cost: 25.0
   normalized_cost: 359.2
 gpt-5-mini-medium:
   score: 80.0
-  normalized_score: 85.11
   cost: 1.0
   normalized_cost: 14.37
 gpt-5-low:
   score: 80.0
-  normalized_score: 85.11
   cost: 3.0
   normalized_cost: 43.1
 grok-3-mini-high:
   score: 79.0
-  normalized_score: 82.98
   cost: 1.0
   normalized_cost: 14.37
 gemini-2.5-flash-0520-thinking:
   score: 79.0
-  normalized_score: 82.98
   cost: 4.0
   normalized_cost: 57.47
 claude-opus-4-thinking:
   score: 79.0
-  normalized_score: 82.98
   cost: 32.0
   normalized_cost: 459.7
 o4-mini-high:
   score: 78.0
-  normalized_score: 80.85
   cost: 7.0
   normalized_cost: 100.6
 claude-sonnet-4-thinking:
   score: 77.0
-  normalized_score: 78.72
   cost: 12.0
   normalized_cost: 172.4
 claude-3.7-sonnet-thinking:
   score: 77.0
-  normalized_score: 78.72
   cost: 27.0
   normalized_cost: 387.9
 kimi-k2:
   score: 76.0
-  normalized_score: 76.6
   cost: 1.0
   normalized_cost: 14.37
 gpt-oss-120b-high:
   score: 72.0
-  normalized_score: 68.09
 deepseek-r1-0120:
   score: 70.0
-  normalized_score: 63.83
   cost: 4.0
   normalized_cost: 57.47
 claude-opus-4-nothinking:
   score: 70.0
-  normalized_score: 63.83
   cost: 8.0
   normalized_cost: 114.9
 qwen-3-235b-a22b-thinking:
   score: 70.0
-  normalized_score: 63.83
   cost: 11.0
   normalized_cost: 158.0
 grok-3:
   score: 69.0
-  normalized_score: 61.7
   cost: 3.0
   normalized_cost: 43.1
 gemini-2.5-flash-preview-0417-thinking:
   score: 69.0
-  normalized_score: 61.7
   cost: 8.0
   normalized_cost: 114.9
 gemini-2.5-flash-0520-nothinking:
   score: 68.0
-  normalized_score: 59.57
   cost: 1.0
   normalized_cost: 14.37
 claude-sonnet-4-nothinking:
   score: 68.0
-  normalized_score: 59.57
   cost: 2.0
   normalized_cost: 28.73
 gpt-5-minimal:
   score: 67.0
-  normalized_score: 57.45
   cost: 1.0
   normalized_cost: 14.37
 gpt-5-nano-medium:
   score: 67.0
-  normalized_score: 57.45
 llama-4-maverick:
   score: 67.0
-  normalized_score: 57.45
 gpt-4.1:
   score: 66.0
-  normalized_score: 55.32
   cost: 1.0
   normalized_cost: 14.37
 gpt-4.1-mini:
   score: 66.0
-  normalized_score: 55.32
 claude-3.7-sonnet-nothinking:
   score: 65.0
-  normalized_score: 53.19
   cost: 1.0
   normalized_cost: 14.37
 deepseek-v3-0324:
   score: 65.0
-  normalized_score: 53.19
 gpt-oss-20b-high:
   score: 61.0
-  normalized_score: 44.68
 qwen-3-235b-a22b-nothinking:
   score: 61.0
-  normalized_score: 44.68
 claude-3.5-sonnet-v2:
   score: 59.0
-  normalized_score: 40.43
   cost: 1.0
   normalized_cost: 14.37
 gemini-2.5-flash-preview-0417-nothinking:
   score: 59.0
-  normalized_score: 40.43
 llama-4-scout:
   score: 58.0
-  normalized_score: 38.3
 claude-3.5-sonnet:
   score: 56.0
-  normalized_score: 34.04
   cost: 1.0
   normalized_cost: 14.37
 deepseek-v3-1224:
   score: 55.0
-  normalized_score: 31.91
 gpt-4o-2024-11-20:
   score: 54.0
-  normalized_score: 29.79
   cost: 1.0
   normalized_cost: 14.37
 gpt-4o-2024-08-06:
   score: 52.0
-  normalized_score: 25.53
   cost: 1.0
   normalized_cost: 14.37
 gpt-4o-2024-05-13:
   score: 52.0
-  normalized_score: 25.53
   cost: 2.0
   normalized_cost: 28.73
 gpt-4.1-nano:
   score: 51.0
-  normalized_score: 23.4
 claude-3.5-haiku:
   score: 40.0
-  normalized_score: 0.0
 sigmoid:
   min: 48.12373194535359
   max: 88.27834397343698

--- a/data/processed/benchmarks/humanitys-last-exam.yaml
+++ b/data/processed/benchmarks/humanitys-last-exam.yaml
@@ -1,216 +1,173 @@
 gpt-5-high:
   score: 26.0
-  normalized_score: 100.0
   cost: 349.0
   normalized_cost: 264.4
 gpt-5-medium:
   score: 23.0
-  normalized_score: 87.5
   cost: 187.0
   normalized_cost: 141.7
 grok-4:
   score: 23.0
-  normalized_score: 87.5
   cost: 696.0
   normalized_cost: 527.2
 gemini-2.5-pro-06-05:
   score: 21.0
-  normalized_score: 79.17
   cost: 315.0
   normalized_cost: 238.6
 o3-medium:
   score: 20.0
-  normalized_score: 75.0
   cost: 165.0
   normalized_cost: 125.0
 gpt-5-low:
   score: 18.0
-  normalized_score: 66.67
   cost: 66.0
   normalized_cost: 49.99
 o4-mini-high:
   score: 17.0
-  normalized_score: 62.5
   cost: 153.0
   normalized_cost: 115.9
 gemini-2.5-pro-preview-03-25:
   score: 17.0
-  normalized_score: 62.5
   cost: 309.0
   normalized_cost: 234.1
 gemini-2.5-pro-preview-05-06:
   score: 15.0
-  normalized_score: 54.17
   cost: 215.0
   normalized_cost: 162.9
 gpt-5-mini-medium:
   score: 14.0
-  normalized_score: 50.0
   cost: 18.0
   normalized_cost: 13.63
 grok-3-mini-high:
   score: 11.0
-  normalized_score: 37.5
   cost: 18.0
   normalized_cost: 13.63
 gemini-2.5-flash-0520-thinking:
   score: 11.0
-  normalized_score: 37.5
   cost: 78.0
   normalized_cost: 59.08
 gemini-2.5-flash-preview-0417-thinking:
   score: 11.0
-  normalized_score: 37.5
   cost: 150.0
   normalized_cost: 113.6
 qwen-3-235b-a22b-thinking:
   score: 11.0
-  normalized_score: 37.5
   cost: 196.0
   normalized_cost: 148.5
 claude-opus-4-thinking:
   score: 11.0
-  normalized_score: 37.5
   cost: 546.0
   normalized_cost: 413.6
 claude-3.7-sonnet-thinking:
   score: 10.0
-  normalized_score: 33.33
   cost: 557.0
   normalized_cost: 421.9
 gpt-oss-120b-high:
   score: 9.0
-  normalized_score: 29.17
   cost: 4.0
   normalized_cost: 3.03
 deepseek-r1-0120:
   score: 9.0
-  normalized_score: 29.17
   cost: 66.0
   normalized_cost: 49.99
 claude-sonnet-4-thinking:
   score: 9.0
-  normalized_score: 29.17
   cost: 194.0
   normalized_cost: 147.0
 gpt-oss-20b-high:
   score: 8.0
-  normalized_score: 25.0
   cost: 5.0
   normalized_cost: 3.787
 gpt-5-nano-medium:
   score: 7.0
-  normalized_score: 20.83
   cost: 7.0
   normalized_cost: 5.302
 kimi-k2:
   score: 7.0
-  normalized_score: 20.83
   cost: 12.0
   normalized_cost: 9.09
 deepseek-v3-0324:
   score: 5.0
-  normalized_score: 12.5
   cost: 3.0
   normalized_cost: 2.272
 gemini-2.5-flash-preview-0417-nothinking:
   score: 5.0
-  normalized_score: 12.5
   cost: 4.0
   normalized_cost: 3.03
 gpt-5-minimal:
   score: 5.0
-  normalized_score: 12.5
   cost: 10.0
   normalized_cost: 7.575
 gemini-2.5-flash-0520-nothinking:
   score: 5.0
-  normalized_score: 12.5
   cost: 16.0
   normalized_cost: 12.12
 grok-3:
   score: 5.0
-  normalized_score: 12.5
   cost: 43.0
   normalized_cost: 32.57
 claude-opus-4-nothinking:
   score: 5.0
-  normalized_score: 12.5
   cost: 110.0
   normalized_cost: 83.32
 llama-4-maverick:
   score: 4.0
-  normalized_score: 8.333
   cost: 2.0
   normalized_cost: 1.515
 llama-4-scout:
   score: 4.0
-  normalized_score: 8.333
   cost: 2.0
   normalized_cost: 1.515
 gpt-4.1-mini:
   score: 4.0
-  normalized_score: 8.333
   cost: 4.0
   normalized_cost: 3.03
 qwen-3-235b-a22b-nothinking:
   score: 4.0
-  normalized_score: 8.333
   cost: 4.0
   normalized_cost: 3.03
 gpt-4.1:
   score: 4.0
-  normalized_score: 8.333
   cost: 19.0
   normalized_cost: 14.39
 claude-3.7-sonnet-nothinking:
   score: 4.0
-  normalized_score: 8.333
   cost: 20.0
   normalized_cost: 15.15
 claude-sonnet-4-nothinking:
   score: 4.0
-  normalized_score: 8.333
   cost: 24.0
   normalized_cost: 18.18
 gpt-4.1-nano:
   score: 3.0
-  normalized_score: 4.167
   cost: 1.0
   normalized_cost: 0.7575
 deepseek-v3-1224:
   score: 3.0
-  normalized_score: 4.167
   cost: 2.0
   normalized_cost: 1.515
 claude-3.5-haiku:
   score: 3.0
-  normalized_score: 4.167
   cost: 4.0
   normalized_cost: 3.03
 claude-3.5-sonnet-v2:
   score: 3.0
-  normalized_score: 4.167
   cost: 15.0
   normalized_cost: 11.36
 gpt-4o-2024-11-20:
   score: 3.0
-  normalized_score: 4.167
   cost: 17.0
   normalized_cost: 12.88
 claude-3.5-sonnet:
   score: 3.0
-  normalized_score: 4.167
   cost: 18.0
   normalized_cost: 13.63
 gpt-4o-2024-08-06:
   score: 2.0
-  normalized_score: 0.0
   cost: 13.0
   normalized_cost: 9.847
 gpt-4o-2024-05-13:
   score: 2.0
-  normalized_score: 0.0
   cost: 22.0
   normalized_cost: 16.66
 sigmoid:

--- a/data/processed/benchmarks/livebench.yaml
+++ b/data/processed/benchmarks/livebench.yaml
@@ -1,99 +1,67 @@
 gpt-5-medium:
   score: 75.84
-  normalized_score: 100.0
 o3-pro-high:
   score: 74.72
-  normalized_score: 96.92
 o3-high:
   score: 74.61
-  normalized_score: 96.61
 claude-opus-4.1-thinking:
   score: 73.48
-  normalized_score: 93.5
 claude-opus-4-thinking:
   score: 72.93
-  normalized_score: 91.99
 grok-4:
   score: 72.11
-  normalized_score: 89.73
 claude-sonnet-4-thinking:
   score: 72.08
-  normalized_score: 89.65
 o3-medium:
   score: 71.98
-  normalized_score: 89.38
 o4-mini-high:
   score: 71.52
-  normalized_score: 88.11
 deepseek-r1-0528:
   score: 70.1
-  normalized_score: 84.2
 gemini-2.5-pro-06-05:
   score: 69.39
-  normalized_score: 82.25
 claude-3.7-sonnet-thinking:
   score: 67.43
-  normalized_score: 76.85
 o4-mini-medium:
   score: 66.87
-  normalized_score: 75.31
 claude-opus-4-nothinking:
   score: 65.93
-  normalized_score: 72.72
 deepseek-r1-0120:
   score: 65.15
-  normalized_score: 70.58
 qwen-3-235b-a22b-thinking:
   score: 64.93
-  normalized_score: 69.97
 gemini-2.5-flash-0520-thinking:
   score: 64.42
-  normalized_score: 68.57
 claude-sonnet-4-nothinking:
   score: 63.37
-  normalized_score: 65.68
 kimi-k2:
   score: 62.7
-  normalized_score: 63.83
 grok-3-mini-high:
   score: 62.36
-  normalized_score: 62.9
 gpt-4.5-preview:
   score: 58.65
-  normalized_score: 52.68
 claude-3.7-sonnet-nothinking:
   score: 58.48
-  normalized_score: 52.22
 grok-3:
   score: 56.05
-  normalized_score: 45.53
 deepseek-v3-0324:
   score: 55.99
-  normalized_score: 45.36
 gpt-4.1:
   score: 55.9
-  normalized_score: 45.11
 gpt-oss-120b-medium:
   score: 54.6
-  normalized_score: 41.54
 claude-3.5-sonnet-v2:
   score: 51.8
-  normalized_score: 33.83
 gpt-4.1-mini:
   score: 51.57
-  normalized_score: 33.2
 llama-4-maverick:
   score: 47.78
-  normalized_score: 22.76
 gpt-4o-2024-11-20:
   score: 47.43
-  normalized_score: 21.8
 gpt-4.1-nano:
   score: 40.51
-  normalized_score: 2.753
 claude-3.5-haiku:
   score: 39.51
-  normalized_score: 0.0
 sigmoid:
   min: 41.658676381802444
   max: 73.84359461848041

--- a/data/processed/benchmarks/lmarena-text.yaml
+++ b/data/processed/benchmarks/lmarena-text.yaml
@@ -1,105 +1,71 @@
 gemini-2.5-pro-06-05:
   score: 1470.0
-  normalized_score: 100.0
 gemini-2.5-pro-preview-05-06:
   score: 1446.0
-  normalized_score: 88.66
 grok-4:
   score: 1435.0
-  normalized_score: 83.32
 o3-medium:
   score: 1429.0
-  normalized_score: 80.58
 deepseek-r1-0528:
   score: 1427.0
-  normalized_score: 79.87
 grok-3:
   score: 1423.0
-  normalized_score: 77.99
 gpt-4.5-preview:
   score: 1415.0
-  normalized_score: 74.41
 gemini-2.5-flash-0520-thinking:
   score: 1412.0
-  normalized_score: 72.59
 gemini-2.5-flash-preview-0417-thinking:
   score: 1397.0
-  normalized_score: 65.79
 qwen-3-235b-a22b-nothinking:
   score: 1391.0
-  normalized_score: 63.19
 kimi-k2:
   score: 1381.0
-  normalized_score: 58.12
 gpt-4.1:
   score: 1380.0
-  normalized_score: 58.09
 deepseek-v3-0324:
   score: 1376.0
-  normalized_score: 56.08
 claude-opus-4-thinking:
   score: 1374.0
-  normalized_score: 55.03
 deepseek-r1-0120:
   score: 1373.0
-  normalized_score: 54.56
 claude-opus-4-nothinking:
   score: 1366.0
-  normalized_score: 51.49
 qwen-3-235b-a22b-thinking:
   score: 1366.0
-  normalized_score: 51.22
 o4-mini-medium:
   score: 1362.0
-  normalized_score: 49.51
 grok-3-mini-high:
   score: 1361.0
-  normalized_score: 49.14
 grok-3-mini-nothinking:
   score: 1360.0
-  normalized_score: 48.62
 claude-sonnet-4-thinking:
   score: 1351.0
-  normalized_score: 44.16
 claude-sonnet-4-nothinking:
   score: 1338.0
-  normalized_score: 38.31
 gpt-4.1-mini:
   score: 1337.0
-  normalized_score: 37.68
 deepseek-v3-1224:
   score: 1334.0
-  normalized_score: 36.31
 claude-3.7-sonnet-thinking:
   score: 1317.0
-  normalized_score: 28.56
 gpt-4o-2024-05-13:
   score: 1302.0
-  normalized_score: 21.61
 claude-3.7-sonnet-nothinking:
   score: 1301.0
-  normalized_score: 21.11
 claude-3.5-sonnet-v2:
   score: 1299.0
-  normalized_score: 20.23
 llama-4-maverick:
   score: 1292.0
-  normalized_score: 16.86
 gpt-4.1-nano:
   score: 1287.0
-  normalized_score: 14.61
 gpt-4o-2024-08-06:
   score: 1285.0
-  normalized_score: 13.6
 claude-3.5-sonnet:
   score: 1283.0
-  normalized_score: 12.69
 llama-4-scout:
   score: 1276.0
-  normalized_score: 9.526
 claude-3.5-haiku:
   score: 1256.0
-  normalized_score: 0.0
 sigmoid:
   min: 1264.7011807988845
   max: 1446.6908284798087

--- a/data/processed/benchmarks/mmlu-pro.yaml
+++ b/data/processed/benchmarks/mmlu-pro.yaml
@@ -1,211 +1,169 @@
 gpt-5-high:
   score: 87.0
-  normalized_score: 100.0
   cost: 306.0
   normalized_cost: 155.0
 claude-opus-4-thinking:
   score: 87.0
-  normalized_score: 100.0
   cost: 1083.0
   normalized_cost: 548.7
 gpt-5-low:
   score: 86.0
-  normalized_score: 95.83
   cost: 62.0
   normalized_cost: 31.41
 gpt-5-medium:
   score: 86.0
-  normalized_score: 95.83
   cost: 142.0
   normalized_cost: 71.94
 claude-opus-4-nothinking:
   score: 86.0
-  normalized_score: 95.83
   cost: 337.0
   normalized_cost: 170.7
 gemini-2.5-pro-06-05:
   score: 86.0
-  normalized_score: 95.83
   cost: 430.0
   normalized_cost: 217.9
 grok-4:
   score: 86.0
-  normalized_score: 95.83
   cost: 637.0
   normalized_cost: 322.7
 o3-medium:
   score: 85.0
-  normalized_score: 91.67
   cost: 173.0
   normalized_cost: 87.65
 gemini-2.5-pro-preview-03-25:
   score: 85.0
-  normalized_score: 91.67
   cost: 298.0
   normalized_cost: 151.0
 deepseek-r1-0120:
   score: 84.0
-  normalized_score: 87.5
   cost: 114.0
   normalized_cost: 57.76
 claude-sonnet-4-thinking:
   score: 84.0
-  normalized_score: 87.5
   cost: 343.0
   normalized_cost: 173.8
 claude-sonnet-4-nothinking:
   score: 83.0
-  normalized_score: 83.33
   cost: 75.0
   normalized_cost: 38.0
 gemini-2.5-flash-0520-thinking:
   score: 83.0
-  normalized_score: 83.33
   cost: 97.0
   normalized_cost: 49.14
 o4-mini-high:
   score: 83.0
-  normalized_score: 83.33
   cost: 105.0
   normalized_cost: 53.2
 claude-3.7-sonnet-thinking:
   score: 83.0
-  normalized_score: 83.33
   cost: 654.0
   normalized_cost: 331.3
 gemini-2.5-pro-preview-05-06:
   score: 83.0
-  normalized_score: 83.33
   cost: 837.0
   normalized_cost: 424.0
 grok-3-mini-high:
   score: 82.0
-  normalized_score: 79.17
   cost: 20.0
   normalized_cost: 10.13
 gpt-5-mini-medium:
   score: 82.0
-  normalized_score: 79.17
   cost: 23.0
   normalized_cost: 11.65
 kimi-k2:
   score: 82.0
-  normalized_score: 79.17
   cost: 57.0
   normalized_cost: 28.88
 qwen-3-235b-a22b-thinking:
   score: 82.0
-  normalized_score: 79.17
   cost: 284.0
   normalized_cost: 143.9
 deepseek-v3-0324:
   score: 81.0
-  normalized_score: 75.0
   cost: 7.0
   normalized_cost: 3.546
 llama-4-maverick:
   score: 80.0
-  normalized_score: 70.83
   cost: 7.0
   normalized_cost: 3.546
 gpt-5-minimal:
   score: 80.0
-  normalized_score: 70.83
   cost: 19.0
   normalized_cost: 9.626
 gemini-2.5-flash-0520-nothinking:
   score: 80.0
-  normalized_score: 70.83
   cost: 23.0
   normalized_cost: 11.65
 gpt-4.1:
   score: 80.0
-  normalized_score: 70.83
   cost: 33.0
   normalized_cost: 16.72
 claude-3.7-sonnet-nothinking:
   score: 80.0
-  normalized_score: 70.83
   cost: 62.0
   normalized_cost: 31.41
 gemini-2.5-flash-preview-0417-thinking:
   score: 80.0
-  normalized_score: 70.83
   cost: 174.0
   normalized_cost: 88.15
 gpt-oss-120b-high:
   score: 79.0
-  normalized_score: 66.67
   cost: 5.0
   normalized_cost: 2.533
 grok-3:
   score: 79.0
-  normalized_score: 66.67
   cost: 75.0
   normalized_cost: 38.0
 gemini-2.5-flash-preview-0417-nothinking:
   score: 78.0
-  normalized_score: 62.5
   cost: 6.0
   normalized_cost: 3.04
 gpt-4.1-mini:
   score: 78.0
-  normalized_score: 62.5
   cost: 9.0
   normalized_cost: 4.56
 gpt-5-nano-medium:
   score: 77.0
-  normalized_score: 58.33
   cost: 10.0
   normalized_cost: 5.066
 claude-3.5-sonnet-v2:
   score: 77.0
-  normalized_score: 58.33
   cost: 50.0
   normalized_cost: 25.33
 qwen-3-235b-a22b-nothinking:
   score: 76.0
-  normalized_score: 54.17
   cost: 14.0
   normalized_cost: 7.093
 llama-4-scout:
   score: 75.0
-  normalized_score: 50.0
   cost: 4.0
   normalized_cost: 2.027
 deepseek-v3-1224:
   score: 75.0
-  normalized_score: 50.0
   cost: 6.0
   normalized_cost: 3.04
 claude-3.5-sonnet:
   score: 75.0
-  normalized_score: 50.0
   cost: 55.0
   normalized_cost: 27.86
 gpt-4o-2024-11-20:
   score: 74.0
-  normalized_score: 45.83
   cost: 39.0
   normalized_cost: 19.76
 gpt-4o-2024-05-13:
   score: 74.0
-  normalized_score: 45.83
   cost: 60.0
   normalized_cost: 30.4
 gpt-oss-20b-high:
   score: 73.0
-  normalized_score: 41.67
   cost: 5.0
   normalized_cost: 2.533
 gpt-4.1-nano:
   score: 65.0
-  normalized_score: 8.333
   cost: 2.0
   normalized_cost: 1.013
 claude-3.5-haiku:
   score: 63.0
-  normalized_score: 0.0
   cost: 12.0
   normalized_cost: 6.08
 sigmoid:

--- a/data/processed/benchmarks/simplebench.yaml
+++ b/data/processed/benchmarks/simplebench.yaml
@@ -1,75 +1,51 @@
 gemini-2.5-pro-06-05:
   score: 62.4
-  normalized_score: 100.0
 grok-4:
   score: 60.5
-  normalized_score: 95.74
 claude-opus-4.1-nothinking:
   score: 60.0
-  normalized_score: 94.62
 claude-opus-4-thinking:
   score: 58.8
-  normalized_score: 91.93
 gpt-5-high:
   score: 56.7
-  normalized_score: 87.22
 o3-high:
   score: 53.1
-  normalized_score: 79.15
 gemini-2.5-pro-preview-03-25:
   score: 51.6
-  normalized_score: 75.78
 claude-3.7-sonnet-thinking:
   score: 46.4
-  normalized_score: 64.13
 claude-sonnet-4-thinking:
   score: 45.5
-  normalized_score: 62.11
 claude-3.7-sonnet-nothinking:
   score: 44.9
-  normalized_score: 60.76
 claude-3.5-sonnet-v2:
   score: 41.4
-  normalized_score: 52.91
 deepseek-r1-0528:
   score: 40.8
-  normalized_score: 51.57
 o4-mini-high:
   score: 38.7
-  normalized_score: 46.86
 grok-3:
   score: 36.1
-  normalized_score: 41.03
 gpt-4.5-preview:
   score: 34.5
-  normalized_score: 37.44
 qwen-3-235b-a22b-thinking:
   score: 31.0
-  normalized_score: 29.6
 deepseek-r1-0120:
   score: 30.9
-  normalized_score: 29.37
 llama-4-maverick:
   score: 27.7
-  normalized_score: 22.2
 claude-3.5-sonnet:
   score: 27.5
-  normalized_score: 21.75
 deepseek-v3-0324:
   score: 27.2
-  normalized_score: 21.08
 gpt-4.1:
   score: 27.0
-  normalized_score: 20.63
 gpt-oss-120b-medium:
   score: 22.1
-  normalized_score: 9.641
 deepseek-v3-1224:
   score: 18.9
-  normalized_score: 2.466
 gpt-4o-2024-08-06:
   score: 17.8
-  normalized_score: 0.0
 sigmoid:
   min: 10.747727575385268
   max: 66.61834585284723

--- a/data/processed/benchmarks/weirdml.yaml
+++ b/data/processed/benchmarks/weirdml.yaml
@@ -1,136 +1,109 @@
 o3-pro-high:
   score: 53.95
-  normalized_score: 100.0
   cost: 5.228
   normalized_cost: 1407.0
 gemini-2.5-pro-06-05:
   score: 50.3
-  normalized_score: 89.54
   cost: 0.8232
   normalized_cost: 221.6
 o3-high:
   score: 49.76
-  normalized_score: 88.0
   cost: 0.4637
   normalized_cost: 124.8
 o4-mini-high:
   score: 49.17
-  normalized_score: 86.31
   cost: 0.3869
   normalized_cost: 104.1
 claude-sonnet-4-thinking:
   score: 45.28
-  normalized_score: 75.16
   cost: 0.6679
   normalized_cost: 179.8
 claude-sonnet-4-nothinking:
   score: 43.0
-  normalized_score: 68.63
   cost: 0.608
   normalized_cost: 163.6
 grok-4:
   score: 42.55
-  normalized_score: 67.34
   cost: 0.934
   normalized_cost: 251.4
 claude-opus-4-thinking:
   score: 42.12
-  normalized_score: 66.11
   cost: 3.398
   normalized_cost: 914.5
 claude-opus-4.1-thinking:
   score: 41.78
-  normalized_score: 65.14
   cost: 3.457
   normalized_cost: 930.6
 deepseek-r1-0528:
   score: 40.88
-  normalized_score: 62.56
   cost: 0.142
   normalized_cost: 38.22
 gpt-oss-120b-medium:
   score: 40.25
-  normalized_score: 60.76
   cost: 0.02325
   normalized_cost: 6.257
 claude-3.5-sonnet-v2:
   score: 39.78
-  normalized_score: 59.41
   cost: 0.4931
   normalized_cost: 132.7
 grok-3-mini-high:
   score: 39.58
-  normalized_score: 58.84
   cost: 0.03499
   normalized_cost: 9.416
 gemini-2.5-flash-0520-thinking:
   score: 38.73
-  normalized_score: 56.4
   cost: 0.2118
   normalized_cost: 57.02
 gpt-4.1:
   score: 37.88
-  normalized_score: 53.97
   cost: 0.1966
   normalized_cost: 52.91
 gpt-4.5-preview:
   score: 37.65
-  normalized_score: 53.31
   cost: 3.16
   normalized_cost: 850.5
 gpt-4.1-mini:
   score: 37.25
-  normalized_score: 52.16
   cost: 0.03297
   normalized_cost: 8.873
 grok-3:
   score: 36.44
-  normalized_score: 49.84
   cost: 0.5004
   normalized_cost: 134.7
 qwen-3-235b-a22b-thinking:
   score: 36.25
-  normalized_score: 49.3
   cost: 0.04172
   normalized_cost: 11.23
 gpt-oss-20b-medium:
   score: 35.92
-  normalized_score: 48.35
   cost: 0.007737
   normalized_cost: 2.082
 deepseek-r1-0120:
   score: 35.56
-  normalized_score: 47.32
   cost: 0.1584
   normalized_cost: 42.62
 deepseek-v3-0324:
   score: 35.09
-  normalized_score: 45.98
   cost: 0.02758
   normalized_cost: 7.424
 claude-3.5-sonnet:
   score: 30.06
-  normalized_score: 31.57
   cost: 0.4874
   normalized_cost: 131.2
 claude-3.5-haiku:
   score: 30.04
-  normalized_score: 31.51
   cost: 0.1141
   normalized_cost: 30.7
 gpt-4o-2024-11-20:
   score: 25.38
-  normalized_score: 18.16
   cost: 0.1664
   normalized_cost: 44.79
 llama-4-maverick:
   score: 23.62
-  normalized_score: 13.12
   cost: 0.01227
   normalized_cost: 3.304
 gpt-4.1-nano:
   score: 19.04
-  normalized_score: 0.0
   cost: 0.005178
   normalized_cost: 1.394
 sigmoid:

--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -37,11 +37,11 @@ export interface BenchmarkResult {
   /** Raw score reported by the benchmark. */
   score: number
   /**
-   * Per-benchmark normalized score derived by converting `score` to an ability
-   * via the benchmark's inverse sigmoid and then passing that ability through
-   * the global sigmoid.
+   * Per-benchmark score produced by converting `score` to an ability via the
+   * benchmark's inverse sigmoid and then passing that ability through the
+   * global sigmoid.
    */
-  normalizedScore?: number
+  sigmoidScore?: number
   /** Benchmark's textual description. */
   description: string
   /** Monetary cost per task, when provided by the benchmark. */
@@ -58,7 +58,7 @@ export interface BenchmarkResult {
  * Aggregated data for a language model across all benchmarks.
  *
  * Each entry in {@link benchmarks} contains a `BenchmarkResult` whose
- * `normalizedScore` follows the flow: raw score → benchmark inverse sigmoid →
+ * `sigmoidScore` follows the flow: raw score → benchmark inverse sigmoid →
  * global sigmoid.
  */
 export interface LLMData {
@@ -81,7 +81,7 @@ export interface LLMData {
  *
  * Each benchmark score is normalized by first inverting the benchmark-specific
  * sigmoid to obtain a model ability and then applying the global sigmoid. The
- * returned array is sorted in descending order by average normalized score and
+ * returned array is sorted in descending order by average sigmoid score and
  * contains normalized cost information when available.
  */
 export async function loadLLMData(): Promise<LLMData[]> {
@@ -162,15 +162,13 @@ export async function loadLLMData(): Promise<LLMData[]> {
         if (sigmoid) {
           const ability = scoreToAbility(Number(result.score), sigmoid)
           normScore = abilityToNormalized(ability)
-        } else if (result.normalized_score !== undefined) {
-          normScore = Number(result.normalized_score)
         }
         llm.benchmarks[data.benchmark] = {
           score: Number(result.score),
           description: data.description,
           ...(hasCost ? { costPerTask: Number(result.cost) } : {}),
           ...(normalized !== undefined ? { normalizedCost: normalized } : {}),
-          ...(normScore !== undefined ? { normalizedScore: normScore } : {}),
+          ...(normScore !== undefined ? { sigmoidScore: normScore } : {}),
           scoreWeight: data.score_weight,
           costWeight: data.cost_weight,
         }

--- a/lib/yaml-schemas.ts
+++ b/lib/yaml-schemas.ts
@@ -42,7 +42,6 @@ export const ProcessedBenchmarkFileSchema = z
   .catchall(
     z.object({
       score: z.number(),
-      normalized_score: z.number(),
       cost: z.number().optional(),
       normalized_cost: z.number().optional(),
     }),

--- a/scripts_python/tests/test_process_data.py
+++ b/scripts_python/tests/test_process_data.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 import yaml
+import numpy as np
 
 # Add scripts_python directory to path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -13,13 +14,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from process_data import (
     load_benchmark,
     load_mapping_file,
-    normalize_benchmark_scores,
     build_output,
     compute_normalization_factors,
 )
 
 
-def test_normalize_benchmarks(tmp_path: Path):
+def test_build_output(tmp_path: Path):
     bench_file = tmp_path / "bench.yaml"
     mapping_dir = tmp_path
 
@@ -48,12 +48,12 @@ def test_normalize_benchmarks(tmp_path: Path):
     map_df = load_mapping_file(mapping_dir / "map.yaml")
     df = bench_df.merge(map_df, on="alias", how="left")[["benchmark", "slug", "score", "cost", "cost_weight"]]
     df = df.dropna(subset=["slug"])
-    df = normalize_benchmark_scores(df)
-    output = build_output(df[["slug", "score", "normalized_score", "cost"]], None)
+    df.loc[df["cost"] == 0, "cost"] = np.nan
+    output = build_output(df[["slug", "score", "cost"]], None)
 
     expected = {
-        "slug-a": {"score": 0.9, "cost": 0.1, "normalized_score": 100.0},
-        "slug-b": {"score": 0.5, "cost": 0.2, "normalized_score": 0.0},
+        "slug-a": {"score": 0.9, "cost": 0.1},
+        "slug-b": {"score": 0.5, "cost": 0.2},
     }
     assert output == expected
     assert df["cost_weight"].iloc[0] == 1.0
@@ -86,12 +86,12 @@ def test_zero_cost_ignored(tmp_path: Path):
     map_df = load_mapping_file(mapping_dir / "map.yaml")
     df = bench_df.merge(map_df, on="alias", how="left")[["benchmark", "slug", "score", "cost", "cost_weight"]]
     df = df.dropna(subset=["slug"])
-    df = normalize_benchmark_scores(df)
-    output = build_output(df[["slug", "score", "normalized_score", "cost"]], None)
+    df.loc[df["cost"] == 0, "cost"] = np.nan
+    output = build_output(df[["slug", "score", "cost"]], None)
 
     expected = {
-        "slug-a": {"score": 1.0, "cost": 0.1, "normalized_score": 100.0},
-        "slug-b": {"score": 0.8, "normalized_score": 0.0},
+        "slug-a": {"score": 1.0, "cost": 0.1},
+        "slug-b": {"score": 0.8},
     }
     assert output == expected
     assert df.set_index("slug")["cost"].dropna().to_dict() == {"slug-a": 0.1}


### PR DESCRIPTION
## Summary
- drop legacy normalized score field and use joint sigmoid scores throughout
- update data pipeline and benchmark outputs to omit normalized_score
- refresh UI and docs to reference sigmoid scores

## Testing
- `uv run process_data.py`
- `pnpm process:all`
- `uv run pytest`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689b0216c6a08320909ee0adecfedfbe