### PR TITLE
chore: zero out MathArena benchmark weights

### DIFF
--- a/data/raw/benchmarks/matharena-aime-2025.yaml
+++ b/data/raw/benchmarks/matharena-aime-2025.yaml
@@ -2,8 +2,8 @@ benchmark: MathArena AIME 2025
 description: Accuracy on MathArena AIME 2025 competition
 website: https://matharena.ai/
 github: https://github.com/eth-sri/matharena
-score_weight: 1
-cost_weight: 1
+score_weight: 0
+cost_weight: 0
 results:
   Claude-3.5-Sonnet: 3.3333333333333335
   Claude-3.7-Sonnet (Think): 49.16666666666668

--- a/data/raw/benchmarks/matharena-apex.yaml
+++ b/data/raw/benchmarks/matharena-apex.yaml
@@ -2,8 +2,8 @@ benchmark: MathArena CMIMC 2025
 description: Accuracy on MathArena CMIMC 2025 competition
 website: https://matharena.ai/
 github: https://github.com/eth-sri/matharena
-score_weight: 1
-cost_weight: 1
+score_weight: 0
+cost_weight: 0
 model_name_mapping_file: matharena.yaml
 private_holdout: false
 results:

--- a/data/raw/benchmarks/matharena-brumo-2025.yaml
+++ b/data/raw/benchmarks/matharena-brumo-2025.yaml
@@ -2,8 +2,8 @@ benchmark: MathArena BRUMO 2025
 description: Accuracy on MathArena BRUMO 2025 competition
 website: https://matharena.ai/
 github: https://github.com/eth-sri/matharena
-score_weight: 1
-cost_weight: 1
+score_weight: 0
+cost_weight: 0
 results:
   Claude-3.7-Sonnet (Think): 65.83333333333334
   Claude-Opus-4.0 (Think): 81.66666666666669

--- a/data/raw/benchmarks/matharena-cmimc-2025.yaml
+++ b/data/raw/benchmarks/matharena-cmimc-2025.yaml
@@ -2,8 +2,8 @@ benchmark: MathArena CMIMC 2025
 description: Accuracy on MathArena CMIMC 2025 competition
 website: https://matharena.ai/
 github: https://github.com/eth-sri/matharena
-score_weight: 1
-cost_weight: 1
+score_weight: 0
+cost_weight: 0
 results:
   DeepSeek-R1-0528: 69.375
   DeepSeek-v3.1 (Think): 81.25

--- a/data/raw/benchmarks/matharena-hmmt-feb-2025.yaml
+++ b/data/raw/benchmarks/matharena-hmmt-feb-2025.yaml
@@ -2,8 +2,8 @@ benchmark: MathArena HMMT 2025
 description: Accuracy on MathArena HMMT 2025 competition
 website: https://matharena.ai/
 github: https://github.com/eth-sri/matharena
-score_weight: 1
-cost_weight: 1
+score_weight: 0
+cost_weight: 0
 model_name_mapping_file: matharena.yaml
 private_holdout: false
 results:

--- a/data/raw/benchmarks/matharena-hmmt-february-2025.yaml
+++ b/data/raw/benchmarks/matharena-hmmt-february-2025.yaml
@@ -2,8 +2,8 @@ benchmark: MathArena HMMT February 2025
 description: Accuracy on MathArena HMMT February 2025 competition
 website: https://matharena.ai/
 github: https://github.com/eth-sri/matharena
-score_weight: 1
-cost_weight: 1
+score_weight: 0
+cost_weight: 0
 model_name_mapping_file: matharena.yaml
 private_holdout: false
 results:

--- a/data/raw/benchmarks/matharena-imc-2025.yaml
+++ b/data/raw/benchmarks/matharena-imc-2025.yaml
@@ -2,8 +2,8 @@ benchmark: MathArena IMC 2025
 description: Accuracy on MathArena IMC 2025 competition
 website: https://matharena.ai/
 github: https://github.com/eth-sri/matharena
-score_weight: 1
-cost_weight: 1
+score_weight: 0
+cost_weight: 0
 results:
   Gemini IMO Deep Think: 93
   gemini-2.5-pro (agent): 94.5

--- a/data/raw/benchmarks/matharena-imo-2025.yaml
+++ b/data/raw/benchmarks/matharena-imo-2025.yaml
@@ -2,8 +2,8 @@ benchmark: MathArena IMO 2025
 description: Accuracy on MathArena IMO 2025 competition
 website: https://matharena.ai/
 github: https://github.com/eth-sri/matharena
-score_weight: 1
-cost_weight: 1
+score_weight: 0
+cost_weight: 0
 results:
   DeepSeek-R1-0528: 6.845238095238095
   GPT-5 (high): 38.0952380952381

--- a/data/raw/benchmarks/matharena-overall.yaml
+++ b/data/raw/benchmarks/matharena-overall.yaml
@@ -2,8 +2,8 @@ benchmark: MathArena Overall
 description: Average accuracy across MathArena competitions
 website: https://matharena.ai/
 github: https://github.com/eth-sri/matharena
-score_weight: 1
-cost_weight: 1
+score_weight: 0
+cost_weight: 0
 results:
   Claude-3.5-Sonnet: 2.5
   Claude-3.7-Sonnet (Think): 50.81761006289308

--- a/data/raw/benchmarks/matharena-project-euler.yaml
+++ b/data/raw/benchmarks/matharena-project-euler.yaml
@@ -2,8 +2,8 @@ benchmark: MathArena Project Euler
 description: Accuracy on MathArena Project Euler competition
 website: https://matharena.ai/
 github: https://github.com/eth-sri/matharena
-score_weight: 1
-cost_weight: 1
+score_weight: 0
+cost_weight: 0
 results:
   Claude-Sonnet-4.0: 1.6666666666666667
   GPT-5 (high): 56.666666666666664

--- a/data/raw/benchmarks/matharena-smt-2025.yaml
+++ b/data/raw/benchmarks/matharena-smt-2025.yaml
@@ -2,8 +2,8 @@ benchmark: MathArena SMT 2025
 description: Accuracy on MathArena SMT 2025 competition
 website: https://matharena.ai/
 github: https://github.com/eth-sri/matharena
-score_weight: 1
-cost_weight: 1
+score_weight: 0
+cost_weight: 0
 results:
   Claude-3.7-Sonnet (Think): 56.60377358490564
   DeepSeek-R1: 66.98113207547168

--- a/data/raw/benchmarks/matharena-usamo-2025.yaml
+++ b/data/raw/benchmarks/matharena-usamo-2025.yaml
@@ -2,8 +2,8 @@ benchmark: MathArena USAMO 2025
 description: Accuracy on MathArena USAMO 2025 competition
 website: https://matharena.ai/
 github: https://github.com/eth-sri/matharena
-score_weight: 1
-cost_weight: 1
+score_weight: 0
+cost_weight: 0
 results:
   Claude-3.7-Sonnet (Think): 3.645833333333333
   DeepSeek-R1: 4.761904761904762


### PR DESCRIPTION
## Summary
- set `score_weight` and `cost_weight` to 0 for all MathArena benchmark definitions

## Testing
- `uv run process_data.py`
- `pnpm prettier`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1a970c4608320abaa77acda69582b