### PR TITLE
feat: add GLM-4.5 model mapping

### DIFF
--- a/data/config/mappings/livebench.yaml
+++ b/data/config/mappings/livebench.yaml
@@ -28,8 +28,8 @@ gemma-3-27b-it: null
 gemma-3-4b-it: null
 gemma-3n-e2b-it: null
 gemma-3n-e4b-it: null
-glm-4.5: null
-glm-4.5-air: null
+glm-4.5: glm-4.5
+glm-4.5-air: glm-4.5-air
 gpt-4.1-2025-04-14: gpt-4.1
 gpt-4.1-mini-2025-04-14: gpt-4.1-mini
 gpt-4.1-nano-2025-04-14: gpt-4.1-nano

--- a/data/config/mappings/lmarena-text.yaml
+++ b/data/config/mappings/lmarena-text.yaml
@@ -97,8 +97,8 @@ glm-4-0116: null
 glm-4-0520: null
 glm-4-plus: null
 glm-4-plus-0111: null
-glm-4.5: null
-glm-4.5-air: null
+glm-4.5: glm-4.5
+glm-4.5-air: glm-4.5-air
 gpt-3.5-turbo-0125: null
 gpt-3.5-turbo-0314: null
 gpt-3.5-turbo-0613: null

--- a/data/config/mappings/weirdml.yaml
+++ b/data/config/mappings/weirdml.yaml
@@ -21,7 +21,7 @@ gemini-2.5-flash-lite-preview-06-17 (thinking 16k): null
 gemini-2.5-pro (thinking 16k): gemini-2.5-pro-06-05
 gemini-flash-1.5-002: null
 gemini-pro-1.5-002: null
-glm-4.5 (thinking): null
+glm-4.5 (thinking): glm-4.5-air
 gpt-3.5-turbo-0125: null
 gpt-4-0613: null
 gpt-4-turbo-2024-04-09: null

--- a/data/config/models/glm-4.5.yaml
+++ b/data/config/models/glm-4.5.yaml
@@ -1,0 +1,4 @@
+provider: ZhipuAI
+reasoning_efforts:
+  glm-4.5: GLM-4.5
+  glm-4.5-air: GLM-4.5 Air

--- a/data/processed/benchmarks/arc-agi-1.yaml
+++ b/data/processed/benchmarks/arc-agi-1.yaml
@@ -212,4 +212,4 @@ gpt-4.1-nano:
   score: 0.0
   normalized_score: 0.0
   cost: 0.0021
-  normalized_cost: 0.8766
+  normalized_cost: 0.8765

--- a/data/processed/benchmarks/livebench.yaml
+++ b/data/processed/benchmarks/livebench.yaml
@@ -67,6 +67,9 @@ gemini-2.5-flash-0520-thinking:
 gpt-5-mini-low:
   score: 63.85
   normalized_score: 68.3
+glm-4.5:
+  score: 63.55
+  normalized_score: 67.66
 claude-sonnet-4-nothinking:
   score: 63.37
   normalized_score: 67.27
@@ -79,6 +82,9 @@ deepseek-v3.1:
 grok-3-mini-high:
   score: 62.36
   normalized_score: 65.1
+glm-4.5-air:
+  score: 59.93
+  normalized_score: 59.87
 gpt-5-nano-medium:
   score: 58.74
   normalized_score: 57.31

--- a/data/processed/benchmarks/lmarena-text.yaml
+++ b/data/processed/benchmarks/lmarena-text.yaml
@@ -4,6 +4,9 @@ gemini-2.5-pro-06-05:
 gemini-2.5-pro-preview-05-06:
   score: 1446.0
   normalized_score: 88.66
+glm-4.5:
+  score: 1435.0
+  normalized_score: 83.39
 grok-4:
   score: 1435.0
   normalized_score: 83.32
@@ -25,6 +28,9 @@ gemini-2.5-flash-0520-thinking:
 gemini-2.5-flash-preview-0417-thinking:
   score: 1397.0
   normalized_score: 65.79
+glm-4.5-air:
+  score: 1394.0
+  normalized_score: 64.37
 qwen-3-235b-a22b-nothinking:
   score: 1391.0
   normalized_score: 63.19

--- a/data/processed/benchmarks/weirdml.yaml
+++ b/data/processed/benchmarks/weirdml.yaml
@@ -58,6 +58,11 @@ deepseek-r1-0528:
   normalized_score: 58.62
   cost: 0.071
   normalized_cost: 41.15
+glm-4.5-air:
+  score: 40.76
+  normalized_score: 58.29
+  cost: 0.07364
+  normalized_cost: 42.68
 claude-3.5-sonnet-v2:
   score: 39.78
   normalized_score: 55.66
@@ -92,7 +97,7 @@ gpt-4.1-mini:
   score: 37.25
   normalized_score: 48.87
   cost: 0.01648
-  normalized_cost: 9.553
+  normalized_cost: 9.552
 deepseek-v3.1-thinking:
   score: 37.1
   normalized_score: 48.47


### PR DESCRIPTION
## Summary
- add GLM-4.5 model definition
- map GLM-4.5 and GLM-4.5 Air across benchmarks and regenerate processed data

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test`
- `pnpm mappings:update`
- `pnpm process:all`


------
https://chatgpt.com/codex/tasks/task_e_68b1b67d856483208e3ccd237e6c3399