### PR TITLE
refactor: rename sigmoid score to normalized score

### DIFF
--- a/app/models/[slug]/page.tsx
+++ b/app/models/[slug]/page.tsx
@@ -63,7 +63,7 @@ export default async function ModelPage({
               <TableRow>
                 <TableHead>Benchmark</TableHead>
                 <TableHead className="text-right">Raw Score</TableHead>
-                <TableHead className="text-right">Sigmoid Score</TableHead>
+                <TableHead className="text-right">Normalized Score</TableHead>
                 <TableHead className="text-right">Raw Cost</TableHead>
                 <TableHead className="text-right">Normalized Cost</TableHead>
               </TableRow>
@@ -76,8 +76,8 @@ export default async function ModelPage({
                     {res?.score !== undefined ? res.score : "—"}
                   </TableCell>
                   <TableCell className="text-right">
-                    {res?.sigmoidScore !== undefined
-                      ? res.sigmoidScore.toFixed(1)
+                    {res?.normalizedScore !== undefined
+                      ? res.normalizedScore.toFixed(1)
                       : "—"}
                   </TableCell>
                   <TableCell className="text-right">

--- a/components/benchmark-section.tsx
+++ b/components/benchmark-section.tsx
@@ -45,7 +45,7 @@ export default function BenchmarkSection({ llmData, benchmark }: Props) {
       model: string
       provider: string
       score: number
-      sigmoidScore?: number
+      normalizedScore?: number
       normalizedCost?: number
       costPerTask?: number
     }[]
@@ -70,7 +70,7 @@ export default function BenchmarkSection({ llmData, benchmark }: Props) {
               <TableRow>
                 <TableHead>Model</TableHead>
                 <TableHead className="text-right">Raw Score</TableHead>
-                <TableHead className="text-right">Sigmoid Score</TableHead>
+                <TableHead className="text-right">Normalized Score</TableHead>
                 <TableHead className="text-right">Raw Cost</TableHead>
                 <TableHead className="text-right">Normalized Cost</TableHead>
               </TableRow>
@@ -81,8 +81,8 @@ export default function BenchmarkSection({ llmData, benchmark }: Props) {
                   <TableCell>{entry.model}</TableCell>
                   <TableCell className="text-right">{entry.score}</TableCell>
                   <TableCell className="text-right">
-                    {entry.sigmoidScore !== undefined
-                      ? entry.sigmoidScore.toFixed(1)
+                    {entry.normalizedScore !== undefined
+                      ? entry.normalizedScore.toFixed(1)
                       : "—"}
                   </TableCell>
                   <TableCell className="text-right">

--- a/components/columns.tsx
+++ b/components/columns.tsx
@@ -119,7 +119,7 @@ export const columns: ColumnDef<TableRow>[] = [
           variant="ghost"
           onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
         >
-          Average Sigmoid Score
+          Average Normalized Score
           <ArrowUpDown className="ml-2 h-4 w-4" />
         </Button>
       )

--- a/components/cost-score-chart.tsx
+++ b/components/cost-score-chart.tsx
@@ -104,7 +104,7 @@ export default function CostScoreChart({
     <CostPerformanceChart
       entries={entries}
       xLabel="Normalized Cost per Task ($)"
-      yLabel="Average Sigmoid Score"
+      yLabel="Average Normalized Score"
       yDomain={[0, 100]}
       yTicks={[0, 25, 50, 75, 100]}
       xScale={useLinearScale ? "linear" : "log"}

--- a/components/leaderboard.tsx
+++ b/components/leaderboard.tsx
@@ -67,7 +67,7 @@ export default async function Leaderboard() {
                     {llm.averageScore?.toFixed(1)}
                   </div>
                   <div className="text-sm text-muted-foreground">
-                    Average Sigmoid Score
+                    Average Normalized Score
                   </div>
                 </div>
               </div>

--- a/components/model-cost-score-chart.tsx
+++ b/components/model-cost-score-chart.tsx
@@ -31,13 +31,13 @@ export default function ModelCostScoreChart({
       .filter(
         (e) =>
           e.result.normalizedCost !== undefined &&
-          e.result.sigmoidScore !== undefined,
+          e.result.normalizedScore !== undefined,
       )
       .map((e) => ({
         label: e.benchmark,
         provider,
         cost: e.result.normalizedCost as number,
-        score: e.result.sigmoidScore as number,
+        score: e.result.normalizedScore as number,
       })) as CostPerformanceEntry[]
   }, [entries, provider])
 
@@ -52,7 +52,7 @@ export default function ModelCostScoreChart({
     <CostPerformanceChart
       entries={items}
       xLabel="Normalized Cost per Task ($)"
-      yLabel="Sigmoid Score"
+      yLabel="Normalized Score"
       xDomain={xDomain}
       yDomain={yDomain}
       yTicks={yTicks}

--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -41,7 +41,7 @@ export interface BenchmarkResult {
    * benchmark's inverse sigmoid and then passing that ability through the
    * global sigmoid.
    */
-  sigmoidScore?: number
+  normalizedScore?: number
   /** Benchmark's textual description. */
   description: string
   /** Monetary cost per task, when provided by the benchmark. */
@@ -58,7 +58,7 @@ export interface BenchmarkResult {
  * Aggregated data for a language model across all benchmarks.
  *
  * Each entry in {@link benchmarks} contains a `BenchmarkResult` whose
- * `sigmoidScore` follows the flow: raw score → benchmark inverse sigmoid →
+ * `normalizedScore` follows the flow: raw score → benchmark inverse sigmoid →
  * global sigmoid.
  */
 export interface LLMData {
@@ -81,7 +81,7 @@ export interface LLMData {
  *
  * Each benchmark score is normalized by first inverting the benchmark-specific
  * sigmoid to obtain a model ability and then applying the global sigmoid. The
- * returned array is sorted in descending order by average sigmoid score and
+ * returned array is sorted in descending order by average normalized score and
  * contains normalized cost information when available.
  */
 export async function loadLLMData(): Promise<LLMData[]> {
@@ -168,7 +168,7 @@ export async function loadLLMData(): Promise<LLMData[]> {
           description: data.description,
           ...(hasCost ? { costPerTask: Number(result.cost) } : {}),
           ...(normalized !== undefined ? { normalizedCost: normalized } : {}),
-          ...(normScore !== undefined ? { sigmoidScore: normScore } : {}),
+          ...(normScore !== undefined ? { normalizedScore: normScore } : {}),
           scoreWeight: data.score_weight,
           costWeight: data.cost_weight,
         }


### PR DESCRIPTION
## Summary
- rename sigmoid score references to normalized score in UI and data loader
- update benchmark result field to normalizedScore

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689b0ec154c88320af2fb96a38f9e190