### PR TITLE
Add GLM-4.5 and GLM-4.5 Air models

### DIFF
--- a/data/config/mappings/artificial-analysis.yaml
+++ b/data/config/mappings/artificial-analysis.yaml
@@ -86,8 +86,8 @@ Gemma 3 4B: null
 Gemma 3n E2B: null
 Gemma 3n E4B: null
 Gemma 3n E4B (May '25): null
-GLM-4.5: null
-GLM-4.5-Air: null
+GLM-4.5: glm-4.5
+GLM-4.5-Air: glm-4.5-air
 GLM-4.5V (Reasoning): null
 GPT-3.5 Turbo: null
 GPT-4: null

--- a/data/config/mappings/eqbench3.yaml
+++ b/data/config/mappings/eqbench3.yaml
@@ -43,4 +43,4 @@ Qwen/Qwen3-30B-A3B: null
 Qwen/Qwen3-32B: null
 Qwen/Qwen3-8B: null
 qwen/qwq-32b: null
-zai-org/GLM-4.5: null
+zai-org/GLM-4.5: glm-4.5

--- a/data/config/mappings/gorilla-bfcl.yaml
+++ b/data/config/mappings/gorilla-bfcl.yaml
@@ -37,8 +37,8 @@ Gemma-3-1b-it (Prompt): null
 Gemma-3-27b-it (Prompt): null
 Gemma-3-4b-it (Prompt): null
 GLM-4-9b-Chat (FC): null
-GLM-4.5 (FC): null
-GLM-4.5-Air (FC): null
+GLM-4.5 (FC): glm-4.5
+GLM-4.5-Air (FC): glm-4.5-air
 GPT-4o-2024-11-20 (FC): gpt-4o-2024-11-20
 GPT-4o-2024-11-20 (Prompt): null
 GPT-4o-mini-2024-07-18 (FC): null

--- a/data/config/mappings/matharena.yaml
+++ b/data/config/mappings/matharena.yaml
@@ -20,8 +20,8 @@ gemini-2.5-pro: null
 gemini-2.5-pro (agent): null
 gemini-2.5-pro (best-of-32): null
 gemini-2.5-pro-05-06: null
-GLM 4.5: null
-GLM 4.5 Air: null
+GLM 4.5: glm-4.5
+GLM 4.5 Air: glm-4.5-air
 GPT OSS 120B (high): null
 GPT OSS 20B (high): null
 gpt-4o: null

--- a/data/config/models/glm-4.5-air.yaml
+++ b/data/config/models/glm-4.5-air.yaml
@@ -1,0 +1,3 @@
+provider: Zhipu AI
+reasoning_efforts:
+  glm-4.5-air: GLM-4.5 Air

--- a/data/config/models/glm-4.5.yaml
+++ b/data/config/models/glm-4.5.yaml
@@ -1,0 +1,3 @@
+provider: Zhipu AI
+reasoning_efforts:
+  glm-4.5: GLM-4.5

--- a/data/processed/benchmarks/aider-polyglot.yaml
+++ b/data/processed/benchmarks/aider-polyglot.yaml
@@ -2,32 +2,32 @@ o3-pro-high:
   score: 84.9
   normalized_score: 100.0
   cost: 0.6503
-  normalized_cost: 1296.0
+  normalized_cost: 1304.0
 o3-high:
   score: 81.3
   normalized_score: 95.26
   cost: 0.0943
-  normalized_cost: 188.0
+  normalized_cost: 189.1
 grok-4:
   score: 79.6
   normalized_score: 93.03
   cost: 0.265
-  normalized_cost: 528.2
+  normalized_cost: 531.4
 gemini-2.5-pro-06-05:
   score: 79.1
   normalized_score: 92.37
   cost: 0.2026
-  normalized_cost: 403.8
+  normalized_cost: 406.3
 o3-medium:
   score: 76.9
   normalized_score: 89.47
   cost: 0.0611
-  normalized_cost: 121.8
+  normalized_cost: 122.5
 gemini-2.5-pro-preview-05-06:
   score: 76.9
   normalized_score: 89.47
   cost: 0.1663
-  normalized_cost: 331.5
+  normalized_cost: 333.5
 gemini-2.5-pro-preview-03-25:
   score: 72.9
   normalized_score: 84.21
@@ -35,37 +35,37 @@ o4-mini-high:
   score: 72.0
   normalized_score: 83.03
   cost: 0.0873
-  normalized_cost: 174.0
+  normalized_cost: 175.1
 claude-opus-4-thinking:
   score: 72.0
   normalized_score: 83.03
   cost: 0.2922
-  normalized_cost: 582.4
+  normalized_cost: 585.9
 deepseek-r1-0528:
   score: 71.4
   normalized_score: 82.24
   cost: 0.0214
-  normalized_cost: 42.66
+  normalized_cost: 42.91
 claude-opus-4-nothinking:
   score: 70.7
   normalized_score: 81.32
   cost: 0.305
-  normalized_cost: 608.0
+  normalized_cost: 611.6
 claude-3.7-sonnet-thinking:
   score: 64.9
   normalized_score: 73.68
   cost: 0.1637
-  normalized_cost: 326.3
+  normalized_cost: 328.3
 claude-sonnet-4-thinking:
   score: 61.3
   normalized_score: 68.95
   cost: 0.1181
-  normalized_cost: 235.4
+  normalized_cost: 236.8
 claude-3.7-sonnet-nothinking:
   score: 60.4
   normalized_score: 67.76
   cost: 0.0788
-  normalized_cost: 157.1
+  normalized_cost: 158.0
 qwen-3-235b-a22b-nothinking:
   score: 59.6
   normalized_score: 66.71
@@ -73,87 +73,87 @@ kimi-k2:
   score: 59.1
   normalized_score: 66.05
   cost: 0.0055
-  normalized_cost: 10.96
+  normalized_cost: 11.03
 deepseek-r1-0120:
   score: 56.9
   normalized_score: 63.16
   cost: 0.0241
-  normalized_cost: 48.04
+  normalized_cost: 48.33
 claude-sonnet-4-nothinking:
   score: 56.4
   normalized_score: 62.5
   cost: 0.0703
-  normalized_cost: 140.1
+  normalized_cost: 141.0
 deepseek-v3-0324:
   score: 55.1
   normalized_score: 60.79
   cost: 0.005
-  normalized_cost: 9.967
+  normalized_cost: 10.03
 grok-3:
   score: 53.3
   normalized_score: 58.42
   cost: 0.049
-  normalized_cost: 97.67
+  normalized_cost: 98.26
 gpt-4.1:
   score: 52.4
   normalized_score: 57.24
   cost: 0.0438
-  normalized_cost: 87.31
+  normalized_cost: 87.83
 claude-3.5-sonnet-v2:
   score: 51.6
   normalized_score: 56.18
   cost: 0.064
-  normalized_cost: 127.6
+  normalized_cost: 128.3
 grok-3-mini-high:
   score: 49.3
   normalized_score: 53.16
   cost: 0.0033
-  normalized_cost: 6.578
+  normalized_cost: 6.617
 deepseek-v3-1224:
   score: 48.4
   normalized_score: 51.97
   cost: 0.0015
-  normalized_cost: 2.99
+  normalized_cost: 3.008
 gemini-2.5-flash-0520-thinking:
   score: 47.1
   normalized_score: 50.26
   cost: 0.0082
-  normalized_cost: 16.35
+  normalized_cost: 16.44
 gpt-4.5-preview:
   score: 44.9
   normalized_score: 47.37
   cost: 0.8178
-  normalized_cost: 1630.0
+  normalized_cost: 1640.0
 gemini-2.5-flash-0520-nothinking:
   score: 44.0
   normalized_score: 46.18
   cost: 0.005
-  normalized_cost: 9.967
+  normalized_cost: 10.03
 grok-3-mini-low:
   score: 34.7
   normalized_score: 33.95
   cost: 0.0035
-  normalized_cost: 6.977
+  normalized_cost: 7.018
 gpt-4.1-mini:
   score: 32.4
   normalized_score: 30.92
   cost: 0.0089
-  normalized_cost: 17.74
+  normalized_cost: 17.85
 claude-3.5-haiku:
   score: 28.0
   normalized_score: 25.13
   cost: 0.0269
-  normalized_cost: 53.62
+  normalized_cost: 53.94
 gpt-4o-2024-08-06:
   score: 23.1
   normalized_score: 18.68
   cost: 0.0312
-  normalized_cost: 62.19
+  normalized_cost: 62.56
 gpt-4o-2024-11-20:
   score: 18.2
   normalized_score: 12.24
   cost: 0.0299
-  normalized_cost: 59.6
+  normalized_cost: 59.96
 llama-4-maverick:
   score: 15.6
   normalized_score: 8.816
@@ -161,4 +161,4 @@ gpt-4.1-nano:
   score: 8.9
   normalized_score: 0.0
   cost: 0.0019
-  normalized_cost: 3.787
+  normalized_cost: 3.81

--- a/data/processed/benchmarks/arc-agi-1.yaml
+++ b/data/processed/benchmarks/arc-agi-1.yaml
@@ -2,214 +2,214 @@ grok-4:
   score: 66.7
   normalized_score: 100.0
   cost: 1.014
-  normalized_cost: 419.7
+  normalized_cost: 422.2
 gpt-5-high:
   score: 65.7
   normalized_score: 98.5
   cost: 0.5087
-  normalized_cost: 210.6
+  normalized_cost: 211.9
 o3-high:
   score: 60.8
   normalized_score: 91.15
   cost: 0.5002
-  normalized_cost: 207.1
+  normalized_cost: 208.3
 o3-pro-high:
   score: 59.3
   normalized_score: 88.91
   cost: 4.16
-  normalized_cost: 1722.0
+  normalized_cost: 1733.0
 o4-mini-high:
   score: 58.7
   normalized_score: 88.01
   cost: 0.4058
-  normalized_cost: 168.0
+  normalized_cost: 169.0
 o3-pro-medium:
   score: 57.0
   normalized_score: 85.46
   cost: 3.177
-  normalized_cost: 1315.0
+  normalized_cost: 1323.0
 gpt-5-medium:
   score: 56.2
   normalized_score: 84.26
   cost: 0.3301
-  normalized_cost: 136.7
+  normalized_cost: 137.5
 gpt-5-mini-high:
   score: 54.3
   normalized_score: 81.41
   cost: 0.116
-  normalized_cost: 48.03
+  normalized_cost: 48.32
 o3-medium:
   score: 53.8
   normalized_score: 80.66
   cost: 0.2882
-  normalized_cost: 119.3
+  normalized_cost: 120.0
 o3-pro-low:
   score: 44.3
   normalized_score: 66.42
   cost: 1.638
-  normalized_cost: 678.3
+  normalized_cost: 682.3
 gpt-5-low:
   score: 44.0
   normalized_score: 65.97
   cost: 0.1531
-  normalized_cost: 63.39
+  normalized_cost: 63.77
 o4-mini-medium:
   score: 41.8
   normalized_score: 62.67
   cost: 0.15
-  normalized_cost: 62.11
+  normalized_cost: 62.48
 o3-low:
   score: 41.5
   normalized_score: 62.22
   cost: 0.1764
-  normalized_cost: 73.04
+  normalized_cost: 73.47
 claude-sonnet-4-thinking:
   score: 40.0
   normalized_score: 59.97
   cost: 0.3658
-  normalized_cost: 151.5
+  normalized_cost: 152.4
 gpt-5-mini-medium:
   score: 37.3
   normalized_score: 55.92
   cost: 0.0401
-  normalized_cost: 16.6
+  normalized_cost: 16.7
 gemini-2.5-pro-06-05:
   score: 37.0
   normalized_score: 55.47
   cost: 0.5123
-  normalized_cost: 212.1
+  normalized_cost: 213.4
 claude-opus-4-thinking:
   score: 35.7
   normalized_score: 53.52
   cost: 1.25
-  normalized_cost: 517.4
+  normalized_cost: 520.5
 gemini-2.5-flash-0520-nothinking:
   score: 33.3
   normalized_score: 49.93
   cost: 0.0371
-  normalized_cost: 15.36
+  normalized_cost: 15.45
 gemini-2.5-flash-0520-thinking:
   score: 32.3
   normalized_score: 48.43
   cost: 0.1971
-  normalized_cost: 81.61
+  normalized_cost: 82.1
 claude-3.7-sonnet-thinking:
   score: 28.6
   normalized_score: 42.88
   cost: 0.33
-  normalized_cost: 136.6
+  normalized_cost: 137.5
 gpt-5-mini-low:
   score: 26.3
   normalized_score: 39.43
   cost: 0.0135
-  normalized_cost: 5.59
+  normalized_cost: 5.623
 claude-sonnet-4-nothinking:
   score: 23.8
   normalized_score: 35.68
   cost: 0.0806
-  normalized_cost: 33.37
+  normalized_cost: 33.57
 claude-opus-4-nothinking:
   score: 22.5
   normalized_score: 33.73
   cost: 0.4036
-  normalized_cost: 167.1
+  normalized_cost: 168.1
 o4-mini-low:
   score: 21.3
   normalized_score: 31.93
   cost: 0.0406
-  normalized_cost: 16.81
+  normalized_cost: 16.91
 deepseek-r1-0528:
   score: 21.2
   normalized_score: 31.78
   cost: 0.0464
-  normalized_cost: 19.21
+  normalized_cost: 19.33
 gpt-5-nano-medium:
   score: 20.7
   normalized_score: 31.03
   cost: 0.0124
-  normalized_cost: 5.134
+  normalized_cost: 5.165
 gpt-5-nano-high:
   score: 16.7
   normalized_score: 25.04
   cost: 0.0292
-  normalized_cost: 12.09
+  normalized_cost: 12.16
 grok-3-mini-low:
   score: 16.5
   normalized_score: 24.74
   cost: 0.0099
-  normalized_cost: 4.099
+  normalized_cost: 4.124
 deepseek-r1-0120:
   score: 15.8
   normalized_score: 23.69
   cost: 0.06
-  normalized_cost: 24.84
+  normalized_cost: 24.99
 claude-3.7-sonnet-nothinking:
   score: 13.6
   normalized_score: 20.39
   cost: 0.058
-  normalized_cost: 24.01
+  normalized_cost: 24.16
 qwen-3-235b-a22b-nothinking:
   score: 11.0
   normalized_score: 16.49
   cost: 0.0025
-  normalized_cost: 1.035
+  normalized_cost: 1.041
 gpt-4.5-preview:
   score: 10.3
   normalized_score: 15.44
   cost: 0.29
-  normalized_cost: 120.1
+  normalized_cost: 120.8
 gpt-5-minimal:
   score: 6.0
   normalized_score: 8.996
   cost: 0.0335
-  normalized_cost: 13.87
+  normalized_cost: 13.95
 gpt-4.1:
   score: 5.5
   normalized_score: 8.246
   cost: 0.039
-  normalized_cost: 16.15
+  normalized_cost: 16.24
 grok-3:
   score: 5.5
   normalized_score: 8.246
   cost: 0.0931
-  normalized_cost: 38.55
+  normalized_cost: 38.78
 gpt-5-mini-minimal:
   score: 5.3
   normalized_score: 7.946
   cost: 0.0057
-  normalized_cost: 2.36
+  normalized_cost: 2.374
 gpt-4o-2024-05-13:
   score: 4.5
   normalized_score: 6.747
   cost: 0.05
-  normalized_cost: 20.7
+  normalized_cost: 20.83
 llama-4-maverick:
   score: 4.4
   normalized_score: 6.597
   cost: 0.0078
-  normalized_cost: 3.23
+  normalized_cost: 3.249
 gpt-5-nano-low:
   score: 4.0
   normalized_score: 5.997
   cost: 0.0033
-  normalized_cost: 1.366
+  normalized_cost: 1.375
 gpt-4.1-mini:
   score: 3.5
   normalized_score: 5.247
   cost: 0.0078
-  normalized_cost: 3.23
+  normalized_cost: 3.249
 gpt-5-nano-minimal:
   score: 1.5
   normalized_score: 2.249
   cost: 0.0015
-  normalized_cost: 0.6211
+  normalized_cost: 0.6248
 llama-4-scout:
   score: 0.5
   normalized_score: 0.7496
   cost: 0.0041
-  normalized_cost: 1.698
+  normalized_cost: 1.708
 gpt-4.1-nano:
   score: 0.0
   normalized_score: 0.0
   cost: 0.0021
-  normalized_cost: 0.8695
+  normalized_cost: 0.8747

--- a/data/processed/benchmarks/arc-agi-2.yaml
+++ b/data/processed/benchmarks/arc-agi-2.yaml
@@ -2,214 +2,214 @@ grok-4:
   score: 16.0
   normalized_score: 100.0
   cost: 2.166
-  normalized_cost: 517.0
+  normalized_cost: 520.0
 gpt-5-high:
   score: 9.9
   normalized_score: 61.88
   cost: 0.7302
-  normalized_cost: 174.3
+  normalized_cost: 175.3
 claude-opus-4-thinking:
   score: 8.6
   normalized_score: 53.75
   cost: 1.928
-  normalized_cost: 460.3
+  normalized_cost: 463.0
 gpt-5-medium:
   score: 7.5
   normalized_score: 46.88
   cost: 0.4486
-  normalized_cost: 107.1
+  normalized_cost: 107.7
 o3-high:
   score: 6.5
   normalized_score: 40.62
   cost: 0.8339
-  normalized_cost: 199.0
+  normalized_cost: 200.2
 o4-mini-high:
   score: 6.1
   normalized_score: 38.12
   cost: 0.856
-  normalized_cost: 204.3
+  normalized_cost: 205.5
 claude-sonnet-4-thinking:
   score: 5.9
   normalized_score: 36.88
   cost: 0.4857
-  normalized_cost: 115.9
+  normalized_cost: 116.6
 gemini-2.5-pro-06-05:
   score: 4.9
   normalized_score: 30.63
   cost: 0.757
-  normalized_cost: 180.7
+  normalized_cost: 181.8
 o3-pro-high:
   score: 4.9
   normalized_score: 30.63
   cost: 7.552
-  normalized_cost: 1802.0
+  normalized_cost: 1813.0
 gpt-5-mini-high:
   score: 4.4
   normalized_score: 27.5
   cost: 0.1977
-  normalized_cost: 47.19
+  normalized_cost: 47.47
 gpt-5-mini-medium:
   score: 4.0
   normalized_score: 25.0
   cost: 0.0629
-  normalized_cost: 15.01
+  normalized_cost: 15.1
 o3-medium:
   score: 3.0
   normalized_score: 18.75
   cost: 0.4787
-  normalized_cost: 114.3
+  normalized_cost: 114.9
 gpt-5-nano-high:
   score: 2.6
   normalized_score: 16.25
   cost: 0.0295
-  normalized_cost: 7.041
+  normalized_cost: 7.083
 gemini-2.5-flash-0520-thinking:
   score: 2.5
   normalized_score: 15.62
   cost: 0.3191
-  normalized_cost: 76.16
+  normalized_cost: 76.62
 o4-mini-medium:
   score: 2.4
   normalized_score: 15.0
   cost: 0.2311
-  normalized_cost: 55.16
+  normalized_cost: 55.49
 o3-pro-low:
   score: 2.1
   normalized_score: 13.12
   cost: 2.229
-  normalized_cost: 532.1
+  normalized_cost: 535.3
 o3-low:
   score: 2.0
   normalized_score: 12.5
   cost: 0.2343
-  normalized_cost: 55.92
+  normalized_cost: 56.26
 gpt-5-low:
   score: 1.9
   normalized_score: 11.88
   cost: 0.1896
-  normalized_cost: 45.25
+  normalized_cost: 45.52
 o3-pro-medium:
   score: 1.9
   normalized_score: 11.88
   cost: 4.744
-  normalized_cost: 1132.0
+  normalized_cost: 1139.0
 gpt-5-mini-minimal:
   score: 1.7
   normalized_score: 10.62
   cost: 0.0094
-  normalized_cost: 2.244
+  normalized_cost: 2.257
 o4-mini-low:
   score: 1.7
   normalized_score: 10.62
   cost: 0.05
-  normalized_cost: 11.93
+  normalized_cost: 12.01
 gemini-2.5-flash-0520-nothinking:
   score: 1.7
   normalized_score: 10.62
   cost: 0.057
-  normalized_cost: 13.6
+  normalized_cost: 13.69
 qwen-3-235b-a22b-nothinking:
   score: 1.3
   normalized_score: 8.125
   cost: 0.0044
-  normalized_cost: 1.05
+  normalized_cost: 1.056
 deepseek-r1-0120:
   score: 1.3
   normalized_score: 8.125
   cost: 0.08
-  normalized_cost: 19.09
+  normalized_cost: 19.21
 claude-sonnet-4-nothinking:
   score: 1.3
   normalized_score: 8.125
   cost: 0.1272
-  normalized_cost: 30.36
+  normalized_cost: 30.54
 claude-opus-4-nothinking:
   score: 1.3
   normalized_score: 8.125
   cost: 0.6388
-  normalized_cost: 152.5
+  normalized_cost: 153.4
 deepseek-r1-0528:
   score: 1.1
   normalized_score: 6.875
   cost: 0.0527
-  normalized_cost: 12.58
+  normalized_cost: 12.65
 gpt-5-nano-medium:
   score: 0.9
   normalized_score: 5.625
   cost: 0.0137
-  normalized_cost: 3.27
+  normalized_cost: 3.289
 gpt-5-mini-low:
   score: 0.8
   normalized_score: 5.0
   cost: 0.0189
-  normalized_cost: 4.511
+  normalized_cost: 4.538
 gpt-4.5-preview:
   score: 0.8
   normalized_score: 5.0
   cost: 2.1
-  normalized_cost: 501.2
+  normalized_cost: 504.2
 claude-3.7-sonnet-thinking:
   score: 0.7
   normalized_score: 4.375
   cost: 0.51
-  normalized_cost: 121.7
+  normalized_cost: 122.5
 grok-3-mini-low:
   score: 0.4
   normalized_score: 2.5
   cost: 0.0131
-  normalized_cost: 3.127
+  normalized_cost: 3.145
 gpt-4.1:
   score: 0.4
   normalized_score: 2.5
   cost: 0.0691
-  normalized_cost: 16.49
+  normalized_cost: 16.59
 gpt-5-nano-minimal:
   score: 0.0
   normalized_score: 0.0
   cost: 0.0025
-  normalized_cost: 0.5967
+  normalized_cost: 0.6003
 gpt-5-nano-low:
   score: 0.0
   normalized_score: 0.0
   cost: 0.0033
-  normalized_cost: 0.7876
+  normalized_cost: 0.7923
 gpt-4.1-nano:
   score: 0.0
   normalized_score: 0.0
   cost: 0.0036
-  normalized_cost: 0.8592
+  normalized_cost: 0.8644
 llama-4-scout:
   score: 0.0
   normalized_score: 0.0
   cost: 0.0062
-  normalized_cost: 1.48
+  normalized_cost: 1.489
 llama-4-maverick:
   score: 0.0
   normalized_score: 0.0
   cost: 0.0121
-  normalized_cost: 2.888
+  normalized_cost: 2.905
 gpt-4.1-mini:
   score: 0.0
   normalized_score: 0.0
   cost: 0.0139
-  normalized_cost: 3.318
+  normalized_cost: 3.337
 gpt-5-minimal:
   score: 0.0
   normalized_score: 0.0
   cost: 0.0562
-  normalized_cost: 13.41
+  normalized_cost: 13.49
 gpt-4o-2024-05-13:
   score: 0.0
   normalized_score: 0.0
   cost: 0.08
-  normalized_cost: 19.09
+  normalized_cost: 19.21
 claude-3.7-sonnet-nothinking:
   score: 0.0
   normalized_score: 0.0
   cost: 0.12
-  normalized_cost: 28.64
+  normalized_cost: 28.81
 grok-3:
   score: 0.0
   normalized_score: 0.0
   cost: 0.1421
-  normalized_cost: 33.92
+  normalized_cost: 34.12

--- a/data/processed/benchmarks/artificial-analysis-index.yaml
+++ b/data/processed/benchmarks/artificial-analysis-index.yaml
@@ -2,57 +2,57 @@ gpt-5-high:
   score: 69.0
   normalized_score: 100.0
   cost: 823.0
-  normalized_cost: 194.5
+  normalized_cost: 195.6
 gpt-5-medium:
   score: 68.0
   normalized_score: 97.83
   cost: 432.0
-  normalized_cost: 102.1
+  normalized_cost: 102.6
 grok-4:
   score: 68.0
   normalized_score: 97.83
   cost: 1658.0
-  normalized_cost: 391.8
+  normalized_cost: 394.0
 o3-medium:
   score: 67.0
   normalized_score: 95.65
   cost: 410.0
-  normalized_cost: 96.88
+  normalized_cost: 97.42
 gpt-5-mini-high:
   score: 65.0
   normalized_score: 91.3
   cost: 155.0
-  normalized_cost: 36.63
+  normalized_cost: 36.83
 o4-mini-high:
   score: 65.0
   normalized_score: 91.3
   cost: 330.0
-  normalized_cost: 77.98
+  normalized_cost: 78.41
 gemini-2.5-pro-06-05:
   score: 65.0
   normalized_score: 91.3
   cost: 983.0
-  normalized_cost: 232.3
+  normalized_cost: 233.6
 gpt-5-mini-medium:
   score: 64.0
   normalized_score: 89.13
   cost: 52.0
-  normalized_cost: 12.29
+  normalized_cost: 12.36
 gpt-5-low:
   score: 63.0
   normalized_score: 86.96
   cost: 169.0
-  normalized_cost: 39.94
+  normalized_cost: 40.16
 gpt-oss-120b-high:
   score: 61.0
   normalized_score: 82.61
   cost: 66.0
-  normalized_cost: 15.6
+  normalized_cost: 15.68
 claude-sonnet-4-thinking:
   score: 59.0
   normalized_score: 78.26
   cost: 650.0
-  normalized_cost: 153.6
+  normalized_cost: 154.4
 gemini-2.5-pro-preview-03-25:
   score: 59.0
   normalized_score: 78.26
@@ -60,35 +60,45 @@ grok-3-mini-high:
   score: 58.0
   normalized_score: 76.09
   cost: 67.0
-  normalized_cost: 15.83
+  normalized_cost: 15.92
 gemini-2.5-flash-0520-thinking:
   score: 58.0
   normalized_score: 76.09
   cost: 229.0
-  normalized_cost: 54.11
+  normalized_cost: 54.41
 gemini-2.5-pro-preview-05-06:
   score: 58.0
   normalized_score: 76.09
+glm-4.5:
+  score: 56.0
+  normalized_score: 71.74
+  cost: 230.0
+  normalized_cost: 54.65
 gpt-5-nano-high:
   score: 55.0
   normalized_score: 69.57
   cost: 56.0
-  normalized_cost: 13.23
+  normalized_cost: 13.31
 claude-opus-4-thinking:
   score: 55.0
   normalized_score: 69.57
   cost: 1999.0
-  normalized_cost: 472.4
+  normalized_cost: 475.0
 gpt-5-nano-medium:
   score: 54.0
   normalized_score: 67.39
   cost: 23.0
-  normalized_cost: 5.435
+  normalized_cost: 5.465
+glm-4.5-air:
+  score: 53.0
+  normalized_score: 65.22
+  cost: 125.0
+  normalized_cost: 29.7
 deepseek-r1-0120:
   score: 53.0
   normalized_score: 65.22
   cost: 218.0
-  normalized_cost: 51.51
+  normalized_cost: 51.8
 gemini-2.5-flash-preview-0417-thinking:
   score: 50.0
   normalized_score: 58.7
@@ -96,32 +106,32 @@ gpt-oss-20b-high:
   score: 49.0
   normalized_score: 56.52
   cost: 11.0
-  normalized_cost: 2.599
+  normalized_cost: 2.614
 kimi-k2:
   score: 49.0
   normalized_score: 56.52
   cost: 76.0
-  normalized_cost: 17.96
+  normalized_cost: 18.06
 qwen-3-235b-a22b-thinking:
   score: 48.0
   normalized_score: 54.35
   cost: 706.0
-  normalized_cost: 166.8
+  normalized_cost: 167.8
 gemini-2.5-flash-0520-nothinking:
   score: 47.0
   normalized_score: 52.17
   cost: 46.0
-  normalized_cost: 10.87
+  normalized_cost: 10.93
 gpt-4.1:
   score: 47.0
   normalized_score: 52.17
   cost: 63.0
-  normalized_cost: 14.89
+  normalized_cost: 14.97
 claude-opus-4-nothinking:
   score: 47.0
   normalized_score: 52.17
   cost: 539.0
-  normalized_cost: 127.4
+  normalized_cost: 128.1
 claude-3.7-sonnet-thinking:
   score: 47.0
   normalized_score: 52.17
@@ -129,32 +139,32 @@ gpt-5-mini-minimal:
   score: 46.0
   normalized_score: 50.0
   cost: 9.0
-  normalized_cost: 2.127
+  normalized_cost: 2.138
 gpt-4.1-mini:
   score: 46.0
   normalized_score: 50.0
   cost: 16.0
-  normalized_cost: 3.781
+  normalized_cost: 3.802
 claude-sonnet-4-nothinking:
   score: 46.0
   normalized_score: 50.0
   cost: 117.0
-  normalized_cost: 27.65
+  normalized_cost: 27.8
 deepseek-v3-0324:
   score: 44.0
   normalized_score: 45.65
   cost: 13.0
-  normalized_cost: 3.072
+  normalized_cost: 3.089
 gpt-5-minimal:
   score: 44.0
   normalized_score: 45.65
   cost: 41.0
-  normalized_cost: 9.688
+  normalized_cost: 9.742
 llama-4-maverick:
   score: 42.0
   normalized_score: 41.3
   cost: 10.0
-  normalized_cost: 2.363
+  normalized_cost: 2.376
 grok-3:
   score: 40.0
   normalized_score: 36.96
@@ -165,7 +175,7 @@ deepseek-v3-1224:
   score: 37.0
   normalized_score: 30.43
   cost: 9.0
-  normalized_cost: 2.127
+  normalized_cost: 2.138
 claude-3.7-sonnet-nothinking:
   score: 37.0
   normalized_score: 30.43
@@ -173,12 +183,12 @@ llama-4-scout:
   score: 33.0
   normalized_score: 21.74
   cost: 6.0
-  normalized_cost: 1.418
+  normalized_cost: 1.426
 qwen-3-235b-a22b-nothinking:
   score: 33.0
   normalized_score: 21.74
   cost: 22.0
-  normalized_cost: 5.199
+  normalized_cost: 5.227
 claude-3.5-sonnet-v2:
   score: 33.0
   normalized_score: 21.74
@@ -186,17 +196,17 @@ gpt-5-nano-minimal:
   score: 32.0
   normalized_score: 19.57
   cost: 1.0
-  normalized_cost: 0.2363
+  normalized_cost: 0.2376
 gpt-4.1-nano:
   score: 32.0
   normalized_score: 19.57
   cost: 3.0
-  normalized_cost: 0.7089
+  normalized_cost: 0.7128
 gpt-4o-2024-11-20:
   score: 30.0
   normalized_score: 15.22
   cost: 63.0
-  normalized_cost: 14.89
+  normalized_cost: 14.97
 gpt-4o-2024-05-13:
   score: 30.0
   normalized_score: 15.22

--- a/data/processed/benchmarks/eqbench3.yaml
+++ b/data/processed/benchmarks/eqbench3.yaml
@@ -7,6 +7,9 @@ o3-medium:
 gemini-2.5-pro-06-05:
   score: 1470.0
   normalized_score: 91.32
+glm-4.5:
+  score: 1312.0
+  normalized_score: 76.86
 o4-mini-medium:
   score: 1291.0
   normalized_score: 74.97

--- a/data/processed/benchmarks/gorilla-bfcl.yaml
+++ b/data/processed/benchmarks/gorilla-bfcl.yaml
@@ -1,90 +1,100 @@
+glm-4.5:
+  score: 70.85
+  normalized_score: 100.0
+  cost: 2.9
+  normalized_cost: 3.527
 claude-opus-4.1-nothinking:
   score: 70.36
-  normalized_score: 100.0
+  normalized_score: 98.91
   cost: 207.1
-  normalized_cost: 246.7
+  normalized_cost: 251.9
 claude-sonnet-4-nothinking:
   score: 70.29
-  normalized_score: 99.84
+  normalized_score: 98.75
   cost: 41.49
-  normalized_cost: 49.42
+  normalized_cost: 50.46
+glm-4.5-air:
+  score: 67.87
+  normalized_score: 93.36
+  cost: 4.22
+  normalized_cost: 5.132
 grok-4:
   score: 61.01
-  normalized_score: 78.92
+  normalized_score: 78.06
   cost: 329.4
-  normalized_cost: 392.4
+  normalized_cost: 400.7
 gpt-5-medium:
   score: 59.22
-  normalized_score: 74.89
+  normalized_score: 74.07
   cost: 159.2
-  normalized_cost: 189.6
+  normalized_cost: 193.6
 kimi-k2:
   score: 56.07
-  normalized_score: 67.79
+  normalized_score: 67.05
   cost: 6.94
-  normalized_cost: 8.267
+  normalized_cost: 8.44
 qwen-3-235b-a22b-nothinking:
   score: 54.37
-  normalized_score: 63.95
+  normalized_score: 63.26
   cost: 12.02
-  normalized_cost: 14.32
+  normalized_cost: 14.62
 o3-high:
   score: 54.36
-  normalized_score: 63.93
+  normalized_score: 63.23
   cost: 136.8
-  normalized_cost: 162.9
+  normalized_cost: 166.3
 gpt-5-mini-medium:
   score: 54.21
-  normalized_score: 63.59
+  normalized_score: 62.9
   cost: 21.14
-  normalized_cost: 25.18
+  normalized_cost: 25.71
 gemini-2.5-flash-0520-nothinking:
   score: 53.63
-  normalized_score: 62.29
+  normalized_score: 61.61
   cost: 26.32
-  normalized_cost: 31.35
+  normalized_cost: 32.01
 o4-mini-high:
   score: 53.25
-  normalized_score: 61.43
+  normalized_score: 60.76
   cost: 82.46
-  normalized_cost: 98.22
+  normalized_cost: 100.3
 gemini-2.5-pro-06-05:
   score: 50.92
-  normalized_score: 56.18
+  normalized_score: 55.56
   cost: 132.8
-  normalized_cost: 158.2
+  normalized_cost: 161.5
 gpt-4o-2024-11-20:
   score: 50.27
-  normalized_score: 54.71
+  normalized_score: 54.11
   cost: 133.6
-  normalized_cost: 159.1
+  normalized_cost: 162.5
 deepseek-r1-0528:
   score: 48.97
-  normalized_score: 51.78
+  normalized_score: 51.22
   cost: 53.04
-  normalized_cost: 63.18
+  normalized_cost: 64.51
 gpt-5-nano-medium:
   score: 48.75
-  normalized_score: 51.28
+  normalized_score: 50.72
   cost: 8.99
-  normalized_cost: 10.71
+  normalized_cost: 10.93
 deepseek-v3-0324:
   score: 45.2
-  normalized_score: 43.28
+  normalized_score: 42.81
   cost: 6.11
-  normalized_cost: 7.278
+  normalized_cost: 7.431
 claude-3.5-haiku:
   score: 43.42
-  normalized_score: 39.27
+  normalized_score: 38.84
   cost: 10.66
-  normalized_cost: 12.7
+  normalized_cost: 12.96
 llama-4-maverick:
   score: 36.37
-  normalized_score: 23.38
+  normalized_score: 23.12
   cost: 4.63
-  normalized_cost: 5.515
+  normalized_cost: 5.631
 llama-4-scout:
   score: 26.0
   normalized_score: 0.0
   cost: 5.0
-  normalized_cost: 5.956
+  normalized_cost: 6.081

--- a/data/processed/benchmarks/gpqa-diamond.yaml
+++ b/data/processed/benchmarks/gpqa-diamond.yaml
@@ -2,127 +2,137 @@ grok-4:
   score: 87.0
   normalized_score: 100.0
   cost: 27.0
-  normalized_cost: 380.5
+  normalized_cost: 382.6
 gpt-5-high:
   score: 85.0
   normalized_score: 95.74
   cost: 14.0
-  normalized_cost: 197.3
+  normalized_cost: 198.4
 gpt-5-medium:
   score: 84.0
   normalized_score: 93.62
   cost: 7.0
-  normalized_cost: 98.64
+  normalized_cost: 99.18
 gemini-2.5-pro-06-05:
   score: 84.0
   normalized_score: 93.62
   cost: 16.0
-  normalized_cost: 225.5
+  normalized_cost: 226.7
 gemini-2.5-pro-preview-03-25:
   score: 83.0
   normalized_score: 91.49
   cost: 10.0
-  normalized_cost: 140.9
+  normalized_cost: 141.7
 gpt-5-mini-high:
   score: 82.0
   normalized_score: 89.36
   cost: 3.0
-  normalized_cost: 42.28
+  normalized_cost: 42.51
 o3-medium:
   score: 82.0
   normalized_score: 89.36
   cost: 10.0
-  normalized_cost: 140.9
+  normalized_cost: 141.7
 gemini-2.5-pro-preview-05-06:
   score: 82.0
   normalized_score: 89.36
   cost: 25.0
-  normalized_cost: 352.3
+  normalized_cost: 354.2
 gpt-5-mini-medium:
   score: 80.0
   normalized_score: 85.11
   cost: 1.0
-  normalized_cost: 14.09
+  normalized_cost: 14.17
 gpt-5-low:
   score: 80.0
   normalized_score: 85.11
   cost: 3.0
-  normalized_cost: 42.28
+  normalized_cost: 42.51
 grok-3-mini-high:
   score: 79.0
   normalized_score: 82.98
   cost: 1.0
-  normalized_cost: 14.09
+  normalized_cost: 14.17
 gemini-2.5-flash-0520-thinking:
   score: 79.0
   normalized_score: 82.98
   cost: 4.0
-  normalized_cost: 56.37
+  normalized_cost: 56.68
 claude-opus-4-thinking:
   score: 79.0
   normalized_score: 82.98
   cost: 32.0
-  normalized_cost: 450.9
+  normalized_cost: 453.4
 gpt-oss-120b-high:
   score: 78.0
   normalized_score: 80.85
   cost: 1.0
-  normalized_cost: 14.09
+  normalized_cost: 14.17
+glm-4.5:
+  score: 78.0
+  normalized_score: 80.85
+  cost: 4.0
+  normalized_cost: 56.68
 o4-mini-high:
   score: 78.0
   normalized_score: 80.85
   cost: 7.0
-  normalized_cost: 98.64
+  normalized_cost: 99.18
 claude-sonnet-4-thinking:
   score: 77.0
   normalized_score: 78.72
   cost: 12.0
-  normalized_cost: 169.1
+  normalized_cost: 170.0
 claude-3.7-sonnet-thinking:
   score: 77.0
   normalized_score: 78.72
   cost: 27.0
-  normalized_cost: 380.5
+  normalized_cost: 382.6
 kimi-k2:
   score: 76.0
   normalized_score: 76.6
   cost: 1.0
-  normalized_cost: 14.09
+  normalized_cost: 14.17
+glm-4.5-air:
+  score: 73.0
+  normalized_score: 70.21
+  cost: 2.0
+  normalized_cost: 28.34
 deepseek-r1-0120:
   score: 70.0
   normalized_score: 63.83
   cost: 4.0
-  normalized_cost: 56.37
+  normalized_cost: 56.68
 claude-opus-4-nothinking:
   score: 70.0
   normalized_score: 63.83
   cost: 8.0
-  normalized_cost: 112.7
+  normalized_cost: 113.4
 qwen-3-235b-a22b-thinking:
   score: 70.0
   normalized_score: 63.83
   cost: 11.0
-  normalized_cost: 155.0
+  normalized_cost: 155.9
 grok-3:
   score: 69.0
   normalized_score: 61.7
   cost: 3.0
-  normalized_cost: 42.28
+  normalized_cost: 42.51
 gemini-2.5-flash-preview-0417-thinking:
   score: 69.0
   normalized_score: 61.7
   cost: 8.0
-  normalized_cost: 112.7
+  normalized_cost: 113.4
 gemini-2.5-flash-0520-nothinking:
   score: 68.0
   normalized_score: 59.57
   cost: 1.0
-  normalized_cost: 14.09
+  normalized_cost: 14.17
 claude-sonnet-4-nothinking:
   score: 68.0
   normalized_score: 59.57
   cost: 2.0
-  normalized_cost: 28.18
+  normalized_cost: 28.34
 gpt-5-mini-minimal:
   score: 68.0
   normalized_score: 59.57
@@ -130,12 +140,12 @@ gpt-5-minimal:
   score: 67.0
   normalized_score: 57.45
   cost: 1.0
-  normalized_cost: 14.09
+  normalized_cost: 14.17
 gpt-5-nano-high:
   score: 67.0
   normalized_score: 57.45
   cost: 1.0
-  normalized_cost: 14.09
+  normalized_cost: 14.17
 gpt-5-nano-medium:
   score: 67.0
   normalized_score: 57.45
@@ -146,7 +156,7 @@ gpt-4.1:
   score: 66.0
   normalized_score: 55.32
   cost: 1.0
-  normalized_cost: 14.09
+  normalized_cost: 14.17
 gpt-4.1-mini:
   score: 66.0
   normalized_score: 55.32
@@ -154,7 +164,7 @@ claude-3.7-sonnet-nothinking:
   score: 65.0
   normalized_score: 53.19
   cost: 1.0
-  normalized_cost: 14.09
+  normalized_cost: 14.17
 deepseek-v3-0324:
   score: 65.0
   normalized_score: 53.19
@@ -168,7 +178,7 @@ claude-3.5-sonnet-v2:
   score: 59.0
   normalized_score: 40.43
   cost: 1.0
-  normalized_cost: 14.09
+  normalized_cost: 14.17
 gemini-2.5-flash-preview-0417-nothinking:
   score: 59.0
   normalized_score: 40.43
@@ -179,7 +189,7 @@ claude-3.5-sonnet:
   score: 56.0
   normalized_score: 34.04
   cost: 1.0
-  normalized_cost: 14.09
+  normalized_cost: 14.17
 deepseek-v3-1224:
   score: 55.0
   normalized_score: 31.91
@@ -187,17 +197,17 @@ gpt-4o-2024-11-20:
   score: 54.0
   normalized_score: 29.79
   cost: 1.0
-  normalized_cost: 14.09
+  normalized_cost: 14.17
 gpt-4o-2024-08-06:
   score: 52.0
   normalized_score: 25.53
   cost: 1.0
-  normalized_cost: 14.09
+  normalized_cost: 14.17
 gpt-4o-2024-05-13:
   score: 52.0
   normalized_score: 25.53
   cost: 2.0
-  normalized_cost: 28.18
+  normalized_cost: 28.34
 gpt-4.1-nano:
   score: 51.0
   normalized_score: 23.4

--- a/data/processed/benchmarks/humanitys-last-exam.yaml
+++ b/data/processed/benchmarks/humanitys-last-exam.yaml
@@ -2,192 +2,202 @@ gpt-5-high:
   score: 26.0
   normalized_score: 100.0
   cost: 349.0
-  normalized_cost: 259.2
+  normalized_cost: 260.3
 gpt-5-medium:
   score: 23.0
   normalized_score: 87.5
   cost: 187.0
-  normalized_cost: 138.9
+  normalized_cost: 139.4
 grok-4:
   score: 23.0
   normalized_score: 87.5
   cost: 696.0
-  normalized_cost: 516.9
+  normalized_cost: 519.0
 gemini-2.5-pro-06-05:
   score: 21.0
   normalized_score: 79.17
   cost: 315.0
-  normalized_cost: 233.9
+  normalized_cost: 234.9
 o3-medium:
   score: 20.0
   normalized_score: 75.0
   cost: 165.0
-  normalized_cost: 122.5
+  normalized_cost: 123.0
 gpt-5-mini-high:
   score: 19.0
   normalized_score: 70.83
   cost: 63.0
-  normalized_cost: 46.79
+  normalized_cost: 46.98
 gpt-oss-120b-high:
   score: 18.0
   normalized_score: 66.67
   cost: 29.0
-  normalized_cost: 21.54
+  normalized_cost: 21.63
 gpt-5-low:
   score: 18.0
   normalized_score: 66.67
   cost: 66.0
-  normalized_cost: 49.01
+  normalized_cost: 49.22
 o4-mini-high:
   score: 17.0
   normalized_score: 62.5
   cost: 153.0
-  normalized_cost: 113.6
+  normalized_cost: 114.1
 gemini-2.5-pro-preview-03-25:
   score: 17.0
   normalized_score: 62.5
   cost: 309.0
-  normalized_cost: 229.5
+  normalized_cost: 230.4
 gemini-2.5-pro-preview-05-06:
   score: 15.0
   normalized_score: 54.17
   cost: 215.0
-  normalized_cost: 159.7
+  normalized_cost: 160.3
 gpt-5-mini-medium:
   score: 14.0
   normalized_score: 50.0
   cost: 18.0
-  normalized_cost: 13.37
+  normalized_cost: 13.42
+glm-4.5:
+  score: 12.0
+  normalized_score: 41.67
+  cost: 94.0
+  normalized_cost: 70.1
 grok-3-mini-high:
   score: 11.0
   normalized_score: 37.5
   cost: 18.0
-  normalized_cost: 13.37
+  normalized_cost: 13.42
 gemini-2.5-flash-0520-thinking:
   score: 11.0
   normalized_score: 37.5
   cost: 78.0
-  normalized_cost: 57.93
+  normalized_cost: 58.17
 gemini-2.5-flash-preview-0417-thinking:
   score: 11.0
   normalized_score: 37.5
   cost: 150.0
-  normalized_cost: 111.4
+  normalized_cost: 111.9
 qwen-3-235b-a22b-thinking:
   score: 11.0
   normalized_score: 37.5
   cost: 196.0
-  normalized_cost: 145.6
+  normalized_cost: 146.2
 claude-opus-4-thinking:
   score: 11.0
   normalized_score: 37.5
   cost: 546.0
-  normalized_cost: 405.5
+  normalized_cost: 407.2
 claude-3.7-sonnet-thinking:
   score: 10.0
   normalized_score: 33.33
   cost: 557.0
-  normalized_cost: 413.6
+  normalized_cost: 415.4
 deepseek-r1-0120:
   score: 9.0
   normalized_score: 29.17
   cost: 66.0
-  normalized_cost: 49.01
+  normalized_cost: 49.22
 claude-sonnet-4-thinking:
   score: 9.0
   normalized_score: 29.17
   cost: 194.0
-  normalized_cost: 144.1
+  normalized_cost: 144.7
 gpt-oss-20b-high:
   score: 8.0
   normalized_score: 25.0
   cost: 5.0
-  normalized_cost: 3.713
+  normalized_cost: 3.729
 gpt-5-nano-high:
   score: 8.0
   normalized_score: 25.0
   cost: 19.0
-  normalized_cost: 14.11
+  normalized_cost: 14.17
 gpt-5-nano-medium:
   score: 7.0
   normalized_score: 20.83
   cost: 7.0
-  normalized_cost: 5.198
+  normalized_cost: 5.22
 kimi-k2:
   score: 7.0
   normalized_score: 20.83
   cost: 12.0
-  normalized_cost: 8.912
+  normalized_cost: 8.949
+glm-4.5-air:
+  score: 6.0
+  normalized_score: 16.67
+  cost: 54.0
+  normalized_cost: 40.27
 gpt-5-mini-minimal:
   score: 5.0
   normalized_score: 12.5
   cost: 2.0
-  normalized_cost: 1.485
+  normalized_cost: 1.491
 deepseek-v3-0324:
   score: 5.0
   normalized_score: 12.5
   cost: 3.0
-  normalized_cost: 2.228
+  normalized_cost: 2.237
 gemini-2.5-flash-preview-0417-nothinking:
   score: 5.0
   normalized_score: 12.5
   cost: 4.0
-  normalized_cost: 2.971
+  normalized_cost: 2.983
 gpt-5-minimal:
   score: 5.0
   normalized_score: 12.5
   cost: 10.0
-  normalized_cost: 7.426
+  normalized_cost: 7.457
 gemini-2.5-flash-0520-nothinking:
   score: 5.0
   normalized_score: 12.5
   cost: 16.0
-  normalized_cost: 11.88
+  normalized_cost: 11.93
 grok-3:
   score: 5.0
   normalized_score: 12.5
   cost: 43.0
-  normalized_cost: 31.93
+  normalized_cost: 32.07
 claude-opus-4-nothinking:
   score: 5.0
   normalized_score: 12.5
   cost: 110.0
-  normalized_cost: 81.69
+  normalized_cost: 82.03
 llama-4-maverick:
   score: 4.0
   normalized_score: 8.333
   cost: 2.0
-  normalized_cost: 1.485
+  normalized_cost: 1.491
 llama-4-scout:
   score: 4.0
   normalized_score: 8.333
   cost: 2.0
-  normalized_cost: 1.485
+  normalized_cost: 1.491
 gpt-4.1-mini:
   score: 4.0
   normalized_score: 8.333
   cost: 4.0
-  normalized_cost: 2.971
+  normalized_cost: 2.983
 qwen-3-235b-a22b-nothinking:
   score: 4.0
   normalized_score: 8.333
   cost: 4.0
-  normalized_cost: 2.971
+  normalized_cost: 2.983
 gpt-4.1:
   score: 4.0
   normalized_score: 8.333
   cost: 19.0
-  normalized_cost: 14.11
+  normalized_cost: 14.17
 claude-3.7-sonnet-nothinking:
   score: 4.0
   normalized_score: 8.333
   cost: 20.0
-  normalized_cost: 14.85
+  normalized_cost: 14.91
 claude-sonnet-4-nothinking:
   score: 4.0
   normalized_score: 8.333
   cost: 24.0
-  normalized_cost: 17.82
+  normalized_cost: 17.9
 gpt-5-nano-minimal:
   score: 4.0
   normalized_score: 8.333
@@ -195,39 +205,39 @@ gpt-4.1-nano:
   score: 3.0
   normalized_score: 4.167
   cost: 1.0
-  normalized_cost: 0.7426
+  normalized_cost: 0.7457
 deepseek-v3-1224:
   score: 3.0
   normalized_score: 4.167
   cost: 2.0
-  normalized_cost: 1.485
+  normalized_cost: 1.491
 claude-3.5-haiku:
   score: 3.0
   normalized_score: 4.167
   cost: 4.0
-  normalized_cost: 2.971
+  normalized_cost: 2.983
 claude-3.5-sonnet-v2:
   score: 3.0
   normalized_score: 4.167
   cost: 15.0
-  normalized_cost: 11.14
+  normalized_cost: 11.19
 gpt-4o-2024-11-20:
   score: 3.0
   normalized_score: 4.167
   cost: 17.0
-  normalized_cost: 12.62
+  normalized_cost: 12.68
 claude-3.5-sonnet:
   score: 3.0
   normalized_score: 4.167
   cost: 18.0
-  normalized_cost: 13.37
+  normalized_cost: 13.42
 gpt-4o-2024-08-06:
   score: 2.0
   normalized_score: 0.0
   cost: 13.0
-  normalized_cost: 9.654
+  normalized_cost: 9.694
 gpt-4o-2024-05-13:
   score: 2.0
   normalized_score: 0.0
   cost: 22.0
-  normalized_cost: 16.34
+  normalized_cost: 16.41

--- a/data/processed/benchmarks/matharena-aime-2025.yaml
+++ b/data/processed/benchmarks/matharena-aime-2025.yaml
@@ -1,10 +1,20 @@
+glm-4.5:
+  score: 93.33
+  normalized_score: 100.0
+  cost: 5.814
+  normalized_cost: 271.2
 deepseek-v3.1-thinking:
   score: 90.83
-  normalized_score: 100.0
+  normalized_score: 80.0
   cost: 3.946
-  normalized_cost: 423.3
+  normalized_cost: 184.1
+glm-4.5-air:
+  score: 83.33
+  normalized_score: 20.0
+  cost: 3.176
+  normalized_cost: 148.2
 qwen-3-235b-a22b-thinking:
   score: 80.83
   normalized_score: 0.0
   cost: 1.079
-  normalized_cost: 115.7
+  normalized_cost: 50.32

--- a/data/processed/benchmarks/matharena-apex.yaml
+++ b/data/processed/benchmarks/matharena-apex.yaml
@@ -1,5 +1,10 @@
+glm-4.5:
+  score: 1.042
+  normalized_score: 100.0
+  cost: 14.5
+  normalized_cost: 44.51
 deepseek-v3.1-thinking:
   score: 0.5208
-  normalized_score: 100.0
+  normalized_score: 0.0
   cost: 14.04
-  normalized_cost: 17.9
+  normalized_cost: 43.1

--- a/data/processed/benchmarks/matharena-brumo-2025.yaml
+++ b/data/processed/benchmarks/matharena-brumo-2025.yaml
@@ -1,10 +1,20 @@
+glm-4.5:
+  score: 92.5
+  normalized_score: 100.0
+  cost: 5.217
+  normalized_cost: 282.9
 deepseek-v3.1-thinking:
   score: 90.0
-  normalized_score: 100.0
+  normalized_score: 57.14
   cost: 3.259
-  normalized_cost: 427.1
+  normalized_cost: 176.8
+glm-4.5-air:
+  score: 90.0
+  normalized_score: 57.14
+  cost: 2.689
+  normalized_cost: 145.8
 qwen-3-235b-a22b-thinking:
   score: 86.67
   normalized_score: 0.0
   cost: 0.88
-  normalized_cost: 115.3
+  normalized_cost: 47.73

--- a/data/processed/benchmarks/matharena-cmimc-2025.yaml
+++ b/data/processed/benchmarks/matharena-cmimc-2025.yaml
@@ -2,4 +2,14 @@ deepseek-v3.1-thinking:
   score: 81.25
   normalized_score: 100.0
   cost: 7.379
-  normalized_cost: 17.9
+  normalized_cost: 37.55
+glm-4.5:
+  score: 71.25
+  normalized_score: 5.882
+  cost: 9.568
+  normalized_cost: 48.68
+glm-4.5-air:
+  score: 70.62
+  normalized_score: 0.0
+  cost: 4.884
+  normalized_cost: 24.85

--- a/data/processed/benchmarks/matharena-hmmt-feb-2025.yaml
+++ b/data/processed/benchmarks/matharena-hmmt-feb-2025.yaml
@@ -2,9 +2,19 @@ deepseek-v3.1-thinking:
   score: 85.83
   normalized_score: 100.0
   cost: 5.062
-  normalized_cost: 498.5
+  normalized_cost: 208.9
+glm-4.5:
+  score: 77.5
+  normalized_score: 64.29
+  cost: 6.725
+  normalized_cost: 277.5
+glm-4.5-air:
+  score: 69.17
+  normalized_score: 28.57
+  cost: 3.662
+  normalized_cost: 151.1
 qwen-3-235b-a22b-thinking:
   score: 62.5
   normalized_score: 0.0
   cost: 1.09
-  normalized_cost: 107.4
+  normalized_cost: 44.99

--- a/data/processed/benchmarks/matharena-hmmt-february-2025.yaml
+++ b/data/processed/benchmarks/matharena-hmmt-february-2025.yaml
@@ -1,5 +1,15 @@
+glm-4.5:
+  score: 77.5
+  normalized_score: 100.0
+  cost: 6.725
+  normalized_cost: 313.6
+glm-4.5-air:
+  score: 69.17
+  normalized_score: 44.44
+  cost: 3.662
+  normalized_cost: 170.8
 qwen-3-235b-a22b-thinking:
   score: 62.5
-  normalized_score: 100.0
+  normalized_score: 0.0
   cost: 1.09
-  normalized_cost: 160.8
+  normalized_cost: 50.85

--- a/data/processed/benchmarks/matharena-overall.yaml
+++ b/data/processed/benchmarks/matharena-overall.yaml
@@ -2,9 +2,19 @@ deepseek-v3.1-thinking:
   score: 86.38
   normalized_score: 100.0
   cost: 5.339
-  normalized_cost: 490.6
+  normalized_cost: 201.8
+glm-4.5:
+  score: 83.33
+  normalized_score: 68.47
+  cost: 7.463
+  normalized_cost: 282.1
+glm-4.5-air:
+  score: 78.1
+  normalized_score: 14.24
+  cost: 3.958
+  normalized_cost: 149.6
 qwen-3-235b-a22b-thinking:
   score: 76.72
   normalized_score: 0.0
   cost: 1.178
-  normalized_cost: 108.2
+  normalized_cost: 44.53

--- a/data/processed/benchmarks/matharena-smt-2025.yaml
+++ b/data/processed/benchmarks/matharena-smt-2025.yaml
@@ -2,9 +2,19 @@ deepseek-v3.1-thinking:
   score: 83.96
   normalized_score: 100.0
   cost: 7.047
-  normalized_cost: 468.9
+  normalized_cost: 196.3
+glm-4.5:
+  score: 82.08
+  normalized_score: 73.33
+  cost: 9.992
+  normalized_cost: 278.3
+glm-4.5-air:
+  score: 77.36
+  normalized_score: 6.667
+  cost: 5.381
+  normalized_cost: 149.9
 qwen-3-235b-a22b-thinking:
   score: 76.89
   normalized_score: 0.0
   cost: 1.663
-  normalized_cost: 110.7
+  normalized_cost: 46.33

--- a/data/processed/benchmarks/mmlu-pro.yaml
+++ b/data/processed/benchmarks/mmlu-pro.yaml
@@ -2,227 +2,237 @@ gpt-5-high:
   score: 87.0
   normalized_score: 100.0
   cost: 306.0
-  normalized_cost: 152.2
+  normalized_cost: 153.1
 claude-opus-4-thinking:
   score: 87.0
   normalized_score: 100.0
   cost: 1083.0
-  normalized_cost: 538.5
+  normalized_cost: 541.8
 gpt-5-low:
   score: 86.0
   normalized_score: 96.88
   cost: 62.0
-  normalized_cost: 30.83
+  normalized_cost: 31.02
 gpt-5-medium:
   score: 86.0
   normalized_score: 96.88
   cost: 142.0
-  normalized_cost: 70.61
+  normalized_cost: 71.05
 claude-opus-4-nothinking:
   score: 86.0
   normalized_score: 96.88
   cost: 337.0
-  normalized_cost: 167.6
+  normalized_cost: 168.6
 gemini-2.5-pro-06-05:
   score: 86.0
   normalized_score: 96.88
   cost: 430.0
-  normalized_cost: 213.8
+  normalized_cost: 215.1
 grok-4:
   score: 86.0
   normalized_score: 96.88
   cost: 637.0
-  normalized_cost: 316.7
+  normalized_cost: 318.7
 o3-medium:
   score: 85.0
   normalized_score: 93.75
   cost: 173.0
-  normalized_cost: 86.02
+  normalized_cost: 86.56
 gemini-2.5-pro-preview-03-25:
   score: 85.0
   normalized_score: 93.75
   cost: 298.0
-  normalized_cost: 148.2
+  normalized_cost: 149.1
 deepseek-r1-0120:
   score: 84.0
   normalized_score: 90.62
   cost: 114.0
-  normalized_cost: 56.68
+  normalized_cost: 57.04
 claude-sonnet-4-thinking:
   score: 84.0
   normalized_score: 90.62
   cost: 343.0
-  normalized_cost: 170.5
+  normalized_cost: 171.6
 gpt-5-mini-high:
   score: 83.0
   normalized_score: 87.5
   cost: 65.0
-  normalized_cost: 32.32
+  normalized_cost: 32.52
 claude-sonnet-4-nothinking:
   score: 83.0
   normalized_score: 87.5
   cost: 75.0
-  normalized_cost: 37.29
+  normalized_cost: 37.52
+glm-4.5:
+  score: 83.0
+  normalized_score: 87.5
+  cost: 93.0
+  normalized_cost: 46.53
 gemini-2.5-flash-0520-thinking:
   score: 83.0
   normalized_score: 87.5
   cost: 97.0
-  normalized_cost: 48.23
+  normalized_cost: 48.53
 o4-mini-high:
   score: 83.0
   normalized_score: 87.5
   cost: 105.0
-  normalized_cost: 52.21
+  normalized_cost: 52.53
 claude-3.7-sonnet-thinking:
   score: 83.0
   normalized_score: 87.5
   cost: 654.0
-  normalized_cost: 325.2
+  normalized_cost: 327.2
 gemini-2.5-pro-preview-05-06:
   score: 83.0
   normalized_score: 87.5
   cost: 837.0
-  normalized_cost: 416.2
+  normalized_cost: 418.8
 grok-3-mini-high:
   score: 82.0
   normalized_score: 84.38
   cost: 20.0
-  normalized_cost: 9.945
+  normalized_cost: 10.01
 gpt-5-mini-medium:
   score: 82.0
   normalized_score: 84.38
   cost: 23.0
-  normalized_cost: 11.44
+  normalized_cost: 11.51
 kimi-k2:
   score: 82.0
   normalized_score: 84.38
   cost: 57.0
-  normalized_cost: 28.34
+  normalized_cost: 28.52
 qwen-3-235b-a22b-thinking:
   score: 82.0
   normalized_score: 84.38
   cost: 284.0
-  normalized_cost: 141.2
+  normalized_cost: 142.1
 deepseek-v3-0324:
   score: 81.0
   normalized_score: 81.25
   cost: 7.0
-  normalized_cost: 3.481
+  normalized_cost: 3.502
+glm-4.5-air:
+  score: 81.0
+  normalized_score: 81.25
+  cost: 50.0
+  normalized_cost: 25.02
 llama-4-maverick:
   score: 80.0
   normalized_score: 78.12
   cost: 7.0
-  normalized_cost: 3.481
+  normalized_cost: 3.502
 gpt-5-minimal:
   score: 80.0
   normalized_score: 78.12
   cost: 19.0
-  normalized_cost: 9.447
+  normalized_cost: 9.506
 gpt-oss-120b-high:
   score: 80.0
   normalized_score: 78.12
   cost: 21.0
-  normalized_cost: 10.44
+  normalized_cost: 10.51
 gemini-2.5-flash-0520-nothinking:
   score: 80.0
   normalized_score: 78.12
   cost: 23.0
-  normalized_cost: 11.44
+  normalized_cost: 11.51
 gpt-4.1:
   score: 80.0
   normalized_score: 78.12
   cost: 33.0
-  normalized_cost: 16.41
+  normalized_cost: 16.51
 claude-3.7-sonnet-nothinking:
   score: 80.0
   normalized_score: 78.12
   cost: 62.0
-  normalized_cost: 30.83
+  normalized_cost: 31.02
 gemini-2.5-flash-preview-0417-thinking:
   score: 80.0
   normalized_score: 78.12
   cost: 174.0
-  normalized_cost: 86.52
+  normalized_cost: 87.06
 grok-3:
   score: 79.0
   normalized_score: 75.0
   cost: 75.0
-  normalized_cost: 37.29
+  normalized_cost: 37.52
 gemini-2.5-flash-preview-0417-nothinking:
   score: 78.0
   normalized_score: 71.88
   cost: 6.0
-  normalized_cost: 2.983
+  normalized_cost: 3.002
 gpt-4.1-mini:
   score: 78.0
   normalized_score: 71.88
   cost: 9.0
-  normalized_cost: 4.475
+  normalized_cost: 4.503
 gpt-5-nano-high:
   score: 78.0
   normalized_score: 71.88
   cost: 25.0
-  normalized_cost: 12.43
+  normalized_cost: 12.51
 gpt-5-mini-minimal:
   score: 77.0
   normalized_score: 68.75
   cost: 4.0
-  normalized_cost: 1.989
+  normalized_cost: 2.001
 gpt-5-nano-medium:
   score: 77.0
   normalized_score: 68.75
   cost: 10.0
-  normalized_cost: 4.972
+  normalized_cost: 5.003
 claude-3.5-sonnet-v2:
   score: 77.0
   normalized_score: 68.75
   cost: 50.0
-  normalized_cost: 24.86
+  normalized_cost: 25.02
 qwen-3-235b-a22b-nothinking:
   score: 76.0
   normalized_score: 65.62
   cost: 14.0
-  normalized_cost: 6.961
+  normalized_cost: 7.005
 llama-4-scout:
   score: 75.0
   normalized_score: 62.5
   cost: 4.0
-  normalized_cost: 1.989
+  normalized_cost: 2.001
 deepseek-v3-1224:
   score: 75.0
   normalized_score: 62.5
   cost: 6.0
-  normalized_cost: 2.983
+  normalized_cost: 3.002
 claude-3.5-sonnet:
   score: 75.0
   normalized_score: 62.5
   cost: 55.0
-  normalized_cost: 27.35
+  normalized_cost: 27.52
 gpt-4o-2024-11-20:
   score: 74.0
   normalized_score: 59.38
   cost: 39.0
-  normalized_cost: 19.39
+  normalized_cost: 19.51
 gpt-4o-2024-05-13:
   score: 74.0
   normalized_score: 59.38
   cost: 60.0
-  normalized_cost: 29.83
+  normalized_cost: 30.02
 gpt-oss-20b-high:
   score: 73.0
   normalized_score: 56.25
   cost: 5.0
-  normalized_cost: 2.486
+  normalized_cost: 2.502
 gpt-4.1-nano:
   score: 65.0
   normalized_score: 31.25
   cost: 2.0
-  normalized_cost: 0.9945
+  normalized_cost: 1.001
 claude-3.5-haiku:
   score: 63.0
   normalized_score: 25.0
   cost: 12.0
-  normalized_cost: 5.967
+  normalized_cost: 6.004
 gpt-5-nano-minimal:
   score: 55.0
   normalized_score: 0.0

--- a/data/processed/benchmarks/weirdml.yaml
+++ b/data/processed/benchmarks/weirdml.yaml
@@ -2,149 +2,149 @@ gpt-5-high:
   score: 56.3
   normalized_score: 100.0
   cost: 0.6031
-  normalized_cost: 346.3
+  normalized_cost: 348.4
 o3-pro-high:
   score: 53.95
   normalized_score: 93.69
   cost: 2.614
-  normalized_cost: 1501.0
+  normalized_cost: 1510.0
 gemini-2.5-pro-06-05:
   score: 50.3
   normalized_score: 83.9
   cost: 0.4116
-  normalized_cost: 236.3
+  normalized_cost: 237.7
 o3-high:
   score: 49.76
   normalized_score: 82.45
   cost: 0.2319
-  normalized_cost: 133.1
+  normalized_cost: 133.9
 gpt-5-mini-high:
   score: 49.66
   normalized_score: 82.18
   cost: 0.1094
-  normalized_cost: 62.82
+  normalized_cost: 63.2
 o4-mini-high:
   score: 49.17
   normalized_score: 80.86
   cost: 0.1934
-  normalized_cost: 111.1
+  normalized_cost: 111.7
 claude-sonnet-4-thinking:
   score: 45.28
   normalized_score: 70.42
   cost: 0.3339
-  normalized_cost: 191.7
+  normalized_cost: 192.9
 claude-sonnet-4-nothinking:
   score: 43.0
   normalized_score: 64.3
   cost: 0.304
-  normalized_cost: 174.5
+  normalized_cost: 175.6
 grok-4:
   score: 42.55
   normalized_score: 63.1
   cost: 0.467
-  normalized_cost: 268.1
+  normalized_cost: 269.8
 claude-opus-4-thinking:
   score: 42.12
   normalized_score: 61.94
   cost: 1.699
-  normalized_cost: 975.5
+  normalized_cost: 981.4
 claude-opus-4.1-thinking:
   score: 41.78
   normalized_score: 61.03
   cost: 1.729
-  normalized_cost: 992.6
+  normalized_cost: 998.6
 deepseek-r1-0528:
   score: 40.88
   normalized_score: 58.62
   cost: 0.071
-  normalized_cost: 40.77
+  normalized_cost: 41.01
 claude-3.5-sonnet-v2:
   score: 39.78
   normalized_score: 55.66
   cost: 0.2466
-  normalized_cost: 141.6
+  normalized_cost: 142.4
 grok-3-mini-high:
   score: 39.58
   normalized_score: 55.13
   cost: 0.01749
-  normalized_cost: 10.04
+  normalized_cost: 10.1
 gemini-2.5-flash-0520-thinking:
   score: 38.73
   normalized_score: 52.84
   cost: 0.1059
-  normalized_cost: 60.82
+  normalized_cost: 61.18
 gpt-4.1:
   score: 37.88
   normalized_score: 50.56
   cost: 0.09829
-  normalized_cost: 56.43
+  normalized_cost: 56.77
 gpt-4.5-preview:
   score: 37.65
   normalized_score: 49.95
   cost: 1.58
-  normalized_cost: 907.2
+  normalized_cost: 912.7
 deepseek-v3.1:
   score: 37.42
   normalized_score: 49.33
   cost: 0.01961
-  normalized_cost: 11.26
+  normalized_cost: 11.33
 gpt-4.1-mini:
   score: 37.25
   normalized_score: 48.87
   cost: 0.01648
-  normalized_cost: 9.464
+  normalized_cost: 9.521
 deepseek-v3.1-thinking:
   score: 37.1
   normalized_score: 48.47
   cost: 0.03122
-  normalized_cost: 17.92
+  normalized_cost: 18.03
 grok-3:
   score: 36.44
   normalized_score: 46.7
   cost: 0.2502
-  normalized_cost: 143.7
+  normalized_cost: 144.5
 qwen-3-235b-a22b-thinking:
   score: 36.25
   normalized_score: 46.19
   cost: 0.02086
-  normalized_cost: 11.98
+  normalized_cost: 12.05
 gpt-5-nano-high:
   score: 35.57
   normalized_score: 44.36
   cost: 0.02687
-  normalized_cost: 15.43
+  normalized_cost: 15.52
 deepseek-r1-0120:
   score: 35.56
   normalized_score: 44.34
   cost: 0.07918
-  normalized_cost: 45.46
+  normalized_cost: 45.74
 deepseek-v3-0324:
   score: 35.09
   normalized_score: 43.08
   cost: 0.01379
-  normalized_cost: 7.918
+  normalized_cost: 7.966
 claude-3.5-sonnet:
   score: 30.06
   normalized_score: 29.58
   cost: 0.2437
-  normalized_cost: 139.9
+  normalized_cost: 140.8
 claude-3.5-haiku:
   score: 30.04
   normalized_score: 29.52
   cost: 0.05704
-  normalized_cost: 32.75
+  normalized_cost: 32.95
 gpt-4o-2024-11-20:
   score: 25.38
   normalized_score: 17.02
   cost: 0.0832
-  normalized_cost: 47.77
+  normalized_cost: 48.06
 llama-4-maverick:
   score: 23.62
   normalized_score: 12.29
   cost: 0.006137
-  normalized_cost: 3.524
+  normalized_cost: 3.545
 gpt-4.1-nano:
   score: 19.04
   normalized_score: 0.0
   cost: 0.002589
-  normalized_cost: 1.487
+  normalized_cost: 1.496


### PR DESCRIPTION
## Summary
- add model definitions for GLM-4.5 and GLM-4.5 Air
- map GLM-4.5 variants across benchmark mapping files
- regenerate processed benchmarks to include the new models

## Testing
- `pnpm prettier`
- `pnpm lint`
- `pnpm test`
- `pnpm mappings:update`
- `pnpm process:all`


------
https://chatgpt.com/codex/tasks/task_e_68b1c7c2264c8320bd7bbb8c2c1d10ef