### PR TITLE
Add release dates for GPT‑4o and Grok models

### DIFF
--- a/data/config/models/gpt-4o-2024-05-13.yaml
+++ b/data/config/models/gpt-4o-2024-05-13.yaml
@@ -1,4 +1,5 @@
 provider: OpenAI
+release_date: 2024-05-13
 deprecated: true
 reasoning_efforts:
   gpt-4o-2024-05-13: GPT-4o 2024-05-13

--- a/data/config/models/gpt-4o-2024-08-06.yaml
+++ b/data/config/models/gpt-4o-2024-08-06.yaml
@@ -1,4 +1,5 @@
 provider: OpenAI
+release_date: 2024-08-06
 deprecated: true
 reasoning_efforts:
   gpt-4o-2024-08-06: GPT-4o 2024-08-06

--- a/data/config/models/gpt-4o-2024-11-20.yaml
+++ b/data/config/models/gpt-4o-2024-11-20.yaml
@@ -1,4 +1,5 @@
 provider: OpenAI
+release_date: 2024-11-20
 deprecated: true
 reasoning_efforts:
   gpt-4o-2024-11-20: GPT-4o 2024-11-20

--- a/data/config/models/grok-3-mini.yaml
+++ b/data/config/models/grok-3-mini.yaml
@@ -1,4 +1,5 @@
 provider: xAI
+release_date: 2025-02-19
 reasoning_efforts:
   grok-3-mini-nothinking: Grok 3 Mini (no thinking)
   grok-3-mini-low: Grok 3 Mini (low)

--- a/data/config/models/grok-3.yaml
+++ b/data/config/models/grok-3.yaml
@@ -1,4 +1,5 @@
 provider: xAI
+release_date: 2025-02-19
 deprecated: true
 reasoning_efforts:
   grok-3: Grok 3


### PR DESCRIPTION
## Summary
- add release dates for three GPT-4o model versions
- add release dates for Grok 3 and Grok 3 Mini

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b19f9e13bc83209ff5761a7b463ae6