### PR TITLE
feat: add GLM-4.5 model mappings

### DIFF
--- a/data/config/mappings/artificial-analysis.yaml
+++ b/data/config/mappings/artificial-analysis.yaml
@@ -86,8 +86,8 @@ Gemma 3 4B: null
 Gemma 3n E2B: null
 Gemma 3n E4B: null
 Gemma 3n E4B (May '25): null
-GLM-4.5: null
-GLM-4.5-Air: null
+GLM-4.5: glm-4.5
+GLM-4.5-Air: glm-4.5-air
 GLM-4.5V (Reasoning): null
 GPT-3.5 Turbo: null
 GPT-4: null

--- a/data/config/mappings/eqbench3.yaml
+++ b/data/config/mappings/eqbench3.yaml
@@ -43,4 +43,4 @@ Qwen/Qwen3-30B-A3B: null
 Qwen/Qwen3-32B: null
 Qwen/Qwen3-8B: null
 qwen/qwq-32b: null
-zai-org/GLM-4.5: null
+zai-org/GLM-4.5: glm-4.5

--- a/data/config/mappings/matharena.yaml
+++ b/data/config/mappings/matharena.yaml
@@ -20,8 +20,8 @@ gemini-2.5-pro: null
 gemini-2.5-pro (agent): null
 gemini-2.5-pro (best-of-32): null
 gemini-2.5-pro-05-06: null
-GLM 4.5: null
-GLM 4.5 Air: null
+GLM 4.5: glm-4.5
+GLM 4.5 Air: glm-4.5-air
 GPT OSS 120B (high): null
 GPT OSS 20B (high): null
 gpt-4o: null

--- a/data/config/models/glm-4.5-air.yaml
+++ b/data/config/models/glm-4.5-air.yaml
@@ -1,0 +1,3 @@
+provider: ZhipuAI
+reasoning_efforts:
+  glm-4.5-air: GLM-4.5-Air

--- a/data/config/models/glm-4.5.yaml
+++ b/data/config/models/glm-4.5.yaml
@@ -1,0 +1,3 @@
+provider: ZhipuAI
+reasoning_efforts:
+  glm-4.5: GLM-4.5

--- a/data/processed/benchmarks/aider-polyglot.yaml
+++ b/data/processed/benchmarks/aider-polyglot.yaml
@@ -2,32 +2,32 @@ o3-pro-high:
   score: 84.9
   normalized_score: 100.0
   cost: 0.6503
-  normalized_cost: 1308.0
+  normalized_cost: 1321.0
 o3-high:
   score: 81.3
   normalized_score: 95.26
   cost: 0.0943
-  normalized_cost: 189.6
+  normalized_cost: 191.5
 grok-4:
   score: 79.6
   normalized_score: 93.03
   cost: 0.265
-  normalized_cost: 532.8
+  normalized_cost: 538.1
 gemini-2.5-pro-06-05:
   score: 79.1
   normalized_score: 92.37
   cost: 0.2026
-  normalized_cost: 407.4
+  normalized_cost: 411.4
 o3-medium:
   score: 76.9
   normalized_score: 89.47
   cost: 0.0611
-  normalized_cost: 122.9
+  normalized_cost: 124.1
 gemini-2.5-pro-preview-05-06:
   score: 76.9
   normalized_score: 89.47
   cost: 0.1663
-  normalized_cost: 334.4
+  normalized_cost: 337.7
 gemini-2.5-pro-preview-03-25:
   score: 72.9
   normalized_score: 84.21
@@ -35,37 +35,37 @@ o4-mini-high:
   score: 72.0
   normalized_score: 83.03
   cost: 0.0873
-  normalized_cost: 175.5
+  normalized_cost: 177.3
 claude-opus-4-thinking:
   score: 72.0
   normalized_score: 83.03
   cost: 0.2922
-  normalized_cost: 587.5
+  normalized_cost: 593.4
 deepseek-r1-0528:
   score: 71.4
   normalized_score: 82.24
   cost: 0.0214
-  normalized_cost: 43.03
+  normalized_cost: 43.46
 claude-opus-4-nothinking:
   score: 70.7
   normalized_score: 81.32
   cost: 0.305
-  normalized_cost: 613.3
+  normalized_cost: 619.4
 claude-3.7-sonnet-thinking:
   score: 64.9
   normalized_score: 73.68
   cost: 0.1637
-  normalized_cost: 329.2
+  normalized_cost: 332.4
 claude-sonnet-4-thinking:
   score: 61.3
   normalized_score: 68.95
   cost: 0.1181
-  normalized_cost: 237.5
+  normalized_cost: 239.8
 claude-3.7-sonnet-nothinking:
   score: 60.4
   normalized_score: 67.76
   cost: 0.0788
-  normalized_cost: 158.4
+  normalized_cost: 160.0
 qwen-3-235b-a22b-nothinking:
   score: 59.6
   normalized_score: 66.71
@@ -73,87 +73,87 @@ kimi-k2:
   score: 59.1
   normalized_score: 66.05
   cost: 0.0055
-  normalized_cost: 11.06
+  normalized_cost: 11.17
 deepseek-r1-0120:
   score: 56.9
   normalized_score: 63.16
   cost: 0.0241
-  normalized_cost: 48.46
+  normalized_cost: 48.94
 claude-sonnet-4-nothinking:
   score: 56.4
   normalized_score: 62.5
   cost: 0.0703
-  normalized_cost: 141.4
+  normalized_cost: 142.8
 deepseek-v3-0324:
   score: 55.1
   normalized_score: 60.79
   cost: 0.005
-  normalized_cost: 10.05
+  normalized_cost: 10.15
 grok-3:
   score: 53.3
   normalized_score: 58.42
   cost: 0.049
-  normalized_cost: 98.52
+  normalized_cost: 99.51
 gpt-4.1:
   score: 52.4
   normalized_score: 57.24
   cost: 0.0438
-  normalized_cost: 88.07
+  normalized_cost: 88.95
 claude-3.5-sonnet-v2:
   score: 51.6
   normalized_score: 56.18
   cost: 0.064
-  normalized_cost: 128.7
+  normalized_cost: 130.0
 grok-3-mini-high:
   score: 49.3
   normalized_score: 53.16
   cost: 0.0033
-  normalized_cost: 6.635
+  normalized_cost: 6.701
 deepseek-v3-1224:
   score: 48.4
   normalized_score: 51.97
   cost: 0.0015
-  normalized_cost: 3.016
+  normalized_cost: 3.046
 gemini-2.5-flash-0520-thinking:
   score: 47.1
   normalized_score: 50.26
   cost: 0.0082
-  normalized_cost: 16.49
+  normalized_cost: 16.65
 gpt-4.5-preview:
   score: 44.9
   normalized_score: 47.37
   cost: 0.8178
-  normalized_cost: 1644.0
+  normalized_cost: 1661.0
 gemini-2.5-flash-0520-nothinking:
   score: 44.0
   normalized_score: 46.18
   cost: 0.005
-  normalized_cost: 10.05
+  normalized_cost: 10.15
 grok-3-mini-low:
   score: 34.7
   normalized_score: 33.95
   cost: 0.0035
-  normalized_cost: 7.037
+  normalized_cost: 7.108
 gpt-4.1-mini:
   score: 32.4
   normalized_score: 30.92
   cost: 0.0089
-  normalized_cost: 17.9
+  normalized_cost: 18.07
 claude-3.5-haiku:
   score: 28.0
   normalized_score: 25.13
   cost: 0.0269
-  normalized_cost: 54.09
+  normalized_cost: 54.63
 gpt-4o-2024-08-06:
   score: 23.1
   normalized_score: 18.68
   cost: 0.0312
-  normalized_cost: 62.73
+  normalized_cost: 63.36
 gpt-4o-2024-11-20:
   score: 18.2
   normalized_score: 12.24
   cost: 0.0299
-  normalized_cost: 60.12
+  normalized_cost: 60.72
 llama-4-maverick:
   score: 15.6
   normalized_score: 8.816
@@ -161,4 +161,4 @@ gpt-4.1-nano:
   score: 8.9
   normalized_score: 0.0
   cost: 0.0019
-  normalized_cost: 3.82
+  normalized_cost: 3.858

--- a/data/processed/benchmarks/arc-agi-1.yaml
+++ b/data/processed/benchmarks/arc-agi-1.yaml
@@ -2,214 +2,214 @@ grok-4:
   score: 66.7
   normalized_score: 100.0
   cost: 1.014
-  normalized_cost: 423.1
+  normalized_cost: 427.3
 gpt-5-high:
   score: 65.7
   normalized_score: 98.5
   cost: 0.5087
-  normalized_cost: 212.3
+  normalized_cost: 214.5
 o3-high:
   score: 60.8
   normalized_score: 91.15
   cost: 0.5002
-  normalized_cost: 208.8
+  normalized_cost: 210.9
 o3-pro-high:
   score: 59.3
   normalized_score: 88.91
   cost: 4.16
-  normalized_cost: 1736.0
+  normalized_cost: 1754.0
 o4-mini-high:
   score: 58.7
   normalized_score: 88.01
   cost: 0.4058
-  normalized_cost: 169.4
+  normalized_cost: 171.1
 o3-pro-medium:
   score: 57.0
   normalized_score: 85.46
   cost: 3.177
-  normalized_cost: 1326.0
+  normalized_cost: 1339.0
 gpt-5-medium:
   score: 56.2
   normalized_score: 84.26
   cost: 0.3301
-  normalized_cost: 137.8
+  normalized_cost: 139.2
 gpt-5-mini-high:
   score: 54.3
   normalized_score: 81.41
   cost: 0.116
-  normalized_cost: 48.42
+  normalized_cost: 48.9
 o3-medium:
   score: 53.8
   normalized_score: 80.66
   cost: 0.2882
-  normalized_cost: 120.3
+  normalized_cost: 121.5
 o3-pro-low:
   score: 44.3
   normalized_score: 66.42
   cost: 1.638
-  normalized_cost: 683.8
+  normalized_cost: 690.6
 gpt-5-low:
   score: 44.0
   normalized_score: 65.97
   cost: 0.1531
-  normalized_cost: 63.9
+  normalized_cost: 64.54
 o4-mini-medium:
   score: 41.8
   normalized_score: 62.67
   cost: 0.15
-  normalized_cost: 62.61
+  normalized_cost: 63.24
 o3-low:
   score: 41.5
   normalized_score: 62.22
   cost: 0.1764
-  normalized_cost: 73.63
+  normalized_cost: 74.36
 claude-sonnet-4-thinking:
   score: 40.0
   normalized_score: 59.97
   cost: 0.3658
-  normalized_cost: 152.7
+  normalized_cost: 154.2
 gpt-5-mini-medium:
   score: 37.3
   normalized_score: 55.92
   cost: 0.0401
-  normalized_cost: 16.74
+  normalized_cost: 16.9
 gemini-2.5-pro-06-05:
   score: 37.0
   normalized_score: 55.47
   cost: 0.5123
-  normalized_cost: 213.8
+  normalized_cost: 216.0
 claude-opus-4-thinking:
   score: 35.7
   normalized_score: 53.52
   cost: 1.25
-  normalized_cost: 521.6
+  normalized_cost: 526.8
 gemini-2.5-flash-0520-nothinking:
   score: 33.3
   normalized_score: 49.93
   cost: 0.0371
-  normalized_cost: 15.49
+  normalized_cost: 15.64
 gemini-2.5-flash-0520-thinking:
   score: 32.3
   normalized_score: 48.43
   cost: 0.1971
-  normalized_cost: 82.27
+  normalized_cost: 83.09
 claude-3.7-sonnet-thinking:
   score: 28.6
   normalized_score: 42.88
   cost: 0.33
-  normalized_cost: 137.7
+  normalized_cost: 139.1
 gpt-5-mini-low:
   score: 26.3
   normalized_score: 39.43
   cost: 0.0135
-  normalized_cost: 5.635
+  normalized_cost: 5.691
 claude-sonnet-4-nothinking:
   score: 23.8
   normalized_score: 35.68
   cost: 0.0806
-  normalized_cost: 33.64
+  normalized_cost: 33.98
 claude-opus-4-nothinking:
   score: 22.5
   normalized_score: 33.73
   cost: 0.4036
-  normalized_cost: 168.5
+  normalized_cost: 170.1
 o4-mini-low:
   score: 21.3
   normalized_score: 31.93
   cost: 0.0406
-  normalized_cost: 16.95
+  normalized_cost: 17.12
 deepseek-r1-0528:
   score: 21.2
   normalized_score: 31.78
   cost: 0.0464
-  normalized_cost: 19.37
+  normalized_cost: 19.56
 gpt-5-nano-medium:
   score: 20.7
   normalized_score: 31.03
   cost: 0.0124
-  normalized_cost: 5.176
+  normalized_cost: 5.227
 gpt-5-nano-high:
   score: 16.7
   normalized_score: 25.04
   cost: 0.0292
-  normalized_cost: 12.19
+  normalized_cost: 12.31
 grok-3-mini-low:
   score: 16.5
   normalized_score: 24.74
   cost: 0.0099
-  normalized_cost: 4.132
+  normalized_cost: 4.174
 deepseek-r1-0120:
   score: 15.8
   normalized_score: 23.69
   cost: 0.06
-  normalized_cost: 25.04
+  normalized_cost: 25.29
 claude-3.7-sonnet-nothinking:
   score: 13.6
   normalized_score: 20.39
   cost: 0.058
-  normalized_cost: 24.21
+  normalized_cost: 24.45
 qwen-3-235b-a22b-nothinking:
   score: 11.0
   normalized_score: 16.49
   cost: 0.0025
-  normalized_cost: 1.044
+  normalized_cost: 1.054
 gpt-4.5-preview:
   score: 10.3
   normalized_score: 15.44
   cost: 0.29
-  normalized_cost: 121.0
+  normalized_cost: 122.3
 gpt-5-minimal:
   score: 6.0
   normalized_score: 8.996
   cost: 0.0335
-  normalized_cost: 13.98
+  normalized_cost: 14.12
 gpt-4.1:
   score: 5.5
   normalized_score: 8.246
   cost: 0.039
-  normalized_cost: 16.28
+  normalized_cost: 16.44
 grok-3:
   score: 5.5
   normalized_score: 8.246
   cost: 0.0931
-  normalized_cost: 38.86
+  normalized_cost: 39.25
 gpt-5-mini-minimal:
   score: 5.3
   normalized_score: 7.946
   cost: 0.0057
-  normalized_cost: 2.379
+  normalized_cost: 2.403
 gpt-4o-2024-05-13:
   score: 4.5
   normalized_score: 6.747
   cost: 0.05
-  normalized_cost: 20.87
+  normalized_cost: 21.08
 llama-4-maverick:
   score: 4.4
   normalized_score: 6.597
   cost: 0.0078
-  normalized_cost: 3.256
+  normalized_cost: 3.288
 gpt-5-nano-low:
   score: 4.0
   normalized_score: 5.997
   cost: 0.0033
-  normalized_cost: 1.377
+  normalized_cost: 1.391
 gpt-4.1-mini:
   score: 3.5
   normalized_score: 5.247
   cost: 0.0078
-  normalized_cost: 3.256
+  normalized_cost: 3.288
 gpt-5-nano-minimal:
   score: 1.5
   normalized_score: 2.249
   cost: 0.0015
-  normalized_cost: 0.6261
+  normalized_cost: 0.6324
 llama-4-scout:
   score: 0.5
   normalized_score: 0.7496
   cost: 0.0041
-  normalized_cost: 1.711
+  normalized_cost: 1.728
 gpt-4.1-nano:
   score: 0.0
   normalized_score: 0.0
   cost: 0.0021
-  normalized_cost: 0.8766
+  normalized_cost: 0.8853

--- a/data/processed/benchmarks/arc-agi-2.yaml
+++ b/data/processed/benchmarks/arc-agi-2.yaml
@@ -2,214 +2,214 @@ grok-4:
   score: 16.0
   normalized_score: 100.0
   cost: 2.166
-  normalized_cost: 521.1
+  normalized_cost: 526.3
 gpt-5-high:
   score: 9.9
   normalized_score: 61.88
   cost: 0.7302
-  normalized_cost: 175.7
+  normalized_cost: 177.4
 claude-opus-4-thinking:
   score: 8.6
   normalized_score: 53.75
   cost: 1.928
-  normalized_cost: 464.0
+  normalized_cost: 468.6
 gpt-5-medium:
   score: 7.5
   normalized_score: 46.88
   cost: 0.4486
-  normalized_cost: 107.9
+  normalized_cost: 109.0
 o3-high:
   score: 6.5
   normalized_score: 40.62
   cost: 0.8339
-  normalized_cost: 200.6
+  normalized_cost: 202.6
 o4-mini-high:
   score: 6.1
   normalized_score: 38.12
   cost: 0.856
-  normalized_cost: 206.0
+  normalized_cost: 208.0
 claude-sonnet-4-thinking:
   score: 5.9
   normalized_score: 36.88
   cost: 0.4857
-  normalized_cost: 116.9
+  normalized_cost: 118.0
 gemini-2.5-pro-06-05:
   score: 4.9
   normalized_score: 30.63
   cost: 0.757
-  normalized_cost: 182.1
+  normalized_cost: 184.0
 o3-pro-high:
   score: 4.9
   normalized_score: 30.63
   cost: 7.552
-  normalized_cost: 1817.0
+  normalized_cost: 1835.0
 gpt-5-mini-high:
   score: 4.4
   normalized_score: 27.5
   cost: 0.1977
-  normalized_cost: 47.57
+  normalized_cost: 48.04
 gpt-5-mini-medium:
   score: 4.0
   normalized_score: 25.0
   cost: 0.0629
-  normalized_cost: 15.13
+  normalized_cost: 15.29
 o3-medium:
   score: 3.0
   normalized_score: 18.75
   cost: 0.4787
-  normalized_cost: 115.2
+  normalized_cost: 116.3
 gpt-5-nano-high:
   score: 2.6
   normalized_score: 16.25
   cost: 0.0295
-  normalized_cost: 7.098
+  normalized_cost: 7.169
 gemini-2.5-flash-0520-thinking:
   score: 2.5
   normalized_score: 15.62
   cost: 0.3191
-  normalized_cost: 76.78
+  normalized_cost: 77.55
 o4-mini-medium:
   score: 2.4
   normalized_score: 15.0
   cost: 0.2311
-  normalized_cost: 55.61
+  normalized_cost: 56.16
 o3-pro-low:
   score: 2.1
   normalized_score: 13.12
   cost: 2.229
-  normalized_cost: 536.4
+  normalized_cost: 541.7
 o3-low:
   score: 2.0
   normalized_score: 12.5
   cost: 0.2343
-  normalized_cost: 56.38
+  normalized_cost: 56.94
 gpt-5-low:
   score: 1.9
   normalized_score: 11.88
   cost: 0.1896
-  normalized_cost: 45.62
+  normalized_cost: 46.08
 o3-pro-medium:
   score: 1.9
   normalized_score: 11.88
   cost: 4.744
-  normalized_cost: 1141.0
+  normalized_cost: 1153.0
 gpt-5-mini-minimal:
   score: 1.7
   normalized_score: 10.62
   cost: 0.0094
-  normalized_cost: 2.262
+  normalized_cost: 2.284
 o4-mini-low:
   score: 1.7
   normalized_score: 10.62
   cost: 0.05
-  normalized_cost: 12.03
+  normalized_cost: 12.15
 gemini-2.5-flash-0520-nothinking:
   score: 1.7
   normalized_score: 10.62
   cost: 0.057
-  normalized_cost: 13.71
+  normalized_cost: 13.85
 qwen-3-235b-a22b-nothinking:
   score: 1.3
   normalized_score: 8.125
   cost: 0.0044
-  normalized_cost: 1.059
+  normalized_cost: 1.069
 deepseek-r1-0120:
   score: 1.3
   normalized_score: 8.125
   cost: 0.08
-  normalized_cost: 19.25
+  normalized_cost: 19.44
 claude-sonnet-4-nothinking:
   score: 1.3
   normalized_score: 8.125
   cost: 0.1272
-  normalized_cost: 30.61
+  normalized_cost: 30.91
 claude-opus-4-nothinking:
   score: 1.3
   normalized_score: 8.125
   cost: 0.6388
-  normalized_cost: 153.7
+  normalized_cost: 155.2
 deepseek-r1-0528:
   score: 1.1
   normalized_score: 6.875
   cost: 0.0527
-  normalized_cost: 12.68
+  normalized_cost: 12.81
 gpt-5-nano-medium:
   score: 0.9
   normalized_score: 5.625
   cost: 0.0137
-  normalized_cost: 3.296
+  normalized_cost: 3.329
 gpt-5-mini-low:
   score: 0.8
   normalized_score: 5.0
   cost: 0.0189
-  normalized_cost: 4.548
+  normalized_cost: 4.593
 gpt-4.5-preview:
   score: 0.8
   normalized_score: 5.0
   cost: 2.1
-  normalized_cost: 505.3
+  normalized_cost: 510.3
 claude-3.7-sonnet-thinking:
   score: 0.7
   normalized_score: 4.375
   cost: 0.51
-  normalized_cost: 122.7
+  normalized_cost: 123.9
 grok-3-mini-low:
   score: 0.4
   normalized_score: 2.5
   cost: 0.0131
-  normalized_cost: 3.152
+  normalized_cost: 3.183
 gpt-4.1:
   score: 0.4
   normalized_score: 2.5
   cost: 0.0691
-  normalized_cost: 16.63
+  normalized_cost: 16.79
 gpt-5-nano-minimal:
   score: 0.0
   normalized_score: 0.0
   cost: 0.0025
-  normalized_cost: 0.6015
+  normalized_cost: 0.6075
 gpt-5-nano-low:
   score: 0.0
   normalized_score: 0.0
   cost: 0.0033
-  normalized_cost: 0.794
+  normalized_cost: 0.8019
 gpt-4.1-nano:
   score: 0.0
   normalized_score: 0.0
   cost: 0.0036
-  normalized_cost: 0.8662
+  normalized_cost: 0.8748
 llama-4-scout:
   score: 0.0
   normalized_score: 0.0
   cost: 0.0062
-  normalized_cost: 1.492
+  normalized_cost: 1.507
 llama-4-maverick:
   score: 0.0
   normalized_score: 0.0
   cost: 0.0121
-  normalized_cost: 2.911
+  normalized_cost: 2.94
 gpt-4.1-mini:
   score: 0.0
   normalized_score: 0.0
   cost: 0.0139
-  normalized_cost: 3.344
+  normalized_cost: 3.378
 gpt-5-minimal:
   score: 0.0
   normalized_score: 0.0
   cost: 0.0562
-  normalized_cost: 13.52
+  normalized_cost: 13.66
 gpt-4o-2024-05-13:
   score: 0.0
   normalized_score: 0.0
   cost: 0.08
-  normalized_cost: 19.25
+  normalized_cost: 19.44
 claude-3.7-sonnet-nothinking:
   score: 0.0
   normalized_score: 0.0
   cost: 0.12
-  normalized_cost: 28.87
+  normalized_cost: 29.16
 grok-3:
   score: 0.0
   normalized_score: 0.0
   cost: 0.1421
-  normalized_cost: 34.19
+  normalized_cost: 34.53

--- a/data/processed/benchmarks/artificial-analysis-index.yaml
+++ b/data/processed/benchmarks/artificial-analysis-index.yaml
@@ -2,57 +2,57 @@ gpt-5-high:
   score: 69.0
   normalized_score: 100.0
   cost: 823.0
-  normalized_cost: 195.5
+  normalized_cost: 197.6
 gpt-5-medium:
   score: 68.0
   normalized_score: 97.83
   cost: 432.0
-  normalized_cost: 102.6
+  normalized_cost: 103.7
 grok-4:
   score: 68.0
   normalized_score: 97.83
   cost: 1658.0
-  normalized_cost: 393.8
+  normalized_cost: 398.0
 o3-medium:
   score: 67.0
   normalized_score: 95.65
   cost: 410.0
-  normalized_cost: 97.38
+  normalized_cost: 98.42
 gpt-5-mini-high:
   score: 65.0
   normalized_score: 91.3
   cost: 155.0
-  normalized_cost: 36.82
+  normalized_cost: 37.21
 o4-mini-high:
   score: 65.0
   normalized_score: 91.3
   cost: 330.0
-  normalized_cost: 78.38
+  normalized_cost: 79.22
 gemini-2.5-pro-06-05:
   score: 65.0
   normalized_score: 91.3
   cost: 983.0
-  normalized_cost: 233.5
+  normalized_cost: 236.0
 gpt-5-mini-medium:
   score: 64.0
   normalized_score: 89.13
   cost: 52.0
-  normalized_cost: 12.35
+  normalized_cost: 12.48
 gpt-5-low:
   score: 63.0
   normalized_score: 86.96
   cost: 169.0
-  normalized_cost: 40.14
+  normalized_cost: 40.57
 gpt-oss-120b-high:
   score: 61.0
   normalized_score: 82.61
   cost: 66.0
-  normalized_cost: 15.68
+  normalized_cost: 15.84
 claude-sonnet-4-thinking:
   score: 59.0
   normalized_score: 78.26
   cost: 650.0
-  normalized_cost: 154.4
+  normalized_cost: 156.0
 gemini-2.5-pro-preview-03-25:
   score: 59.0
   normalized_score: 78.26
@@ -60,35 +60,45 @@ grok-3-mini-high:
   score: 58.0
   normalized_score: 76.09
   cost: 67.0
-  normalized_cost: 15.91
+  normalized_cost: 16.08
 gemini-2.5-flash-0520-thinking:
   score: 58.0
   normalized_score: 76.09
   cost: 229.0
-  normalized_cost: 54.39
+  normalized_cost: 54.97
 gemini-2.5-pro-preview-05-06:
   score: 58.0
   normalized_score: 76.09
+glm-4.5:
+  score: 56.0
+  normalized_score: 71.74
+  cost: 230.0
+  normalized_cost: 55.21
 gpt-5-nano-high:
   score: 55.0
   normalized_score: 69.57
   cost: 56.0
-  normalized_cost: 13.3
+  normalized_cost: 13.44
 claude-opus-4-thinking:
   score: 55.0
   normalized_score: 69.57
   cost: 1999.0
-  normalized_cost: 474.8
+  normalized_cost: 479.9
 gpt-5-nano-medium:
   score: 54.0
   normalized_score: 67.39
   cost: 23.0
-  normalized_cost: 5.463
+  normalized_cost: 5.521
+glm-4.5-air:
+  score: 53.0
+  normalized_score: 65.22
+  cost: 125.0
+  normalized_cost: 30.01
 deepseek-r1-0120:
   score: 53.0
   normalized_score: 65.22
   cost: 218.0
-  normalized_cost: 51.78
+  normalized_cost: 52.33
 gemini-2.5-flash-preview-0417-thinking:
   score: 50.0
   normalized_score: 58.7
@@ -96,32 +106,32 @@ gpt-oss-20b-high:
   score: 49.0
   normalized_score: 56.52
   cost: 11.0
-  normalized_cost: 2.613
+  normalized_cost: 2.641
 kimi-k2:
   score: 49.0
   normalized_score: 56.52
   cost: 76.0
-  normalized_cost: 18.05
+  normalized_cost: 18.24
 qwen-3-235b-a22b-thinking:
   score: 48.0
   normalized_score: 54.35
   cost: 706.0
-  normalized_cost: 167.7
+  normalized_cost: 169.5
 gemini-2.5-flash-0520-nothinking:
   score: 47.0
   normalized_score: 52.17
   cost: 46.0
-  normalized_cost: 10.93
+  normalized_cost: 11.04
 gpt-4.1:
   score: 47.0
   normalized_score: 52.17
   cost: 63.0
-  normalized_cost: 14.96
+  normalized_cost: 15.12
 claude-opus-4-nothinking:
   score: 47.0
   normalized_score: 52.17
   cost: 539.0
-  normalized_cost: 128.0
+  normalized_cost: 129.4
 claude-3.7-sonnet-thinking:
   score: 47.0
   normalized_score: 52.17
@@ -129,32 +139,32 @@ gpt-5-mini-minimal:
   score: 46.0
   normalized_score: 50.0
   cost: 9.0
-  normalized_cost: 2.138
+  normalized_cost: 2.161
 gpt-4.1-mini:
   score: 46.0
   normalized_score: 50.0
   cost: 16.0
-  normalized_cost: 3.8
+  normalized_cost: 3.841
 claude-sonnet-4-nothinking:
   score: 46.0
   normalized_score: 50.0
   cost: 117.0
-  normalized_cost: 27.79
+  normalized_cost: 28.09
 deepseek-v3-0324:
   score: 44.0
   normalized_score: 45.65
   cost: 13.0
-  normalized_cost: 3.088
+  normalized_cost: 3.121
 gpt-5-minimal:
   score: 44.0
   normalized_score: 45.65
   cost: 41.0
-  normalized_cost: 9.738
+  normalized_cost: 9.842
 llama-4-maverick:
   score: 42.0
   normalized_score: 41.3
   cost: 10.0
-  normalized_cost: 2.375
+  normalized_cost: 2.401
 grok-3:
   score: 40.0
   normalized_score: 36.96
@@ -165,7 +175,7 @@ deepseek-v3-1224:
   score: 37.0
   normalized_score: 30.43
   cost: 9.0
-  normalized_cost: 2.138
+  normalized_cost: 2.161
 claude-3.7-sonnet-nothinking:
   score: 37.0
   normalized_score: 30.43
@@ -173,12 +183,12 @@ llama-4-scout:
   score: 33.0
   normalized_score: 21.74
   cost: 6.0
-  normalized_cost: 1.425
+  normalized_cost: 1.44
 qwen-3-235b-a22b-nothinking:
   score: 33.0
   normalized_score: 21.74
   cost: 22.0
-  normalized_cost: 5.225
+  normalized_cost: 5.281
 claude-3.5-sonnet-v2:
   score: 33.0
   normalized_score: 21.74
@@ -186,17 +196,17 @@ gpt-5-nano-minimal:
   score: 32.0
   normalized_score: 19.57
   cost: 1.0
-  normalized_cost: 0.2375
+  normalized_cost: 0.2401
 gpt-4.1-nano:
   score: 32.0
   normalized_score: 19.57
   cost: 3.0
-  normalized_cost: 0.7126
+  normalized_cost: 0.7202
 gpt-4o-2024-11-20:
   score: 30.0
   normalized_score: 15.22
   cost: 63.0
-  normalized_cost: 14.96
+  normalized_cost: 15.12
 gpt-4o-2024-05-13:
   score: 30.0
   normalized_score: 15.22

--- a/data/processed/benchmarks/eqbench3.yaml
+++ b/data/processed/benchmarks/eqbench3.yaml
@@ -7,6 +7,9 @@ o3-medium:
 gemini-2.5-pro-06-05:
   score: 1470.0
   normalized_score: 91.32
+glm-4.5:
+  score: 1312.0
+  normalized_score: 76.86
 o4-mini-medium:
   score: 1291.0
   normalized_score: 74.97

--- a/data/processed/benchmarks/gpqa-diamond.yaml
+++ b/data/processed/benchmarks/gpqa-diamond.yaml
@@ -2,127 +2,137 @@ grok-4:
   score: 87.0
   normalized_score: 100.0
   cost: 27.0
-  normalized_cost: 382.5
+  normalized_cost: 386.5
 gpt-5-high:
   score: 85.0
   normalized_score: 95.74
   cost: 14.0
-  normalized_cost: 198.3
+  normalized_cost: 200.4
 gpt-5-medium:
   score: 84.0
   normalized_score: 93.62
   cost: 7.0
-  normalized_cost: 99.16
+  normalized_cost: 100.2
 gemini-2.5-pro-06-05:
   score: 84.0
   normalized_score: 93.62
   cost: 16.0
-  normalized_cost: 226.6
+  normalized_cost: 229.0
 gemini-2.5-pro-preview-03-25:
   score: 83.0
   normalized_score: 91.49
   cost: 10.0
-  normalized_cost: 141.7
+  normalized_cost: 143.2
 gpt-5-mini-high:
   score: 82.0
   normalized_score: 89.36
   cost: 3.0
-  normalized_cost: 42.5
+  normalized_cost: 42.95
 o3-medium:
   score: 82.0
   normalized_score: 89.36
   cost: 10.0
-  normalized_cost: 141.7
+  normalized_cost: 143.2
 gemini-2.5-pro-preview-05-06:
   score: 82.0
   normalized_score: 89.36
   cost: 25.0
-  normalized_cost: 354.1
+  normalized_cost: 357.9
 gpt-5-mini-medium:
   score: 80.0
   normalized_score: 85.11
   cost: 1.0
-  normalized_cost: 14.17
+  normalized_cost: 14.32
 gpt-5-low:
   score: 80.0
   normalized_score: 85.11
   cost: 3.0
-  normalized_cost: 42.5
+  normalized_cost: 42.95
 grok-3-mini-high:
   score: 79.0
   normalized_score: 82.98
   cost: 1.0
-  normalized_cost: 14.17
+  normalized_cost: 14.32
 gemini-2.5-flash-0520-thinking:
   score: 79.0
   normalized_score: 82.98
   cost: 4.0
-  normalized_cost: 56.66
+  normalized_cost: 57.26
 claude-opus-4-thinking:
   score: 79.0
   normalized_score: 82.98
   cost: 32.0
-  normalized_cost: 453.3
+  normalized_cost: 458.1
 gpt-oss-120b-high:
   score: 78.0
   normalized_score: 80.85
   cost: 1.0
-  normalized_cost: 14.17
+  normalized_cost: 14.32
+glm-4.5:
+  score: 78.0
+  normalized_score: 80.85
+  cost: 4.0
+  normalized_cost: 57.26
 o4-mini-high:
   score: 78.0
   normalized_score: 80.85
   cost: 7.0
-  normalized_cost: 99.16
+  normalized_cost: 100.2
 claude-sonnet-4-thinking:
   score: 77.0
   normalized_score: 78.72
   cost: 12.0
-  normalized_cost: 170.0
+  normalized_cost: 171.8
 claude-3.7-sonnet-thinking:
   score: 77.0
   normalized_score: 78.72
   cost: 27.0
-  normalized_cost: 382.5
+  normalized_cost: 386.5
 kimi-k2:
   score: 76.0
   normalized_score: 76.6
   cost: 1.0
-  normalized_cost: 14.17
+  normalized_cost: 14.32
+glm-4.5-air:
+  score: 73.0
+  normalized_score: 70.21
+  cost: 2.0
+  normalized_cost: 28.63
 deepseek-r1-0120:
   score: 70.0
   normalized_score: 63.83
   cost: 4.0
-  normalized_cost: 56.66
+  normalized_cost: 57.26
 claude-opus-4-nothinking:
   score: 70.0
   normalized_score: 63.83
   cost: 8.0
-  normalized_cost: 113.3
+  normalized_cost: 114.5
 qwen-3-235b-a22b-thinking:
   score: 70.0
   normalized_score: 63.83
   cost: 11.0
-  normalized_cost: 155.8
+  normalized_cost: 157.5
 grok-3:
   score: 69.0
   normalized_score: 61.7
   cost: 3.0
-  normalized_cost: 42.5
+  normalized_cost: 42.95
 gemini-2.5-flash-preview-0417-thinking:
   score: 69.0
   normalized_score: 61.7
   cost: 8.0
-  normalized_cost: 113.3
+  normalized_cost: 114.5
 gemini-2.5-flash-0520-nothinking:
   score: 68.0
   normalized_score: 59.57
   cost: 1.0
-  normalized_cost: 14.17
+  normalized_cost: 14.32
 claude-sonnet-4-nothinking:
   score: 68.0
   normalized_score: 59.57
   cost: 2.0
-  normalized_cost: 28.33
+  normalized_cost: 28.63
 gpt-5-mini-minimal:
   score: 68.0
   normalized_score: 59.57
@@ -130,12 +140,12 @@ gpt-5-minimal:
   score: 67.0
   normalized_score: 57.45
   cost: 1.0
-  normalized_cost: 14.17
+  normalized_cost: 14.32
 gpt-5-nano-high:
   score: 67.0
   normalized_score: 57.45
   cost: 1.0
-  normalized_cost: 14.17
+  normalized_cost: 14.32
 gpt-5-nano-medium:
   score: 67.0
   normalized_score: 57.45
@@ -146,7 +156,7 @@ gpt-4.1:
   score: 66.0
   normalized_score: 55.32
   cost: 1.0
-  normalized_cost: 14.17
+  normalized_cost: 14.32
 gpt-4.1-mini:
   score: 66.0
   normalized_score: 55.32
@@ -154,7 +164,7 @@ claude-3.7-sonnet-nothinking:
   score: 65.0
   normalized_score: 53.19
   cost: 1.0
-  normalized_cost: 14.17
+  normalized_cost: 14.32
 deepseek-v3-0324:
   score: 65.0
   normalized_score: 53.19
@@ -168,7 +178,7 @@ claude-3.5-sonnet-v2:
   score: 59.0
   normalized_score: 40.43
   cost: 1.0
-  normalized_cost: 14.17
+  normalized_cost: 14.32
 gemini-2.5-flash-preview-0417-nothinking:
   score: 59.0
   normalized_score: 40.43
@@ -179,7 +189,7 @@ claude-3.5-sonnet:
   score: 56.0
   normalized_score: 34.04
   cost: 1.0
-  normalized_cost: 14.17
+  normalized_cost: 14.32
 deepseek-v3-1224:
   score: 55.0
   normalized_score: 31.91
@@ -187,17 +197,17 @@ gpt-4o-2024-11-20:
   score: 54.0
   normalized_score: 29.79
   cost: 1.0
-  normalized_cost: 14.17
+  normalized_cost: 14.32
 gpt-4o-2024-08-06:
   score: 52.0
   normalized_score: 25.53
   cost: 1.0
-  normalized_cost: 14.17
+  normalized_cost: 14.32
 gpt-4o-2024-05-13:
   score: 52.0
   normalized_score: 25.53
   cost: 2.0
-  normalized_cost: 28.33
+  normalized_cost: 28.63
 gpt-4.1-nano:
   score: 51.0
   normalized_score: 23.4

--- a/data/processed/benchmarks/humanitys-last-exam.yaml
+++ b/data/processed/benchmarks/humanitys-last-exam.yaml
@@ -2,192 +2,202 @@ gpt-5-high:
   score: 26.0
   normalized_score: 100.0
   cost: 349.0
-  normalized_cost: 260.6
+  normalized_cost: 263.0
 gpt-5-medium:
   score: 23.0
   normalized_score: 87.5
   cost: 187.0
-  normalized_cost: 139.6
+  normalized_cost: 140.9
 grok-4:
   score: 23.0
   normalized_score: 87.5
   cost: 696.0
-  normalized_cost: 519.6
+  normalized_cost: 524.4
 gemini-2.5-pro-06-05:
   score: 21.0
   normalized_score: 79.17
   cost: 315.0
-  normalized_cost: 235.2
+  normalized_cost: 237.4
 o3-medium:
   score: 20.0
   normalized_score: 75.0
   cost: 165.0
-  normalized_cost: 123.2
+  normalized_cost: 124.3
 gpt-5-mini-high:
   score: 19.0
   normalized_score: 70.83
   cost: 63.0
-  normalized_cost: 47.03
+  normalized_cost: 47.47
 gpt-oss-120b-high:
   score: 18.0
   normalized_score: 66.67
   cost: 29.0
-  normalized_cost: 21.65
+  normalized_cost: 21.85
 gpt-5-low:
   score: 18.0
   normalized_score: 66.67
   cost: 66.0
-  normalized_cost: 49.27
+  normalized_cost: 49.73
 o4-mini-high:
   score: 17.0
   normalized_score: 62.5
   cost: 153.0
-  normalized_cost: 114.2
+  normalized_cost: 115.3
 gemini-2.5-pro-preview-03-25:
   score: 17.0
   normalized_score: 62.5
   cost: 309.0
-  normalized_cost: 230.7
+  normalized_cost: 232.8
 gemini-2.5-pro-preview-05-06:
   score: 15.0
   normalized_score: 54.17
   cost: 215.0
-  normalized_cost: 160.5
+  normalized_cost: 162.0
 gpt-5-mini-medium:
   score: 14.0
   normalized_score: 50.0
   cost: 18.0
-  normalized_cost: 13.44
+  normalized_cost: 13.56
+glm-4.5:
+  score: 12.0
+  normalized_score: 41.67
+  cost: 94.0
+  normalized_cost: 70.83
 grok-3-mini-high:
   score: 11.0
   normalized_score: 37.5
   cost: 18.0
-  normalized_cost: 13.44
+  normalized_cost: 13.56
 gemini-2.5-flash-0520-thinking:
   score: 11.0
   normalized_score: 37.5
   cost: 78.0
-  normalized_cost: 58.23
+  normalized_cost: 58.77
 gemini-2.5-flash-preview-0417-thinking:
   score: 11.0
   normalized_score: 37.5
   cost: 150.0
-  normalized_cost: 112.0
+  normalized_cost: 113.0
 qwen-3-235b-a22b-thinking:
   score: 11.0
   normalized_score: 37.5
   cost: 196.0
-  normalized_cost: 146.3
+  normalized_cost: 147.7
 claude-opus-4-thinking:
   score: 11.0
   normalized_score: 37.5
   cost: 546.0
-  normalized_cost: 407.6
+  normalized_cost: 411.4
 claude-3.7-sonnet-thinking:
   score: 10.0
   normalized_score: 33.33
   cost: 557.0
-  normalized_cost: 415.8
+  normalized_cost: 419.7
 deepseek-r1-0120:
   score: 9.0
   normalized_score: 29.17
   cost: 66.0
-  normalized_cost: 49.27
+  normalized_cost: 49.73
 claude-sonnet-4-thinking:
   score: 9.0
   normalized_score: 29.17
   cost: 194.0
-  normalized_cost: 144.8
+  normalized_cost: 146.2
 gpt-oss-20b-high:
   score: 8.0
   normalized_score: 25.0
   cost: 5.0
-  normalized_cost: 3.733
+  normalized_cost: 3.767
 gpt-5-nano-high:
   score: 8.0
   normalized_score: 25.0
   cost: 19.0
-  normalized_cost: 14.18
+  normalized_cost: 14.32
 gpt-5-nano-medium:
   score: 7.0
   normalized_score: 20.83
   cost: 7.0
-  normalized_cost: 5.226
+  normalized_cost: 5.274
 kimi-k2:
   score: 7.0
   normalized_score: 20.83
   cost: 12.0
-  normalized_cost: 8.959
+  normalized_cost: 9.042
+glm-4.5-air:
+  score: 6.0
+  normalized_score: 16.67
+  cost: 54.0
+  normalized_cost: 40.69
 gpt-5-mini-minimal:
   score: 5.0
   normalized_score: 12.5
   cost: 2.0
-  normalized_cost: 1.493
+  normalized_cost: 1.507
 deepseek-v3-0324:
   score: 5.0
   normalized_score: 12.5
   cost: 3.0
-  normalized_cost: 2.24
+  normalized_cost: 2.26
 gemini-2.5-flash-preview-0417-nothinking:
   score: 5.0
   normalized_score: 12.5
   cost: 4.0
-  normalized_cost: 2.986
+  normalized_cost: 3.014
 gpt-5-minimal:
   score: 5.0
   normalized_score: 12.5
   cost: 10.0
-  normalized_cost: 7.466
+  normalized_cost: 7.535
 gemini-2.5-flash-0520-nothinking:
   score: 5.0
   normalized_score: 12.5
   cost: 16.0
-  normalized_cost: 11.95
+  normalized_cost: 12.06
 grok-3:
   score: 5.0
   normalized_score: 12.5
   cost: 43.0
-  normalized_cost: 32.1
+  normalized_cost: 32.4
 claude-opus-4-nothinking:
   score: 5.0
   normalized_score: 12.5
   cost: 110.0
-  normalized_cost: 82.12
+  normalized_cost: 82.88
 llama-4-maverick:
   score: 4.0
   normalized_score: 8.333
   cost: 2.0
-  normalized_cost: 1.493
+  normalized_cost: 1.507
 llama-4-scout:
   score: 4.0
   normalized_score: 8.333
   cost: 2.0
-  normalized_cost: 1.493
+  normalized_cost: 1.507
 gpt-4.1-mini:
   score: 4.0
   normalized_score: 8.333
   cost: 4.0
-  normalized_cost: 2.986
+  normalized_cost: 3.014
 qwen-3-235b-a22b-nothinking:
   score: 4.0
   normalized_score: 8.333
   cost: 4.0
-  normalized_cost: 2.986
+  normalized_cost: 3.014
 gpt-4.1:
   score: 4.0
   normalized_score: 8.333
   cost: 19.0
-  normalized_cost: 14.18
+  normalized_cost: 14.32
 claude-3.7-sonnet-nothinking:
   score: 4.0
   normalized_score: 8.333
   cost: 20.0
-  normalized_cost: 14.93
+  normalized_cost: 15.07
 claude-sonnet-4-nothinking:
   score: 4.0
   normalized_score: 8.333
   cost: 24.0
-  normalized_cost: 17.92
+  normalized_cost: 18.08
 gpt-5-nano-minimal:
   score: 4.0
   normalized_score: 8.333
@@ -195,39 +205,39 @@ gpt-4.1-nano:
   score: 3.0
   normalized_score: 4.167
   cost: 1.0
-  normalized_cost: 0.7466
+  normalized_cost: 0.7535
 deepseek-v3-1224:
   score: 3.0
   normalized_score: 4.167
   cost: 2.0
-  normalized_cost: 1.493
+  normalized_cost: 1.507
 claude-3.5-haiku:
   score: 3.0
   normalized_score: 4.167
   cost: 4.0
-  normalized_cost: 2.986
+  normalized_cost: 3.014
 claude-3.5-sonnet-v2:
   score: 3.0
   normalized_score: 4.167
   cost: 15.0
-  normalized_cost: 11.2
+  normalized_cost: 11.3
 gpt-4o-2024-11-20:
   score: 3.0
   normalized_score: 4.167
   cost: 17.0
-  normalized_cost: 12.69
+  normalized_cost: 12.81
 claude-3.5-sonnet:
   score: 3.0
   normalized_score: 4.167
   cost: 18.0
-  normalized_cost: 13.44
+  normalized_cost: 13.56
 gpt-4o-2024-08-06:
   score: 2.0
   normalized_score: 0.0
   cost: 13.0
-  normalized_cost: 9.705
+  normalized_cost: 9.795
 gpt-4o-2024-05-13:
   score: 2.0
   normalized_score: 0.0
   cost: 22.0
-  normalized_cost: 16.42
+  normalized_cost: 16.58

--- a/data/processed/benchmarks/matharena-aime-2025.yaml
+++ b/data/processed/benchmarks/matharena-aime-2025.yaml
@@ -1,10 +1,20 @@
+glm-4.5:
+  score: 93.33
+  normalized_score: 100.0
+  cost: 5.814
+  normalized_cost: 271.3
 deepseek-v3.1-thinking:
   score: 90.83
-  normalized_score: 100.0
+  normalized_score: 80.0
   cost: 3.946
-  normalized_cost: 425.0
+  normalized_cost: 184.1
+glm-4.5-air:
+  score: 83.33
+  normalized_score: 20.0
+  cost: 3.176
+  normalized_cost: 148.2
 qwen-3-235b-a22b-thinking:
   score: 80.83
   normalized_score: 0.0
   cost: 1.079
-  normalized_cost: 116.2
+  normalized_cost: 50.34

--- a/data/processed/benchmarks/matharena-apex.yaml
+++ b/data/processed/benchmarks/matharena-apex.yaml
@@ -1,5 +1,10 @@
+glm-4.5:
+  score: 1.042
+  normalized_score: 100.0
+  cost: 14.5
+  normalized_cost: 46.22
 deepseek-v3.1-thinking:
   score: 0.5208
-  normalized_score: 100.0
+  normalized_score: 0.0
   cost: 14.04
-  normalized_cost: 18.06
+  normalized_cost: 44.76

--- a/data/processed/benchmarks/matharena-brumo-2025.yaml
+++ b/data/processed/benchmarks/matharena-brumo-2025.yaml
@@ -1,10 +1,20 @@
+glm-4.5:
+  score: 92.5
+  normalized_score: 100.0
+  cost: 5.217
+  normalized_cost: 282.9
 deepseek-v3.1-thinking:
   score: 90.0
-  normalized_score: 100.0
+  normalized_score: 57.14
   cost: 3.259
-  normalized_cost: 428.8
+  normalized_cost: 176.7
+glm-4.5-air:
+  score: 90.0
+  normalized_score: 57.14
+  cost: 2.689
+  normalized_cost: 145.8
 qwen-3-235b-a22b-thinking:
   score: 86.67
   normalized_score: 0.0
   cost: 0.88
-  normalized_cost: 115.8
+  normalized_cost: 47.72

--- a/data/processed/benchmarks/matharena-cmimc-2025.yaml
+++ b/data/processed/benchmarks/matharena-cmimc-2025.yaml
@@ -2,4 +2,14 @@ deepseek-v3.1-thinking:
   score: 81.25
   normalized_score: 100.0
   cost: 7.379
-  normalized_cost: 18.06
+  normalized_cost: 38.93
+glm-4.5:
+  score: 71.25
+  normalized_score: 5.882
+  cost: 9.568
+  normalized_cost: 50.47
+glm-4.5-air:
+  score: 70.62
+  normalized_score: 0.0
+  cost: 4.884
+  normalized_cost: 25.77

--- a/data/processed/benchmarks/matharena-hmmt-feb-2025.yaml
+++ b/data/processed/benchmarks/matharena-hmmt-feb-2025.yaml
@@ -2,9 +2,19 @@ deepseek-v3.1-thinking:
   score: 85.83
   normalized_score: 100.0
   cost: 5.062
-  normalized_cost: 500.4
+  normalized_cost: 208.9
+glm-4.5:
+  score: 77.5
+  normalized_score: 64.29
+  cost: 6.725
+  normalized_cost: 277.5
+glm-4.5-air:
+  score: 69.17
+  normalized_score: 28.57
+  cost: 3.662
+  normalized_cost: 151.1
 qwen-3-235b-a22b-thinking:
   score: 62.5
   normalized_score: 0.0
   cost: 1.09
-  normalized_cost: 107.8
+  normalized_cost: 44.99

--- a/data/processed/benchmarks/matharena-hmmt-february-2025.yaml
+++ b/data/processed/benchmarks/matharena-hmmt-february-2025.yaml
@@ -1,5 +1,15 @@
+glm-4.5:
+  score: 77.5
+  normalized_score: 100.0
+  cost: 6.725
+  normalized_cost: 313.0
+glm-4.5-air:
+  score: 69.17
+  normalized_score: 44.44
+  cost: 3.662
+  normalized_cost: 170.5
 qwen-3-235b-a22b-thinking:
   score: 62.5
-  normalized_score: 100.0
+  normalized_score: 0.0
   cost: 1.09
-  normalized_cost: 161.7
+  normalized_cost: 50.75

--- a/data/processed/benchmarks/matharena-overall.yaml
+++ b/data/processed/benchmarks/matharena-overall.yaml
@@ -2,9 +2,19 @@ deepseek-v3.1-thinking:
   score: 86.38
   normalized_score: 100.0
   cost: 5.339
-  normalized_cost: 492.5
+  normalized_cost: 201.8
+glm-4.5:
+  score: 83.33
+  normalized_score: 68.47
+  cost: 7.463
+  normalized_cost: 282.0
+glm-4.5-air:
+  score: 78.1
+  normalized_score: 14.24
+  cost: 3.958
+  normalized_cost: 149.6
 qwen-3-235b-a22b-thinking:
   score: 76.72
   normalized_score: 0.0
   cost: 1.178
-  normalized_cost: 108.7
+  normalized_cost: 44.52

--- a/data/processed/benchmarks/matharena-smt-2025.yaml
+++ b/data/processed/benchmarks/matharena-smt-2025.yaml
@@ -2,9 +2,19 @@ deepseek-v3.1-thinking:
   score: 83.96
   normalized_score: 100.0
   cost: 7.047
-  normalized_cost: 470.8
+  normalized_cost: 196.3
+glm-4.5:
+  score: 82.08
+  normalized_score: 73.33
+  cost: 9.992
+  normalized_cost: 278.3
+glm-4.5-air:
+  score: 77.36
+  normalized_score: 6.667
+  cost: 5.381
+  normalized_cost: 149.9
 qwen-3-235b-a22b-thinking:
   score: 76.89
   normalized_score: 0.0
   cost: 1.663
-  normalized_cost: 111.1
+  normalized_cost: 46.33

--- a/data/processed/benchmarks/mmlu-pro.yaml
+++ b/data/processed/benchmarks/mmlu-pro.yaml
@@ -2,227 +2,237 @@ gpt-5-high:
   score: 87.0
   normalized_score: 100.0
   cost: 306.0
-  normalized_cost: 152.9
+  normalized_cost: 154.7
 claude-opus-4-thinking:
   score: 87.0
   normalized_score: 100.0
   cost: 1083.0
-  normalized_cost: 541.2
+  normalized_cost: 547.4
 gpt-5-low:
   score: 86.0
   normalized_score: 96.88
   cost: 62.0
-  normalized_cost: 30.99
+  normalized_cost: 31.34
 gpt-5-medium:
   score: 86.0
   normalized_score: 96.88
   cost: 142.0
-  normalized_cost: 70.97
+  normalized_cost: 71.77
 claude-opus-4-nothinking:
   score: 86.0
   normalized_score: 96.88
   cost: 337.0
-  normalized_cost: 168.4
+  normalized_cost: 170.3
 gemini-2.5-pro-06-05:
   score: 86.0
   normalized_score: 96.88
   cost: 430.0
-  normalized_cost: 214.9
+  normalized_cost: 217.3
 grok-4:
   score: 86.0
   normalized_score: 96.88
   cost: 637.0
-  normalized_cost: 318.4
+  normalized_cost: 322.0
 o3-medium:
   score: 85.0
   normalized_score: 93.75
   cost: 173.0
-  normalized_cost: 86.46
+  normalized_cost: 87.44
 gemini-2.5-pro-preview-03-25:
   score: 85.0
   normalized_score: 93.75
   cost: 298.0
-  normalized_cost: 148.9
+  normalized_cost: 150.6
 deepseek-r1-0120:
   score: 84.0
   normalized_score: 90.62
   cost: 114.0
-  normalized_cost: 56.97
+  normalized_cost: 57.62
 claude-sonnet-4-thinking:
   score: 84.0
   normalized_score: 90.62
   cost: 343.0
-  normalized_cost: 171.4
+  normalized_cost: 173.4
 gpt-5-mini-high:
   score: 83.0
   normalized_score: 87.5
   cost: 65.0
-  normalized_cost: 32.48
+  normalized_cost: 32.85
 claude-sonnet-4-nothinking:
   score: 83.0
   normalized_score: 87.5
   cost: 75.0
-  normalized_cost: 37.48
+  normalized_cost: 37.91
+glm-4.5:
+  score: 83.0
+  normalized_score: 87.5
+  cost: 93.0
+  normalized_cost: 47.01
 gemini-2.5-flash-0520-thinking:
   score: 83.0
   normalized_score: 87.5
   cost: 97.0
-  normalized_cost: 48.48
+  normalized_cost: 49.03
 o4-mini-high:
   score: 83.0
   normalized_score: 87.5
   cost: 105.0
-  normalized_cost: 52.48
+  normalized_cost: 53.07
 claude-3.7-sonnet-thinking:
   score: 83.0
   normalized_score: 87.5
   cost: 654.0
-  normalized_cost: 326.8
+  normalized_cost: 330.6
 gemini-2.5-pro-preview-05-06:
   score: 83.0
   normalized_score: 87.5
   cost: 837.0
-  normalized_cost: 418.3
+  normalized_cost: 423.1
 grok-3-mini-high:
   score: 82.0
   normalized_score: 84.38
   cost: 20.0
-  normalized_cost: 9.995
+  normalized_cost: 10.11
 gpt-5-mini-medium:
   score: 82.0
   normalized_score: 84.38
   cost: 23.0
-  normalized_cost: 11.49
+  normalized_cost: 11.63
 kimi-k2:
   score: 82.0
   normalized_score: 84.38
   cost: 57.0
-  normalized_cost: 28.49
+  normalized_cost: 28.81
 qwen-3-235b-a22b-thinking:
   score: 82.0
   normalized_score: 84.38
   cost: 284.0
-  normalized_cost: 141.9
+  normalized_cost: 143.5
 deepseek-v3-0324:
   score: 81.0
   normalized_score: 81.25
   cost: 7.0
-  normalized_cost: 3.498
+  normalized_cost: 3.538
+glm-4.5-air:
+  score: 81.0
+  normalized_score: 81.25
+  cost: 50.0
+  normalized_cost: 25.27
 llama-4-maverick:
   score: 80.0
   normalized_score: 78.12
   cost: 7.0
-  normalized_cost: 3.498
+  normalized_cost: 3.538
 gpt-5-minimal:
   score: 80.0
   normalized_score: 78.12
   cost: 19.0
-  normalized_cost: 9.496
+  normalized_cost: 9.604
 gpt-oss-120b-high:
   score: 80.0
   normalized_score: 78.12
   cost: 21.0
-  normalized_cost: 10.5
+  normalized_cost: 10.61
 gemini-2.5-flash-0520-nothinking:
   score: 80.0
   normalized_score: 78.12
   cost: 23.0
-  normalized_cost: 11.49
+  normalized_cost: 11.63
 gpt-4.1:
   score: 80.0
   normalized_score: 78.12
   cost: 33.0
-  normalized_cost: 16.49
+  normalized_cost: 16.68
 claude-3.7-sonnet-nothinking:
   score: 80.0
   normalized_score: 78.12
   cost: 62.0
-  normalized_cost: 30.99
+  normalized_cost: 31.34
 gemini-2.5-flash-preview-0417-thinking:
   score: 80.0
   normalized_score: 78.12
   cost: 174.0
-  normalized_cost: 86.96
+  normalized_cost: 87.95
 grok-3:
   score: 79.0
   normalized_score: 75.0
   cost: 75.0
-  normalized_cost: 37.48
+  normalized_cost: 37.91
 gemini-2.5-flash-preview-0417-nothinking:
   score: 78.0
   normalized_score: 71.88
   cost: 6.0
-  normalized_cost: 2.999
+  normalized_cost: 3.033
 gpt-4.1-mini:
   score: 78.0
   normalized_score: 71.88
   cost: 9.0
-  normalized_cost: 4.498
+  normalized_cost: 4.549
 gpt-5-nano-high:
   score: 78.0
   normalized_score: 71.88
   cost: 25.0
-  normalized_cost: 12.49
+  normalized_cost: 12.64
 gpt-5-mini-minimal:
   score: 77.0
   normalized_score: 68.75
   cost: 4.0
-  normalized_cost: 1.999
+  normalized_cost: 2.022
 gpt-5-nano-medium:
   score: 77.0
   normalized_score: 68.75
   cost: 10.0
-  normalized_cost: 4.998
+  normalized_cost: 5.054
 claude-3.5-sonnet-v2:
   score: 77.0
   normalized_score: 68.75
   cost: 50.0
-  normalized_cost: 24.99
+  normalized_cost: 25.27
 qwen-3-235b-a22b-nothinking:
   score: 76.0
   normalized_score: 65.62
   cost: 14.0
-  normalized_cost: 6.997
+  normalized_cost: 7.076
 llama-4-scout:
   score: 75.0
   normalized_score: 62.5
   cost: 4.0
-  normalized_cost: 1.999
+  normalized_cost: 2.022
 deepseek-v3-1224:
   score: 75.0
   normalized_score: 62.5
   cost: 6.0
-  normalized_cost: 2.999
+  normalized_cost: 3.033
 claude-3.5-sonnet:
   score: 75.0
   normalized_score: 62.5
   cost: 55.0
-  normalized_cost: 27.49
+  normalized_cost: 27.8
 gpt-4o-2024-11-20:
   score: 74.0
   normalized_score: 59.38
   cost: 39.0
-  normalized_cost: 19.49
+  normalized_cost: 19.71
 gpt-4o-2024-05-13:
   score: 74.0
   normalized_score: 59.38
   cost: 60.0
-  normalized_cost: 29.99
+  normalized_cost: 30.33
 gpt-oss-20b-high:
   score: 73.0
   normalized_score: 56.25
   cost: 5.0
-  normalized_cost: 2.499
+  normalized_cost: 2.527
 gpt-4.1-nano:
   score: 65.0
   normalized_score: 31.25
   cost: 2.0
-  normalized_cost: 0.9995
+  normalized_cost: 1.011
 claude-3.5-haiku:
   score: 63.0
   normalized_score: 25.0
   cost: 12.0
-  normalized_cost: 5.997
+  normalized_cost: 6.065
 gpt-5-nano-minimal:
   score: 55.0
   normalized_score: 0.0

--- a/data/processed/benchmarks/weirdml.yaml
+++ b/data/processed/benchmarks/weirdml.yaml
@@ -2,149 +2,149 @@ gpt-5-high:
   score: 56.3
   normalized_score: 100.0
   cost: 0.6031
-  normalized_cost: 349.5
+  normalized_cost: 353.0
 o3-pro-high:
   score: 53.95
   normalized_score: 93.69
   cost: 2.614
-  normalized_cost: 1515.0
+  normalized_cost: 1530.0
 gemini-2.5-pro-06-05:
   score: 50.3
   normalized_score: 83.9
   cost: 0.4116
-  normalized_cost: 238.5
+  normalized_cost: 240.9
 o3-high:
   score: 49.76
   normalized_score: 82.45
   cost: 0.2319
-  normalized_cost: 134.4
+  normalized_cost: 135.7
 gpt-5-mini-high:
   score: 49.66
   normalized_score: 82.18
   cost: 0.1094
-  normalized_cost: 63.4
+  normalized_cost: 64.03
 o4-mini-high:
   score: 49.17
   normalized_score: 80.86
   cost: 0.1934
-  normalized_cost: 112.1
+  normalized_cost: 113.2
 claude-sonnet-4-thinking:
   score: 45.28
   normalized_score: 70.42
   cost: 0.3339
-  normalized_cost: 193.5
+  normalized_cost: 195.4
 claude-sonnet-4-nothinking:
   score: 43.0
   normalized_score: 64.3
   cost: 0.304
-  normalized_cost: 176.2
+  normalized_cost: 177.9
 grok-4:
   score: 42.55
   normalized_score: 63.1
   cost: 0.467
-  normalized_cost: 270.6
+  normalized_cost: 273.3
 claude-opus-4-thinking:
   score: 42.12
   normalized_score: 61.94
   cost: 1.699
-  normalized_cost: 984.6
+  normalized_cost: 994.3
 claude-opus-4.1-thinking:
   score: 41.78
   normalized_score: 61.03
   cost: 1.729
-  normalized_cost: 1002.0
+  normalized_cost: 1012.0
 deepseek-r1-0528:
   score: 40.88
   normalized_score: 58.62
   cost: 0.071
-  normalized_cost: 41.15
+  normalized_cost: 41.56
 claude-3.5-sonnet-v2:
   score: 39.78
   normalized_score: 55.66
   cost: 0.2466
-  normalized_cost: 142.9
+  normalized_cost: 144.3
 grok-3-mini-high:
   score: 39.58
   normalized_score: 55.13
   cost: 0.01749
-  normalized_cost: 10.14
+  normalized_cost: 10.24
 gemini-2.5-flash-0520-thinking:
   score: 38.73
   normalized_score: 52.84
   cost: 0.1059
-  normalized_cost: 61.38
+  normalized_cost: 61.99
 gpt-4.1:
   score: 37.88
   normalized_score: 50.56
   cost: 0.09829
-  normalized_cost: 56.96
+  normalized_cost: 57.52
 gpt-4.5-preview:
   score: 37.65
   normalized_score: 49.95
   cost: 1.58
-  normalized_cost: 915.7
+  normalized_cost: 924.8
 deepseek-v3.1:
   score: 37.42
   normalized_score: 49.33
   cost: 0.01961
-  normalized_cost: 11.37
+  normalized_cost: 11.48
 gpt-4.1-mini:
   score: 37.25
   normalized_score: 48.87
   cost: 0.01648
-  normalized_cost: 9.553
+  normalized_cost: 9.647
 deepseek-v3.1-thinking:
   score: 37.1
   normalized_score: 48.47
   cost: 0.03122
-  normalized_cost: 18.09
+  normalized_cost: 18.27
 grok-3:
   score: 36.44
   normalized_score: 46.7
   cost: 0.2502
-  normalized_cost: 145.0
+  normalized_cost: 146.4
 qwen-3-235b-a22b-thinking:
   score: 36.25
   normalized_score: 46.19
   cost: 0.02086
-  normalized_cost: 12.09
+  normalized_cost: 12.21
 gpt-5-nano-high:
   score: 35.57
   normalized_score: 44.36
   cost: 0.02687
-  normalized_cost: 15.57
+  normalized_cost: 15.73
 deepseek-r1-0120:
   score: 35.56
   normalized_score: 44.34
   cost: 0.07918
-  normalized_cost: 45.89
+  normalized_cost: 46.34
 deepseek-v3-0324:
   score: 35.09
   normalized_score: 43.08
   cost: 0.01379
-  normalized_cost: 7.992
+  normalized_cost: 8.071
 claude-3.5-sonnet:
   score: 30.06
   normalized_score: 29.58
   cost: 0.2437
-  normalized_cost: 141.2
+  normalized_cost: 142.6
 claude-3.5-haiku:
   score: 30.04
   normalized_score: 29.52
   cost: 0.05704
-  normalized_cost: 33.06
+  normalized_cost: 33.38
 gpt-4o-2024-11-20:
   score: 25.38
   normalized_score: 17.02
   cost: 0.0832
-  normalized_cost: 48.22
+  normalized_cost: 48.7
 llama-4-maverick:
   score: 23.62
   normalized_score: 12.29
   cost: 0.006137
-  normalized_cost: 3.557
+  normalized_cost: 3.592
 gpt-4.1-nano:
   score: 19.04
   normalized_score: 0.0
   cost: 0.002589
-  normalized_cost: 1.5
+  normalized_cost: 1.515


### PR DESCRIPTION
## Summary
- add model definitions for ZhipuAI's GLM-4.5 and GLM-4.5-Air
- map GLM-4.5 and GLM-4.5 Air across benchmark name mappings
- regenerate processed benchmark data

## Testing
- `pnpm prettier data/config/models/glm-4.5.yaml data/config/models/glm-4.5-air.yaml data/config/mappings/matharena.yaml data/config/mappings/artificial-analysis.yaml data/config/mappings/eqbench3.yaml`
- `pnpm lint`
- `pnpm test`
- `pnpm mappings:update`
- `pnpm process:all`


------
https://chatgpt.com/codex/tasks/task_e_68b1b856f504832080538ec29d4f13af