### PR TITLE
chore: add GPT-OSS mappings

### DIFF
--- a/data/config/mappings/livebench.yaml
+++ b/data/config/mappings/livebench.yaml
@@ -35,6 +35,7 @@ gpt-4.5-preview-2025-02-27: gpt-4.5-preview
 gpt-4o-2024-11-20: gpt-4o-2024-11-20
 gpt-5: gpt-5-medium
 gpt-oss-120b: gpt-oss-120b-medium
+gpt-oss-20b: gpt-oss-20b-medium
 grok-3-beta: grok-3
 grok-3-mini-beta-high: grok-3-mini-high
 grok-4-0709: grok-4

--- a/data/config/mappings/simplebench.yaml
+++ b/data/config/mappings/simplebench.yaml
@@ -24,6 +24,7 @@ GPT-4o 08-06: gpt-4o-2024-08-06
 GPT-4o mini: null
 GPT-5 (high): gpt-5-high
 GPT-OSS 120B: gpt-oss-120b-medium
+GPT-OSS 20B: gpt-oss-20b-medium
 Grok 2: null
 Grok 3: grok-3
 Grok 4: grok-4


### PR DESCRIPTION
## Summary
- map GPT-OSS 20B to SimpleBench and LiveBench
- revert MathArena GPT-OSS entries to null

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1a38654f8832085b7b0c6b964db57