### PR TITLE
feat: show family reasoning efforts on model page

### DIFF
--- a/app/models/[slug]/page.tsx
+++ b/app/models/[slug]/page.tsx
@@ -42,6 +42,17 @@ export default async function ModelPage({
   const entries = benchNames.map(
     (name) => [name, model.benchmarks[name]] as const,
   )
+  const familyEntries = allModels
+    .filter((m) => m.modelSlug === model.modelSlug && m.slug !== model.slug)
+    .flatMap((m) =>
+      benchNames.map((name) => ({
+        model: m.model,
+        provider: m.provider,
+        benchmark: name,
+        result: m.benchmarks[name],
+      })),
+    )
+    .filter((e) => e.result !== undefined)
 
   return (
     <main className="container mx-auto px-4 py-8 max-w-7xl space-y-6">
@@ -52,6 +63,7 @@ export default async function ModelPage({
         entries={entries
           .filter(([, res]) => res !== undefined)
           .map(([benchmark, res]) => ({ benchmark, result: res! }))}
+        familyEntries={familyEntries}
         xDomain={costDomain}
         yDomain={[0, 100]}
         yTicks={[0, 25, 50, 75, 100]}

--- a/components/cost-performance-chart.tsx
+++ b/components/cost-performance-chart.tsx
@@ -23,6 +23,7 @@ export type CostPerformanceEntry = {
   score: number
   connectKey?: string
   meta?: unknown
+  opacity?: number
 }
 
 type Props = {
@@ -138,6 +139,7 @@ export default function CostPerformanceChart({
           cy={cy}
           r={r}
           fill={fill}
+          fillOpacity={payload.opacity ?? 1}
           stroke="white"
           strokeWidth={1}
           onMouseEnter={() => setHoverKey(key)}

--- a/components/model-cost-score-chart.tsx
+++ b/components/model-cost-score-chart.tsx
@@ -11,9 +11,15 @@ type Entry = {
   result: BenchmarkResult
 }
 
+type FamilyEntry = Entry & {
+  model: string
+  provider: string
+}
+
 type Props = {
   provider: string
   entries: Entry[]
+  familyEntries?: FamilyEntry[]
   xDomain: [number, number]
   yDomain?: [number, number]
   yTicks?: number[]
@@ -22,12 +28,13 @@ type Props = {
 export default function ModelCostScoreChart({
   provider,
   entries,
+  familyEntries = [],
   xDomain,
   yDomain = [0, 100],
   yTicks = [0, 25, 50, 75, 100],
 }: Props) {
   const items = React.useMemo(() => {
-    return entries
+    const base = entries
       .filter(
         (e) =>
           e.result.normalizedCost !== undefined &&
@@ -38,8 +45,24 @@ export default function ModelCostScoreChart({
         provider,
         cost: e.result.normalizedCost as number,
         score: e.result.normalizedScore as number,
-      })) as CostPerformanceEntry[]
-  }, [entries, provider])
+      }))
+
+    const extras = familyEntries
+      .filter(
+        (e) =>
+          e.result.normalizedCost !== undefined &&
+          e.result.normalizedScore !== undefined,
+      )
+      .map((e) => ({
+        label: `${e.model} – ${e.benchmark}`,
+        provider: e.provider,
+        cost: e.result.normalizedCost as number,
+        score: e.result.normalizedScore as number,
+        opacity: 0.6,
+      }))
+
+    return [...base, ...extras] as CostPerformanceEntry[]
+  }, [entries, familyEntries, provider])
 
   const renderTooltip = React.useCallback(
     (entry: CostPerformanceEntry) => <span>{entry.label}</span>,


### PR DESCRIPTION
## Summary
- plot additional reasoning efforts from the same model family on model pages
- fade family effort points to 60% opacity
- allow cost-performance chart entries to define fill opacity

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1b6e029cc8320b10fea4fd7073ca3